### PR TITLE
feat: swap embedding backend to fastembed/onnx + migration (v0.7.0)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,9 +32,9 @@ jobs:
           # Editable install with both optional-dep groups. semantic is
           # required: a handful of tests (test_delegated_search,
           # test_vec_search) assert on actual cosine search behavior and
-          # don't have a skip-when-missing guard. sentence-transformers
-          # pulls torch + numpy + sqlite-vec — ~500MB but cached between
-          # runs via the pip cache action above.
+          # don't have a skip-when-missing guard. semantic now uses
+          # fastembed/ONNX Runtime (no PyTorch) + numpy + sqlite-vec; the
+          # model is fetched from HF on first use and is small.
           pip install -e '.[semantic,dev]'
 
       - name: Run pytest
@@ -46,4 +46,8 @@ jobs:
           THREADKEEPER_SPAWN_BUDGET_POLL_S: "0"
           THREADKEEPER_SEARCH_PROXY_POLL_S: "0"
         run: |
-          python -m pytest -q --tb=short
+          # --forked isolates each test in its own process. The suite's
+          # per-test package re-import (tests/conftest.py) otherwise piles up
+          # native ONNX/tokenizer thread pools that can deadlock sqlite
+          # connection finalize in a single long-lived interpreter.
+          python -m pytest -q --forked --tb=short

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ autonomous learning daemons cannot recursively start inside review forks.
 A daemon measures combined child RSS every 10 s; admission control
 refuses a new spawn that would exceed `THREADKEEPER_SPAWN_BUDGET_MB`
 (3 GB default). Slim children that need semantic search delegate to the
-parent via `search_via_parent` — no per-child copy of sentence-transformers.
+parent via `search_via_parent` — no per-child copy of the embedding model.
 
 ### Learning loops
 
@@ -401,7 +401,9 @@ The most-used env knobs (full list in `threadkeeper/config.py`):
 | `THREADKEEPER_MEMORY_GUARD_RETIRE_LIVE` | "" (off) | allow retiring parent-alive MCP servers; off protects live clients |
 | `THREADKEEPER_MEMORY_GUARD_NOTIFY` | "1" | send macOS desktop notification when possible |
 | `THREADKEEPER_INGEST_INTERVAL_S` | 3 | transcript ingest tick (s) |
-| `THREADKEEPER_NO_EMBEDDINGS` | "" | force-disable sentence-transformers |
+| `THREADKEEPER_NO_EMBEDDINGS` | "" | force-disable the embedding model (FTS5 + delegate only) |
+| `THREADKEEPER_EMBED_BACKEND` | `onnx` | embedding runtime: `onnx` (fastembed, no PyTorch) or `sentence-transformers` (legacy fallback) |
+| `THREADKEEPER_EMBED_MODEL` | `paraphrase-multilingual-MiniLM-L12-v2` | 384-dim cross-lingual embedding model |
 | `THREADKEEPER_SPAWNED_CHILD` | "" | spawn-internal marker; disables autonomous daemons in children |
 | `THREADKEEPER_SKILL_NUDGE_INTERVAL` | 10 | events between `skill_hint` nudges |
 
@@ -488,6 +490,34 @@ fallback to Python-side cosine when the extension is missing.
 One file. Backup = `cp`. Wipe memory = `rm`.
 
 Hooks and small runtime artifacts: `~/.threadkeeper/hooks/`.
+
+---
+
+## Embeddings
+
+Semantic search runs `paraphrase-multilingual-MiniLM-L12-v2` (384-dim,
+RU+EN+50 langs). The default backend is **fastembed / ONNX Runtime** — no
+PyTorch. A model-loaded process sits at ~700 MB physical footprint
+(~850 MB RSS), down from ~1.8 GB on the PyTorch backend.
+
+A **sentence-transformers** (PyTorch) backend is kept as an opt-in fallback.
+It is heavier (~1.8 GB RSS) and produces vectors that are *not numerically
+identical* to the ONNX backend's, so switching backends warrants a recompute:
+
+```bash
+# Install the fallback runtime and switch to it:
+pip install -e '.[semantic-st]'
+export THREADKEEPER_EMBED_BACKEND=sentence-transformers
+
+# After any backend switch, homogenize the stored corpus so queries and
+# stored vectors live in the same space:
+tk-migrate-embeddings --all          # or --notes-only / --dialog-only
+tk-migrate-embeddings --dry-run      # report stale counts only
+```
+
+The migration is batched, resumable, and idempotent (a second run finds
+nothing stale). Both backends emit 384-dim vectors, so the `vec0` schema is
+unchanged.
 
 ---
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -19,7 +19,8 @@ threadkeeper/
 ├── db.py              SCHEMA + migrations + WAL-knobs + sqlite-vec loader
 ├── identity.py        per-process session + self-cid + daemon launchers
 ├── ingest.py          live ingest of jsonl transcripts + skill_usage backfill
-├── embeddings.py      sentence-transformers (optional), cosine search
+├── embeddings.py      pluggable backend (ONNX/fastembed default; ST fallback), cosine search
+├── migrate_embeddings.py  CLI: recompute stored vectors after a backend switch
 ├── helpers.py         ID generators, fmt_age, q-quoting, alive-pid check
 ├── brief.py           render_brief() / render_context() — main digest
 ├── nudges.py          counter-driven memory_nudge / skill_hint / auto-review
@@ -493,6 +494,17 @@ The daemon-leak in tests (where `tests/` spawned orphan threads via fixture's
 Optional — not needed for basic functionality. Embeddings themselves are stored
 as BLOB in `notes.embedding` regardless of vec0 availability.
 
+### Embedding backend
+
+`embeddings.py` is backend-pluggable via `THREADKEEPER_EMBED_BACKEND`. The
+default `onnx` runs the model through **fastembed / ONNX Runtime** (no PyTorch,
+~700 MB footprint / ~850 MB RSS); `sentence-transformers` is a heavier opt-in
+fallback (~1.8 GB). `_encode()` L2-normalizes both backends' output so the dot product
+used by vec0 and the legacy path equals cosine. Each row records its producing
+backend in `embed_backend` (NULL = legacy). The two backends are not
+numerically identical, so after a switch run `tk-migrate-embeddings --all`
+(`migrate_embeddings.py`) to recompute stale rows into one consistent space.
+
 ## MCP tools (89 total)
 
 Compact grouping by module. Full signatures are in the code; `_mcp.py`
@@ -560,6 +572,7 @@ having to add tests.
 |---|---|---|
 | `THREADKEEPER_DB` | `~/.threadkeeper/db.sqlite` | sqlite file |
 | `THREADKEEPER_EMBED_MODEL` | paraphrase-multilingual-MiniLM-L12-v2 | 384-dim, RU+EN |
+| `THREADKEEPER_EMBED_BACKEND` | `onnx` | `onnx` (fastembed, no PyTorch) or `sentence-transformers` (fallback) |
 | `CLAUDE_PROJECTS_DIR` | `~/.claude/projects` | jsonl for ingest |
 | `CLAUDE_SKILLS_DIR` | `~/.claude/skills` | skills root |
 | `THREADKEEPER_EXTRA_SKILLS_DIRS` | unset | os.pathsep-separated extra skills roots to mirror into |

--- a/docs/superpowers/specs/2026-05-26-onnx-embeddings-design.md
+++ b/docs/superpowers/specs/2026-05-26-onnx-embeddings-design.md
@@ -1,0 +1,177 @@
+# ONNX embedding backend — design
+
+**Date:** 2026-05-26
+**Status:** approved (pending spec review)
+**Branch:** `feat/onnx-embeddings`
+
+## Problem
+
+The main `threadkeeper.server` process holds a **~1.8 GB physical footprint**
+(peak 1.9 GB; RSS observed climbing past 1.1 GB). Root cause: embeddings are
+computed via `sentence-transformers`, which loads the full **PyTorch CPU
+stack** (`libtorch_cpu.dylib` et al.) plus `transformers`, `scikit-learn`, and
+`scipy` — all to run a single 384-dim, ~33M-param model
+(`paraphrase-multilingual-MiniLM-L12-v2`, 118 MB).
+
+On-disk weight of the stack pulled into the process:
+
+| Package | Size | Why it's loaded |
+|---|---|---|
+| torch | 408 MB | only to run MiniLM |
+| transformers | 101 MB | sentence-transformers dep |
+| scipy | 98 MB | transitive via sklearn |
+| sklearn | 46 MB | sentence-transformers dep |
+| numpy | 33 MB | used directly |
+| sentence_transformers | 4.8 MB | the wrapper |
+| **model** | **118 MB** | the only thing doing real work |
+
+`memory_guard` can drop the model weights on an RSS threshold
+(`reclaim_memory → unload_model`), but the torch dylibs stay mapped for the
+life of the process, so steady state never falls far.
+
+Swap is 0 because macOS *compresses* these dirty pages rather than paging to
+disk — the footprint is real RAM pressure, just not visible as swap.
+
+## Goal
+
+Replace the embedding runtime with **ONNX Runtime via `fastembed`** (pure
+onnxruntime + tokenizers, no torch/transformers/sklearn/scipy), keeping the
+same model and 384-dim output. Target footprint **~250–400 MB**, disk savings
+**~650 MB**.
+
+## Feasibility (verified 2026-05-26)
+
+venv runs **Python 3.14.2**. `pip install --dry-run "fastembed>=0.3"` resolves
+cleanly to **fastembed 0.8.0 + onnxruntime 1.26.0** (cp314 wheels exist), plus
+small deps (mmh3, py_rust_stemmers, pillow, protobuf, flatbuffers, loguru).
+No torch in the dependency tree. Migration is feasible on the current
+interpreter.
+
+## Non-goals
+
+- Changing the embedding model or vector dimension (stays
+  `paraphrase-multilingual-MiniLM-L12-v2`, 384-dim).
+- Changing the `vec0` schema, `sqlite-vec` usage, or the public MCP API.
+- Touching `unload_model()` / `model_loaded()` / `memory_guard` contracts.
+- Re-architecting `search_via_parent` delegation or the `NO_EMBEDDINGS`
+  opt-out.
+
+## Decisions
+
+1. **Backend:** `fastembed` (ONNX) is the default. `sentence-transformers`
+   remains an opt-in fallback, selected by env. Default
+   `THREADKEEPER_EMBED_BACKEND=onnx`; alternative `sentence-transformers`.
+2. **Recompute:** the existing **152,315 dialog + 344 note vectors** were
+   produced by sentence-transformers. fastembed's output for this model is
+   numerically *not identical* (quantization + pooling detail — qdrant/fastembed
+   issue #368), so mixing stored ST vectors with ONNX queries lives in slightly
+   different spaces. We do a **full one-shot recompute** (`tk-migrate-embeddings
+   --all`) at migration time to homogenize the space immediately.
+3. **Per-row backend tag:** add `embed_backend` to `notes` and
+   `dialog_messages` so future backend switches / partial writes can self-heal,
+   and so the migration command knows what is stale. Safety net beyond the
+   one-shot recompute.
+
+## Architecture
+
+### `config.py`
+
+- New `EMBED_BACKEND` constant from `THREADKEEPER_EMBED_BACKEND`
+  (default `onnx`; accepts `onnx` | `sentence-transformers`).
+- `SEMANTIC_AVAILABLE` probe becomes backend-aware:
+  - `onnx` → try importing `fastembed` (+ numpy).
+  - `sentence-transformers` → existing import probe.
+  - `NO_EMBEDDINGS` short-circuit unchanged.
+- Keep `EMBED_MODEL_NAME` as the canonical short name; backends map it to
+  their own id (fastembed wants `sentence-transformers/<name>`).
+
+### `embeddings.py`
+
+- `_get_model()` branches on `EMBED_BACKEND`:
+  - `onnx`: `from fastembed import TextEmbedding; TextEmbedding(model_name=<qualified>)`.
+  - `sentence-transformers`: unchanged path.
+- `encode(text)` returns a 384-dim float32, **explicitly L2-normalized**
+  (fastembed does not guarantee unit vectors the way
+  `SentenceTransformer.encode(normalize_embeddings=True)` does). Dot product on
+  unit vectors == cosine, preserving the existing `vec0` / BLOB search math.
+- A small batch helper `encode_many(texts)` for the migration command (fastembed
+  is generator-based and far faster batched).
+- `unload_model()` continues to drop the cached object; for fastembed there is
+  no torch to release, but clearing the reference is still correct.
+
+### Schema (`db.py`)
+
+- `ALTER TABLE notes ADD COLUMN embed_backend TEXT` and likewise for
+  `dialog_messages`, guarded (idempotent; ignore "duplicate column").
+- `NULL` = legacy (sentence-transformers). New/recomputed rows tagged with the
+  producing backend.
+- `vec0` virtual tables and `EMBED_DIM` (384) unchanged.
+
+### Migration command `tk-migrate-embeddings`
+
+- Console entry point (added to `pyproject.toml [project.scripts]`), or
+  `python -m threadkeeper.migrate_embeddings`.
+- Flags:
+  - `--all` — recompute every row whose `embed_backend` differs from the active
+    backend (covers NULL legacy rows).
+  - `--notes-only` / `--dialog-only` — scope limiters.
+  - `--batch N` (default 256), `--dry-run`.
+- Behavior: stream rows in batches, `encode_many`, rewrite both the BLOB column
+  and the `vec0` row, set `embed_backend`, commit per batch. **Resumable**
+  (re-running skips already-tagged rows) and **idempotent**. Progress logged
+  every batch with ETA.
+
+### Lazy self-heal (secondary)
+
+- On result hydration in semantic search, if a returned row's `embed_backend`
+  differs from active and its text is in hand, re-encode + persist. Keeps the
+  space consistent for any rows written before a future backend change. After
+  the one-shot `--all`, this path is rarely hit.
+
+### `pyproject.toml`
+
+```toml
+[project.optional-dependencies]
+semantic     = ["fastembed>=0.3", "numpy>=1.24.0", "sqlite-vec>=0.1.9"]
+semantic-st  = ["sentence-transformers>=2.2.0", "numpy>=1.24.0", "sqlite-vec>=0.1.9"]
+```
+
+`semantic` (default recommended extra) no longer pulls torch. Users wanting the
+old runtime install `.[semantic-st]` and set
+`THREADKEEPER_EMBED_BACKEND=sentence-transformers`.
+
+## Error handling / compatibility
+
+- If `EMBED_BACKEND=onnx` but `fastembed` is missing → `SEMANTIC_AVAILABLE=False`
+  with a clear one-line log pointing at `pip install .[semantic]`; brief + FTS
+  fallback still work (existing behavior).
+- First fastembed run downloads the ONNX model to its cache; document this and
+  the cache location.
+- The legacy `memory_partner` DB auto-migration in `config.py` is untouched.
+
+## Testing
+
+- Unit: `encode()` returns shape (384,), L2-norm ≈ 1.0, dtype float32 — for
+  whichever backend is installed (skip if neither).
+- Backend-switch: monkeypatch `EMBED_BACKEND`, assert `_get_model()` picks the
+  right loader; assert graceful `SEMANTIC_AVAILABLE=False` when the lib is
+  absent.
+- Migration: seed a tmp DB with a few NULL-backend rows, run migrate, assert all
+  rows tagged + vec0 rebuilt + re-run is a no-op (idempotent/resumable).
+- Existing semantic search tests pass unchanged against ONNX vectors.
+
+## Rollout
+
+1. Land code + `semantic` extra change on `feat/onnx-embeddings`.
+2. `pip install -e .[semantic]` (brings fastembed; torch can be uninstalled).
+3. Run **`tk-migrate-embeddings --all`** to homogenize the 152k+344 vectors.
+4. Restart the server; verify footprint dropped and `dialog_search` quality holds.
+5. Update docs (README, ARCHITECTURE.md, RELEASING.md if release-relevant) in the
+   same change-set. PR into protected `main`.
+
+## Docs to update (same change-set)
+
+- `README.md` — backend env switch, `semantic` vs `semantic-st` extras, the
+  migration command, expected footprint.
+- `ARCHITECTURE.md` — embeddings layer now backend-pluggable; ONNX default.
+- `ROADMAP.md` — mark if this was a tracked item.

--- a/docs/superpowers/specs/2026-05-26-onnx-embeddings-design.md
+++ b/docs/superpowers/specs/2026-05-26-onnx-embeddings-design.md
@@ -36,8 +36,15 @@ disk — the footprint is real RAM pressure, just not visible as swap.
 
 Replace the embedding runtime with **ONNX Runtime via `fastembed`** (pure
 onnxruntime + tokenizers, no torch/transformers/sklearn/scipy), keeping the
-same model and 384-dim output. Target footprint **~250–400 MB**, disk savings
-**~650 MB**.
+same model and 384-dim output.
+
+**Measured result (2026-05-27):** a model-loaded process sits at **~670 MB
+physical footprint / ~844 MB RSS** with **zero `libtorch` mappings**, down from
+~1.8 GB on the PyTorch backend — roughly a 2.7× footprint reduction. (The
+initial ~250–400 MB projection was too optimistic: ONNX Runtime's own library
++ memory arenas + numpy + the quantized model are the floor; the win is real
+but smaller than projected, and PyTorch/transformers/sklearn/scipy are gone.)
+fastembed pulls the quantized `qdrant/...-onnx-Q` build automatically.
 
 ## Feasibility (verified 2026-05-26)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,15 @@ dependencies = [
 [project.optional-dependencies]
 # Semantic cross-language search + sub-linear vector index. Recommended
 # for any real use — without it, dialog_search falls back to FTS5 only.
+# Default backend is fastembed/ONNX Runtime: no PyTorch, ~700MB footprint.
 semantic = [
+    "fastembed>=0.3",
+    "numpy>=1.24.0",
+    "sqlite-vec>=0.1.9",
+]
+# Legacy PyTorch backend, kept as an opt-in fallback. Install this AND set
+# THREADKEEPER_EMBED_BACKEND=sentence-transformers to use it. ~1.8GB RSS.
+semantic-st = [
     "sentence-transformers>=2.2.0",
     "numpy>=1.24.0",
     "sqlite-vec>=0.1.9",
@@ -54,6 +62,9 @@ Changelog     = "https://github.com/po4erk91/thread-keeper/releases"
 # After `pip install threadkeeper`, the user gets `thread-keeper-setup`
 # directly on PATH. Equivalent to `python -m threadkeeper._setup`.
 thread-keeper-setup = "threadkeeper._setup:main"
+# Recompute stored embeddings with the active backend (e.g. after switching to
+# the ONNX default). Equivalent to `python -m threadkeeper.migrate_embeddings`.
+tk-migrate-embeddings = "threadkeeper.migrate_embeddings:main"
 
 [tool.setuptools.packages.find]
 include = ["threadkeeper*"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "threadkeeper"
-version = "0.6.2"
+version = "0.7.0"
 description = "Multi-agent shared brain across Claude Code/Desktop, Codex, Gemini, Copilot, VS Code. Cross-session memory, self-improving skill loops, inter-agent signaling — one local MCP server."
 requires-python = ">=3.11"
 authors = [{ name = "thread-keeper contributors" }]
@@ -45,10 +45,14 @@ semantic-st = [
     "numpy>=1.24.0",
     "sqlite-vec>=0.1.9",
 ]
-# Test runner + coverage.
+# Test runner + coverage. pytest-forked isolates each test in its own
+# process: the per-test package re-import (tests/conftest.py) accumulates
+# native ONNX/tokenizer thread pools that can deadlock sqlite finalize in a
+# single long-lived process, so CI runs `pytest --forked`.
 dev = [
     "pytest>=8.0",
     "pytest-cov>=5.0",
+    "pytest-forked>=1.6",
 ]
 
 [project.urls]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,6 +26,29 @@ def isolated_cli_homes(tmp_path, monkeypatch):
     monkeypatch.delenv("THREADKEEPER_EXTRA_SKILLS_DIRS", raising=False)
 
 
+@pytest.fixture(autouse=True)
+def _drop_embed_model_after_test():
+    """Drop any embedding model loaded during the test (memory hygiene).
+
+    The ONNX backend (fastembed) holds an onnxruntime InferenceSession with a
+    native thread pool; the per-test sys.modules re-import (see _bootstrap_mp)
+    would otherwise let those pile up. CI runs `pytest --forked` so each test is
+    process-isolated (the reliable cure for native-resource accumulation — see
+    .github/workflows/test.yml); this teardown just keeps non-forked local runs
+    of large subsets from ballooning. Best-effort.
+    """
+    yield
+    import gc
+    import sys as _sys
+    emb = _sys.modules.get("threadkeeper.embeddings")
+    if emb is not None:
+        try:
+            emb.unload_model()
+        except Exception:
+            pass
+    gc.collect()
+
+
 def _force_clean_env(tmp_root: Path) -> dict[str, str]:
     """Env knobs that must be set before threadkeeper.config imports.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -52,6 +52,13 @@ def _force_clean_env(tmp_root: Path) -> dict[str, str]:
         "THREADKEEPER_LESSONS": str(tmp_root / "lessons.md"),  # tempdir lessons
         "THREADKEEPER_TASK_LOG_DIR": str(tmp_root / "tasks"),
         "THREADKEEPER_CLIENT": "pytest",
+        # The ONNX embedding backend (fastembed) pulls tokenizers + onnxruntime,
+        # which each spawn native thread pools (tokenizers via rayon). The
+        # per-test sys.modules wipe + re-import (see _bootstrap_mp) orphans those
+        # pools; orphaned rayon workers deadlock sqlite connection finalize on
+        # the next re-import. Disabling the parallel pools keeps re-imports clean.
+        "TOKENIZERS_PARALLELISM": "false",
+        "OMP_NUM_THREADS": "1",
     }
 
 

--- a/tests/test_onnx_embeddings.py
+++ b/tests/test_onnx_embeddings.py
@@ -1,0 +1,133 @@
+"""ONNX embedding backend + tk-migrate-embeddings.
+
+Verifies that:
+- the active backend encodes to L2-normalized 384-dim float32 vectors
+- embed_tag stamps the active backend for a real blob, None otherwise
+- freshly inserted notes carry the embed_backend tag
+- the migration recomputes stale (NULL-tagged) rows, tags them, and is
+  idempotent + dry-run-safe
+
+Skips entirely when no embedding backend is installed.
+"""
+from __future__ import annotations
+
+import time
+
+import pytest
+
+pytestmark = pytest.mark.slow  # model warmup on first encode
+
+
+def _tool(pkg, name):
+    return pkg["mcp"]._tool_manager._tools[name].fn
+
+
+@pytest.fixture()
+def sem_pkg(fresh_mp):
+    """Fresh package against a clean tmp DB; skip if semantic search is off."""
+    if not fresh_mp["config"].SEMANTIC_AVAILABLE:
+        pytest.skip("no embedding backend installed in this environment")
+    return fresh_mp
+
+
+def _seed_legacy_notes(conn, n: int):
+    """Insert n notes with a real embedding blob but a NULL backend tag,
+    simulating rows written before the ONNX migration."""
+    from threadkeeper import embeddings as emb
+    for i in range(n):
+        blob = emb._embed(f"legacy seeded note {i} about webhooks and retries")
+        conn.execute(
+            "INSERT INTO notes (content, kind, created_at, embedding, embed_backend) "
+            "VALUES (?,?,?,?,NULL)",
+            (f"legacy seeded note {i}", "insight", int(time.time()), blob),
+        )
+    conn.commit()
+
+
+# ── encode primitives ────────────────────────────────────────────────
+
+def test_encode_is_normalized_384_float32(sem_pkg):
+    import numpy as np
+    from threadkeeper import embeddings as emb
+    arr = emb._encode(["привет мир", "hello world"])
+    assert arr is not None
+    assert arr.shape == (2, 384)
+    assert arr.dtype == np.dtype("float32")
+    assert np.allclose(np.linalg.norm(arr, axis=1), 1.0, atol=1e-3)
+
+
+def test_encode_is_cross_lingual(sem_pkg):
+    """A RU/EN translation pair must score higher than an unrelated phrase."""
+    from threadkeeper import embeddings as emb
+    v = emb._encode(["кошка", "cat", "quarterly financial report"])
+    assert float(v[0] @ v[1]) > float(v[0] @ v[2])
+
+
+def test_embed_tag(sem_pkg):
+    from threadkeeper import embeddings as emb
+    active = sem_pkg["config"].EMBED_BACKEND
+    assert emb.embed_tag(b"\x00\x01") == active
+    assert emb.embed_tag(None) is None
+
+
+# ── write-path tagging ───────────────────────────────────────────────
+
+def test_new_note_carries_backend_tag(sem_pkg):
+    tid = _tool(sem_pkg, "open_thread")(question="backend tag test")
+    _tool(sem_pkg, "note")(thread_id=tid,
+                           content="tagged note about idempotency keys",
+                           kind="insight")
+    conn = sem_pkg["db"].get_db()
+    active = sem_pkg["config"].EMBED_BACKEND
+    row = conn.execute(
+        "SELECT embedding, embed_backend FROM notes "
+        "WHERE thread_id=? ORDER BY id DESC LIMIT 1",
+        (tid,),
+    ).fetchone()
+    assert row["embedding"] is not None
+    assert row["embed_backend"] == active
+
+
+# ── migration ────────────────────────────────────────────────────────
+
+def test_migration_recomputes_tags_and_is_idempotent(sem_pkg):
+    from threadkeeper import migrate_embeddings as mig
+    active = sem_pkg["config"].EMBED_BACKEND
+    conn = sem_pkg["db"].get_db()
+    _seed_legacy_notes(conn, 3)
+
+    assert mig._count_stale(conn, "notes", active) == 3
+
+    rc = mig.run(do_notes=True, do_dialog=False, batch=2,
+                 dry_run=False, log=lambda _m: None)
+    assert rc == 0
+    assert mig._count_stale(conn, "notes", active) == 0
+    tagged = conn.execute(
+        "SELECT COUNT(*) FROM notes WHERE embed_backend=?", (active,)
+    ).fetchone()[0]
+    assert tagged >= 3
+
+    # idempotent: a second pass finds nothing stale and changes nothing.
+    rc2 = mig.run(do_notes=True, do_dialog=False, batch=2,
+                  dry_run=False, log=lambda _m: None)
+    assert rc2 == 0
+    assert mig._count_stale(conn, "notes", active) == 0
+
+
+def test_migration_dry_run_writes_nothing(sem_pkg):
+    from threadkeeper import migrate_embeddings as mig
+    active = sem_pkg["config"].EMBED_BACKEND
+    conn = sem_pkg["db"].get_db()
+    _seed_legacy_notes(conn, 2)
+
+    assert mig._count_stale(conn, "notes", active) == 2
+    mig.run(do_notes=True, do_dialog=False, batch=10,
+            dry_run=True, log=lambda _m: None)
+    # still stale — dry run must not touch the rows
+    assert mig._count_stale(conn, "notes", active) == 2
+
+
+def test_migration_requires_a_scope_flag(sem_pkg):
+    from threadkeeper import migrate_embeddings as mig
+    with pytest.raises(SystemExit):
+        mig.main([])  # argparse error → SystemExit(2)

--- a/threadkeeper/config.py
+++ b/threadkeeper/config.py
@@ -15,6 +15,23 @@ EMBED_MODEL_NAME: str = os.environ.get(
     "paraphrase-multilingual-MiniLM-L12-v2",  # 118 MB, RU+EN cross-lingual
 )
 
+# Embedding runtime backend. 'onnx' (default) runs the model through fastembed /
+# ONNX Runtime — no PyTorch, ~700MB footprint (vs ~1.8GB). 'sentence-transformers' is
+# the legacy PyTorch path, kept as an opt-in fallback (install `.[semantic-st]`
+# and set THREADKEEPER_EMBED_BACKEND=sentence-transformers). Both produce the
+# same 384-dim vectors, but fastembed's are numerically NOT identical to ST's,
+# so switching backends warrants a `tk-migrate-embeddings --all` recompute.
+EMBED_BACKEND: str = os.environ.get(
+    "THREADKEEPER_EMBED_BACKEND", "onnx"
+).strip().lower()
+
+# fastembed addresses the model under its sentence-transformers org prefix;
+# SentenceTransformer accepts the bare name. Normalize for the ONNX backend.
+FASTEMBED_MODEL_ID: str = (
+    EMBED_MODEL_NAME if "/" in EMBED_MODEL_NAME
+    else f"sentence-transformers/{EMBED_MODEL_NAME}"
+)
+
 DB_PATH.parent.mkdir(parents=True, exist_ok=True)
 
 # One-shot migration from the historical name `memory_partner`. If the new
@@ -54,9 +71,16 @@ NO_EMBEDDINGS: bool = os.environ.get(
 # Brief still works either way.
 if NO_EMBEDDINGS:
     SEMANTIC_AVAILABLE: bool = False
-else:
+elif EMBED_BACKEND == "sentence-transformers":
     try:
         from sentence_transformers import SentenceTransformer  # type: ignore  # noqa: F401
+        import numpy as np  # type: ignore  # noqa: F401
+        SEMANTIC_AVAILABLE = True
+    except Exception:
+        SEMANTIC_AVAILABLE = False
+else:  # 'onnx' (default)
+    try:
+        from fastembed import TextEmbedding  # type: ignore  # noqa: F401
         import numpy as np  # type: ignore  # noqa: F401
         SEMANTIC_AVAILABLE = True
     except Exception:

--- a/threadkeeper/config.py
+++ b/threadkeeper/config.py
@@ -2,6 +2,7 @@
 Imported wherever a constant or config is needed; cheap to import."""
 from __future__ import annotations
 
+import importlib.util
 import os
 from pathlib import Path
 from typing import Optional
@@ -69,22 +70,26 @@ NO_EMBEDDINGS: bool = os.environ.get(
 # Optional semantic search. If sentence-transformers is not installed OR the
 # no-embeddings opt-out is set, fall back to FTS5 keyword matching + delegate.
 # Brief still works either way.
+def _installed(*mods: str) -> bool:
+    """True if every module is importable, checked WITHOUT importing it.
+
+    `find_spec` locates the module via the import machinery but never executes
+    it — so probing availability here doesn't pull PyTorch / ONNX Runtime /
+    tokenizers (and their thread pools) into every process that imports config.
+    The heavy import stays lazy in `embeddings._get_model()`.
+    """
+    try:
+        return all(importlib.util.find_spec(m) is not None for m in mods)
+    except (ImportError, ValueError):
+        return False
+
+
 if NO_EMBEDDINGS:
     SEMANTIC_AVAILABLE: bool = False
 elif EMBED_BACKEND == "sentence-transformers":
-    try:
-        from sentence_transformers import SentenceTransformer  # type: ignore  # noqa: F401
-        import numpy as np  # type: ignore  # noqa: F401
-        SEMANTIC_AVAILABLE = True
-    except Exception:
-        SEMANTIC_AVAILABLE = False
+    SEMANTIC_AVAILABLE = _installed("sentence_transformers", "numpy")
 else:  # 'onnx' (default)
-    try:
-        from fastembed import TextEmbedding  # type: ignore  # noqa: F401
-        import numpy as np  # type: ignore  # noqa: F401
-        SEMANTIC_AVAILABLE = True
-    except Exception:
-        SEMANTIC_AVAILABLE = False
+    SEMANTIC_AVAILABLE = _installed("fastembed", "numpy")
 
 # Client label used for `presence`/`sessions` rows.
 CLIENT_LABEL: str = os.environ.get("THREADKEEPER_CLIENT", "claude")

--- a/threadkeeper/db.py
+++ b/threadkeeper/db.py
@@ -72,7 +72,8 @@ CREATE TABLE IF NOT EXISTS notes (
     kind        TEXT NOT NULL,
     created_at  INTEGER NOT NULL,
     session_id  TEXT,
-    embedding   BLOB
+    embedding   BLOB,
+    embed_backend TEXT           -- backend that produced `embedding`; NULL = legacy
 );
 
 CREATE TABLE IF NOT EXISTS verbatim (
@@ -143,7 +144,8 @@ CREATE TABLE IF NOT EXISTS dialog_messages (
     content      TEXT NOT NULL,                -- concatenated text blocks
     model        TEXT,
     created_at   INTEGER NOT NULL,
-    embedding    BLOB
+    embedding    BLOB,
+    embed_backend TEXT           -- backend that produced `embedding`; NULL = legacy
 );
 
 CREATE TABLE IF NOT EXISTS ingest_state (
@@ -500,6 +502,11 @@ def get_db() -> sqlite3.Connection:
         "ALTER TABLE skill_usage ADD COLUMN wrong_count "
         "INTEGER NOT NULL DEFAULT 0",
         "ALTER TABLE skill_usage ADD COLUMN last_wrong_at INTEGER",
+        # Embedding backend tag. NULL = legacy (sentence-transformers, pre-ONNX
+        # migration). New/recomputed rows carry 'onnx' or 'sentence-transformers'
+        # so `tk-migrate-embeddings` can find stale vectors and skip done ones.
+        "ALTER TABLE notes ADD COLUMN embed_backend TEXT",
+        "ALTER TABLE dialog_messages ADD COLUMN embed_backend TEXT",
     ):
         try:
             conn.execute(ddl)

--- a/threadkeeper/embeddings.py
+++ b/threadkeeper/embeddings.py
@@ -17,7 +17,12 @@ import sqlite3
 import threading
 from typing import Optional
 
-from .config import SEMANTIC_AVAILABLE, EMBED_MODEL_NAME
+from .config import (
+    SEMANTIC_AVAILABLE,
+    EMBED_MODEL_NAME,
+    EMBED_BACKEND,
+    FASTEMBED_MODEL_ID,
+)
 from . import db as _db
 
 
@@ -29,13 +34,22 @@ _model = None
 _model_lock = threading.RLock()
 
 def _get_model():
+    """Lazily load and cache the embedding model for the active backend.
+
+    'onnx' (default) → fastembed.TextEmbedding (ONNX Runtime, no PyTorch).
+    'sentence-transformers' → the legacy PyTorch path (opt-in fallback).
+    """
     global _model
     if not SEMANTIC_AVAILABLE:
         return None
     with _model_lock:
         if _model is None:
-            from sentence_transformers import SentenceTransformer  # type: ignore
-            _model = SentenceTransformer(EMBED_MODEL_NAME)
+            if EMBED_BACKEND == "sentence-transformers":
+                from sentence_transformers import SentenceTransformer  # type: ignore
+                _model = SentenceTransformer(EMBED_MODEL_NAME)
+            else:  # 'onnx' (default)
+                from fastembed import TextEmbedding  # type: ignore
+                _model = TextEmbedding(model_name=FASTEMBED_MODEL_ID)
         return _model
 
 
@@ -66,23 +80,55 @@ def unload_model() -> bool:
     del model
     return True
 
-def _embed(text: str) -> Optional[bytes]:
+def _encode(texts: list[str]):
+    """Backend-agnostic batch encode → L2-normalized float32 array of shape
+    (len(texts), EMBED_DIM), or None when semantic search is unavailable.
+
+    Both backends are normalized to unit length here so the dot product used
+    by the vec0 and legacy paths equals cosine similarity, regardless of
+    whether the backend already normalizes.
+    """
     with _model_lock:
         m = _get_model()
         if m is None:
             return None
-        v = m.encode([text], normalize_embeddings=True)[0].astype("float32")
-    return v.tobytes()
+        import numpy as np  # type: ignore
+        if EMBED_BACKEND == "sentence-transformers":
+            arr = np.asarray(m.encode(list(texts)), dtype="float32")
+        else:  # fastembed generator → stack
+            arr = np.asarray(list(m.embed(list(texts))), dtype="float32")
+    norms = np.linalg.norm(arr, axis=1, keepdims=True)
+    norms[norms == 0] = 1.0
+    return (arr / norms).astype("float32")
+
+
+def encode_many(texts: list[str]):
+    """Public batch encoder for the migration command. Returns the same
+    normalized float32 array as `_encode`, or None when unavailable."""
+    return _encode(texts)
+
+
+def embed_tag(blob: Optional[bytes]) -> Optional[str]:
+    """Backend label to store in the `embed_backend` column alongside a freshly
+    written embedding blob. None when no embedding was produced, so legacy /
+    NULL-vector rows stay untagged."""
+    return EMBED_BACKEND if blob is not None else None
+
+
+def _embed(text: str) -> Optional[bytes]:
+    arr = _encode([text])
+    if arr is None:
+        return None
+    return arr[0].astype("float32").tobytes()
 
 
 def _cosine_search(conn: sqlite3.Connection, query: str, k: int) -> list[dict]:
     """Top-k cosine over notes. Uses vec0 ANN when available."""
-    with _model_lock:
-        m = _get_model()
-        if m is None:
-            return []
-        import numpy as np  # type: ignore
-        qv = m.encode([query], normalize_embeddings=True)[0].astype("float32")
+    import numpy as np  # type: ignore
+    qa = _encode([query])
+    if qa is None:
+        return []
+    qv = qa[0]
     if _vec_on():
         try:
             return _vec0_notes_search(conn, qv.tobytes(), k)
@@ -131,12 +177,11 @@ def _vec0_notes_search(conn: sqlite3.Connection, qv_blob: bytes,
 
 def _dialog_cosine_search(conn, query: str, k: int) -> list[dict]:
     """Top-k cosine over dialog_messages. Uses vec0 ANN when available."""
-    with _model_lock:
-        m = _get_model()
-        if m is None:
-            return []
-        import numpy as np  # type: ignore
-        qv = m.encode([query], normalize_embeddings=True)[0].astype("float32")
+    import numpy as np  # type: ignore
+    qa = _encode([query])
+    if qa is None:
+        return []
+    qv = qa[0]
     if _vec_on():
         try:
             return _vec0_dialog_search(conn, qv.tobytes(), k)

--- a/threadkeeper/ingest.py
+++ b/threadkeeper/ingest.py
@@ -18,7 +18,7 @@ from .config import (
     SEMANTIC_AVAILABLE,
 )
 from .db import get_db
-from .embeddings import _embed
+from .embeddings import _embed, embed_tag
 
 _ingest_thread: Optional[threading.Thread] = None
 _ingest_lock = threading.Lock()
@@ -215,11 +215,11 @@ def _ingest_file(conn: sqlite3.Connection, fp: Path, max_msgs: int,
             emb = _embed(text[:2000]) if SEMANTIC_AVAILABLE else None
             conn.execute(
                 "INSERT INTO dialog_messages (uuid, source, project, session_id, "
-                "role, content, model, created_at, embedding) "
-                "VALUES (?,?,?,?,?,?,?,?,?)",
+                "role, content, model, created_at, embedding, embed_backend) "
+                "VALUES (?,?,?,?,?,?,?,?,?,?)",
                 (nm.uuid, adapter.name, adapter.project_label(fp),
                  nm.session_id, nm.role, text,
-                 nm.model, nm.created_at, emb)
+                 nm.model, nm.created_at, emb, embed_tag(emb))
             )
             try:
                 conn.execute(
@@ -381,7 +381,7 @@ def _backfill_note_embeddings(conn: sqlite3.Connection, max_n: int = 20) -> int:
         return 0
     if not rows:
         return 0
-    from .embeddings import _embed, _vec_upsert_note
+    from .embeddings import _embed, _vec_upsert_note, embed_tag
     updated = 0
     for r in rows:
         try:
@@ -392,8 +392,8 @@ def _backfill_note_embeddings(conn: sqlite3.Connection, max_n: int = 20) -> int:
             continue
         try:
             conn.execute(
-                "UPDATE notes SET embedding=? WHERE id=?",
-                (emb, r["id"]),
+                "UPDATE notes SET embedding=?, embed_backend=? WHERE id=?",
+                (emb, embed_tag(emb), r["id"]),
             )
             _vec_upsert_note(conn, r["id"], emb)
             updated += 1

--- a/threadkeeper/migrate_embeddings.py
+++ b/threadkeeper/migrate_embeddings.py
@@ -1,0 +1,146 @@
+"""One-shot migration: recompute stored embeddings with the active backend.
+
+Every stored vector was produced by whatever embedding backend was active when
+its row was written. Legacy rows (pre-ONNX) came from sentence-transformers and
+carry a NULL `embed_backend` tag. fastembed/ONNX produces 384-dim vectors that
+are numerically *not identical* to sentence-transformers' for the same model
+(quantization + pooling detail), so after switching the default backend the
+stored corpus and fresh queries drift into slightly different spaces.
+
+This command re-encodes every stale row (those whose `embed_backend` differs
+from the active backend) with the active backend, rewriting both the BLOB
+column and the `vec0` mirror, and stamps the new tag. It is:
+
+  * resumable  — only rows still tagged stale are selected, so an interrupted
+                 run picks up where it left off (each batch commits);
+  * idempotent — a second full run finds nothing stale and is a no-op.
+
+Usage:
+    tk-migrate-embeddings --all
+    tk-migrate-embeddings --notes-only --batch 512
+    tk-migrate-embeddings --dry-run
+"""
+from __future__ import annotations
+
+import argparse
+import sqlite3
+import sys
+import time
+from typing import Callable
+
+from .config import EMBED_BACKEND, SEMANTIC_AVAILABLE
+from .db import get_db
+from . import embeddings as _emb
+
+
+def _stale_where() -> str:
+    """Predicate for rows that need recomputing under the active backend."""
+    return ("embedding IS NOT NULL "
+            "AND (embed_backend IS NULL OR embed_backend != ?)")
+
+
+def _count_stale(conn: sqlite3.Connection, table: str, active: str) -> int:
+    return conn.execute(
+        f"SELECT COUNT(*) FROM {table} WHERE {_stale_where()}",
+        (active,),
+    ).fetchone()[0]
+
+
+def _migrate_table(conn: sqlite3.Connection, *, table: str, id_col: str,
+                   text_limit: int | None, active: str, batch: int,
+                   dry_run: bool, log: Callable[[str], None]) -> tuple[int, int]:
+    total = _count_stale(conn, table, active)
+    log(f"{table}: {total} stale vector(s) to recompute")
+    if dry_run or total == 0:
+        return total, 0
+    done = 0
+    started = time.time()
+    while True:
+        rows = conn.execute(
+            f"SELECT {id_col} AS rid, content FROM {table} "
+            f"WHERE {_stale_where()} LIMIT ?",
+            (active, batch),
+        ).fetchall()
+        if not rows:
+            break
+        texts = []
+        for r in rows:
+            t = r["content"] or ""
+            texts.append(t[:text_limit] if text_limit else t)
+        vecs = _emb.encode_many(texts)
+        if vecs is None:
+            log("  semantic backend unavailable mid-run — aborting")
+            break
+        for i, r in enumerate(rows):
+            blob = vecs[i].astype("float32").tobytes()
+            conn.execute(
+                f"UPDATE {table} SET embedding=?, embed_backend=? WHERE {id_col}=?",
+                (blob, active, r["rid"]),
+            )
+            if table == "notes":
+                _emb._vec_upsert_note(conn, r["rid"], blob)
+            else:
+                _emb._vec_upsert_dialog(conn, r["rid"], blob)
+        conn.commit()
+        done += len(rows)
+        elapsed = max(1e-6, time.time() - started)
+        rate = done / elapsed
+        eta = (total - done) / rate if rate > 0 else 0.0
+        log(f"  {table}: {done}/{total}  ({rate:.0f}/s, eta {eta:.0f}s)")
+    return total, done
+
+
+def run(*, do_notes: bool, do_dialog: bool, batch: int, dry_run: bool,
+        log: Callable[[str], None] | None = None) -> int:
+    if log is None:
+        def log(m: str) -> None:  # noqa: E306
+            print(m, file=sys.stderr, flush=True)
+    if not SEMANTIC_AVAILABLE:
+        log("ERROR: no embedding backend available. Install `.[semantic]` "
+            "(ONNX/fastembed) or `.[semantic-st]` (sentence-transformers).")
+        return 1
+    active = EMBED_BACKEND
+    conn = get_db()
+    conn.row_factory = sqlite3.Row
+    log(f"active backend = {active}{'  (dry run)' if dry_run else ''}")
+    # notes hold short text; the model caps at its own token limit, so no slice.
+    if do_notes:
+        _migrate_table(conn, table="notes", id_col="id", text_limit=None,
+                       active=active, batch=batch, dry_run=dry_run, log=log)
+    # dialog messages can be long; match the [:2000] slice used at ingest time.
+    if do_dialog:
+        _migrate_table(conn, table="dialog_messages", id_col="uuid",
+                       text_limit=2000, active=active, batch=batch,
+                       dry_run=dry_run, log=log)
+    log("done.")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(
+        prog="tk-migrate-embeddings",
+        description="Recompute stored embeddings with the active backend "
+                    "(THREADKEEPER_EMBED_BACKEND, default onnx).",
+    )
+    p.add_argument("--all", action="store_true",
+                   help="recompute both notes and dialog_messages")
+    p.add_argument("--notes-only", action="store_true",
+                   help="recompute only notes")
+    p.add_argument("--dialog-only", action="store_true",
+                   help="recompute only dialog_messages")
+    p.add_argument("--batch", type=int, default=256,
+                   help="rows per encode/commit batch (default 256)")
+    p.add_argument("--dry-run", action="store_true",
+                   help="report stale counts without writing")
+    args = p.parse_args(argv)
+
+    do_notes = args.all or args.notes_only
+    do_dialog = args.all or args.dialog_only
+    if not (do_notes or do_dialog):
+        p.error("specify a scope: --all, --notes-only, or --dialog-only")
+    return run(do_notes=do_notes, do_dialog=do_dialog,
+               batch=args.batch, dry_run=args.dry_run)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/threadkeeper/tools/consolidate.py
+++ b/threadkeeper/tools/consolidate.py
@@ -17,7 +17,7 @@ from ..db import get_db
 from ..config import SEMANTIC_AVAILABLE
 from ..helpers import fmt_age, q, normalize_text
 from ..identity import _ensure_session, _emit
-from ..embeddings import _get_model
+from ..embeddings import _get_model, _encode
 
 
 CONSOLIDATE_NOTE_COSINE = 0.95
@@ -121,9 +121,9 @@ def consolidate(dry_run: bool = True,
             for sp, vs in by_speaker.items():
                 if len(vs) < 2:
                     continue
-                vecs = m.encode(
-                    [v["content"] for v in vs], normalize_embeddings=True
-                ).astype("float32")
+                vecs = _encode([v["content"] for v in vs])
+                if vecs is None:
+                    continue
                 sim = vecs @ vecs.T
                 kept = [True] * len(vs)
                 for i in range(len(vs)):

--- a/threadkeeper/tools/extract.py
+++ b/threadkeeper/tools/extract.py
@@ -15,7 +15,7 @@ from ..config import SEMANTIC_AVAILABLE
 from ..helpers import fmt_age, q, gen_concept_id, gen_distill_id
 from .. import identity
 from ..identity import _ensure_session, _detect_self_cid, _emit
-from ..embeddings import _embed
+from ..embeddings import _embed, embed_tag
 
 
 # Locale-aware heuristic matchers — patterns live in i18n.py so this
@@ -340,8 +340,8 @@ def accept_candidate(id: int, target_kind: str = "",
         emb = _embed(content)
         cur = conn.execute(
             "INSERT INTO notes (thread_id, content, kind, created_at, "
-            "session_id, embedding) VALUES (?,?,?,?,?,?)",
-            (tid, content, "insight", now, identity._session_id, emb),
+            "session_id, embedding, embed_backend) VALUES (?,?,?,?,?,?,?)",
+            (tid, content, "insight", now, identity._session_id, emb, embed_tag(emb)),
         )
         placed = f"note id={cur.lastrowid} thread={tid or '-'}"
     elif kind == "concept":

--- a/threadkeeper/tools/pickup.py
+++ b/threadkeeper/tools/pickup.py
@@ -14,7 +14,7 @@ from ..db import get_db
 from ..helpers import fmt_age, q
 from .. import identity
 from ..identity import _ensure_session, _detect_self_cid, _emit
-from ..embeddings import _embed
+from ..embeddings import _embed, embed_tag
 from .spawn import spawn
 
 
@@ -86,8 +86,9 @@ def claim_pickup(thread_id: str, plan: str = "",
         emb = _embed(plan)
         conn.execute(
             "INSERT INTO notes (thread_id, content, kind, created_at, "
-            "session_id, embedding) VALUES (?,?,?,?,?,?)",
-            (tid, f"PICKUP plan: {plan}", "move", now_t, identity._session_id, emb),
+            "session_id, embedding, embed_backend) VALUES (?,?,?,?,?,?,?)",
+            (tid, f"PICKUP plan: {plan}", "move", now_t, identity._session_id,
+             emb, embed_tag(emb)),
         )
     _emit(conn, "claim_pickup", target=tid,
           summary=plan[:140] if plan else (t["question"] or ""))

--- a/threadkeeper/tools/session.py
+++ b/threadkeeper/tools/session.py
@@ -7,7 +7,7 @@ import time
 from .._mcp import mcp
 from ..db import get_db
 from ..helpers import fmt_age
-from ..embeddings import _embed
+from ..embeddings import _embed, embed_tag
 from .. import identity
 
 
@@ -24,9 +24,9 @@ def session_end(summary: str = "") -> str:
     if summary:
         emb = _embed(summary)
         conn.execute(
-            "INSERT INTO notes (thread_id, content, kind, created_at, session_id, embedding) "
-            "VALUES (NULL,?,?,?,?,?)",
-            (summary, "session_summary", now, sid, emb),
+            "INSERT INTO notes (thread_id, content, kind, created_at, session_id, "
+            "embedding, embed_backend) VALUES (NULL,?,?,?,?,?,?)",
+            (summary, "session_summary", now, sid, emb, embed_tag(emb)),
         )
     conn.commit()
     identity._session_id = None

--- a/threadkeeper/tools/threads.py
+++ b/threadkeeper/tools/threads.py
@@ -17,7 +17,7 @@ from ..db import get_db
 from ..helpers import gen_thread_id, fmt_age, q
 from .. import identity
 from ..identity import _ensure_session, _detect_self_cid, _emit
-from ..embeddings import _embed, _cosine_search, _vec_upsert_note
+from ..embeddings import _embed, _cosine_search, _vec_upsert_note, embed_tag
 from ..brief import render_brief
 
 
@@ -92,9 +92,9 @@ def note(thread_id: str, content: str, kind: str = "move") -> str:
     now = int(time.time())
     emb = _embed(content)
     cur = conn.execute(
-        "INSERT INTO notes (thread_id, content, kind, created_at, session_id, embedding) "
-        "VALUES (?,?,?,?,?,?)",
-        (thread_id, content, kind, now, identity._session_id, emb),
+        "INSERT INTO notes (thread_id, content, kind, created_at, session_id, "
+        "embedding, embed_backend) VALUES (?,?,?,?,?,?,?)",
+        (thread_id, content, kind, now, identity._session_id, emb, embed_tag(emb)),
     )
     note_id = cur.lastrowid
     _vec_upsert_note(conn, note_id, emb)
@@ -177,8 +177,8 @@ def mark_skill_materialized(thread_id: str, skill_path: str = "") -> str:
     emb = _embed(note_body)
     cur = conn.execute(
         "INSERT INTO notes (thread_id, content, kind, created_at, session_id, "
-        "embedding) VALUES (?,?,?,?,?,?)",
-        (thread_id, note_body, "move", now, identity._session_id, emb),
+        "embedding, embed_backend) VALUES (?,?,?,?,?,?,?)",
+        (thread_id, note_body, "move", now, identity._session_id, emb, embed_tag(emb)),
     )
     _vec_upsert_note(conn, cur.lastrowid, emb)
     conn.execute(


### PR DESCRIPTION
## Summary

Swaps the embedding runtime from **sentence-transformers / PyTorch** to
**fastembed / ONNX Runtime**. Same model (`paraphrase-multilingual-MiniLM-L12-v2`),
same 384-dim vectors, `vec0` schema unchanged — but no PyTorch.

**Measured:** a model-loaded process drops from **~1.8 GB → ~670 MB** physical
footprint (zero `libtorch` mappings), ~650 MB less installed
(torch/transformers/sklearn/scipy gone).

## What's in it

- `THREADKEEPER_EMBED_BACKEND` (default `onnx`; `sentence-transformers` kept as
  opt-in fallback via the new `semantic-st` extra).
- `embeddings.py`: pluggable `_get_model` + unified `_encode`/`encode_many` with
  explicit L2-norm (dot == cosine for both backends).
- `embed_backend` column on `notes`/`dialog_messages` (NULL = legacy), tagged on write.
- **`tk-migrate-embeddings`** CLI — batched, resumable, idempotent recompute of
  stale vectors after a backend switch.
- `config.py`: backend availability probed via `find_spec` (keeps config import
  cheap; heavy import stays lazy).
- Tests + README + ARCHITECTURE + design spec.

## Test infra

CI now runs `pytest --forked`. The suite's per-test package re-import
accumulates native ONNX/tokenizer thread pools that can deadlock sqlite
connection finalize in a single long-lived interpreter; process isolation per
test is the reliable cure. Full suite green under `--forked` locally (~2 min).

## Release

Bumps version to **0.7.0**. Merging to `main` will auto-tag `v0.7.0` and publish
to PyPI per RELEASING.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)