### PR TITLE
feat: hot-config reload — re-read settings.json without Claude Code restart (#2)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,6 +27,10 @@
 # THREADKEEPER_AUTO_UPDATE_RESTART=true        # exit after applying an update so the host restarts on new code
 # THREADKEEPER_AUTO_UPDATE_TIMEOUT_S=600       # max seconds for git/pip update commands
 
+# ── hot-config reload (#2) ──
+# THREADKEEPER_CONFIG_WATCH_INTERVAL_S=2        # poll ~/.claude/settings.json and hot-apply changed env knobs in-process; 0 disables
+# THREADKEEPER_CONFIG_WATCH_PATH=               # override the watched settings.json path (default ~/.claude/settings.json)
+
 # ── ingest ──
 # THREADKEEPER_INGEST_CAP=50
 # THREADKEEPER_INGEST_INTERVAL_S=3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ version bumps follow semver per the policy in
 
 ## [Unreleased]
 
+### Added
+
+- **Hot-config reload — no Claude Code restart on env changes (#2).** A new
+  `config_watcher` daemon polls `~/.claude/settings.json`
+  (`THREADKEEPER_CONFIG_WATCH_INTERVAL_S`, default 2 s; 0 disables) and, when
+  its mtime moves, mirrors the threadkeeper-relevant `env` keys into the live
+  process and calls the new `config.reload_settings()`. That re-instantiates
+  `Settings`, re-publishes the module constants, and propagates each changed
+  value into every loaded `threadkeeper.*` module that imported a copy — so
+  daemons and tools pick up a changed knob (e.g.
+  `THREADKEEPER_SHADOW_REVIEW_INTERVAL_S`) without a restart. Newly-enabled
+  daemons (interval 0 → >0) are started automatically; already-running ones
+  self-adjust on their next tick. Manual trigger `config_reload()`; diagnostics
+  `config_watch_status()`. A half-written settings file is debounced via an
+  mtime-cursor + JSON-parse guard. New `helpers.daemon_sleep()` keeps every
+  interval daemon's loop from busy-spinning when a live interval is reloaded
+  to 0.
+
 ## v0.13.1 — 2026-06-15
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -536,6 +536,8 @@ The most-used env knobs (full list in `threadkeeper/config.py`):
 | `THREADKEEPER_AUTO_UPDATE_INTERVAL_S` | 86400 | MCP self-update check interval; 0 disables |
 | `THREADKEEPER_AUTO_UPDATE_RESTART` | "1" | exit MCP process after applying an update so the host restarts on new code |
 | `THREADKEEPER_AUTO_UPDATE_TIMEOUT_S` | 600 | max seconds for git/pip update commands |
+| `THREADKEEPER_CONFIG_WATCH_INTERVAL_S` | 2 | hot-config reload: poll `~/.claude/settings.json` and re-apply changed env knobs in-process (no Claude Code restart); 0 disables |
+| `THREADKEEPER_CONFIG_WATCH_PATH` | "" (`~/.claude/settings.json`) | override the watched settings file |
 | `THREADKEEPER_SHADOW_REVIEW_INTERVAL_S` | 0 (off) | shadow daemon tick (s) |
 | `THREADKEEPER_SHADOW_REVIEW_WINDOW_S` | 900 | sliding window for shadow scan (s) |
 | `THREADKEEPER_EXTRACT_INTERVAL_S` | 0 (off) | extract daemon tick (s); 600 = 10 min recommended |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -184,6 +184,26 @@ All daemon threads are cheap (ticks 0.5–30 s), no-op when env-knobs disable th
 - **skill_watcher** — once per `SKILL_WATCH_INTERVAL_S` (default 5 s) walks
   the primary `~/.claude/skills/*/SKILL.md` root and bumps `last_patched_at`
   if the file was changed outside `skill_manage`.
+- **config_watcher** (`config_watcher.start_config_watcher`) — once per
+  `CONFIG_WATCH_INTERVAL_S` (default 2 s, 0 = off) stats
+  `~/.claude/settings.json` (override: `THREADKEEPER_CONFIG_WATCH_PATH`) and,
+  when its mtime moves, re-reads the file's `env` block, mirrors the
+  threadkeeper-relevant keys (`THREADKEEPER_*` plus the unprefixed
+  `CLAUDE_SKILLS_DIR`/`CLAUDE_PROJECTS_DIR`) into `os.environ` (applying new
+  values, dropping deleted ones), and calls `config.reload_settings()`. That
+  re-instantiates `Settings`, re-publishes the UPPER_CASE module constants,
+  and `_propagate`s each changed value into every loaded `threadkeeper.*`
+  module that did `from .config import X` — which works because a function
+  resolves a module-global name at call time, so the next daemon tick / tool
+  call sees the new value with no restart (the issue-#2 acceptance test:
+  change the shadow interval, `shadow_review_status()` reflects it within
+  ~1 s). A daemon whose interval crossed 0 → >0 is started here; the rest
+  self-adjust (and `daemon_sleep` keeps a hot-disabled loop from busy-spinning
+  on `time.sleep(0)`). Cold start records only a baseline (the env is already
+  applied at spawn); a half-written file is skipped via the mtime-cursor +
+  JSON-parse guard and retried. Manual trigger `config_reload()`; diagnostics
+  `config_watch_status()`. Embedding-backend / process-identity flags are
+  intentionally not hot-reloaded.
 - **shadow_review** — once per `SHADOW_REVIEW_INTERVAL_S` (default 0 = off),
   scans a dialog window and, if needed, spawns a slim-child evaluator.
 - **candidate_reviewer** — once per `CANDIDATE_REVIEW_INTERVAL_S` (default

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -153,11 +153,19 @@ deployment is the more concrete need; cross-machine CRDT-based sync
 between independent installs is a strictly harder problem and
 probably never the right answer here.
 
-**Hot-config reload.** `.env` can be edited from the macOS menu-bar Settings
-window and that UI can request an MCP server restart after saving, but true
-in-process reload is not implemented. Ideally — pickup without restarting
-daemons. Scope: S (env via periodic re-read in the config object, daemons
-already read per-tick).
+**Hot-config reload.** ✅ DONE (#2). The `config_watcher` daemon polls
+`~/.claude/settings.json` (one mtime stat per tick, default 2 s) and, on a
+change, mirrors the threadkeeper-relevant `env` keys into the live process,
+calls `config.reload_settings()` to re-instantiate `Settings` and re-publish
+the module constants, and propagates each changed value into every loaded
+`threadkeeper.*` module that imported a copy — so daemons and tools pick up
+the new knob without a Claude Code restart. Newly-enabled daemons (interval
+0 → >0) are started; already-running ones self-adjust on their next tick
+(`daemon_sleep` keeps a hot-disabled loop from busy-spinning). Manual trigger
+`config_reload()`; diagnostics `config_watch_status()`; off via
+`THREADKEEPER_CONFIG_WATCH_INTERVAL_S=0`. Does not help host-CLI hooks (those
+are read by the CLI, not us); half-written files are debounced via an
+mtime-cursor + JSON-parse guard.
 
 **Telemetry dashboard.** ✅ DONE. `mp_dashboard(window_days)` is the
 aggregate the point views (`shadow_review_status`, `spawn_budget_status`,

--- a/tests/test_config_watcher.py
+++ b/tests/test_config_watcher.py
@@ -1,0 +1,264 @@
+"""Hot-config reload (issue #2): config.reload_settings + config_watcher.
+
+Contract:
+  * reload_settings re-reads env and propagates a changed constant into
+    every loaded threadkeeper module that imported a copy.
+  * config_watcher polls a settings.json, debounces on mtime, and on a real
+    change hot-applies the env knobs (the acceptance test: change the shadow
+    interval, see shadow_review_status reflect it without a restart).
+  * malformed/half-written JSON is skipped (cursor not advanced) and retried.
+  * deleting a key reverts the knob to its default.
+  * daemon_sleep never busy-spins when an interval is hot-reloaded to 0.
+"""
+from __future__ import annotations
+
+import json
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+
+def _bootstrap(tmp_path, monkeypatch, *, watch_interval="2", shadow="0"):
+    """Fresh re-import of threadkeeper with the watcher pointed at a tmp
+    settings.json so the real ~/.claude/settings.json is never touched."""
+    settings_json = tmp_path / "settings.json"
+    settings_json.write_text(
+        json.dumps({"env": {"THREADKEEPER_SHADOW_REVIEW_INTERVAL_S": shadow}})
+    )
+    env = {
+        "THREADKEEPER_DB": str(tmp_path / "db.sqlite"),
+        "CLAUDE_PROJECTS_DIR": str(tmp_path / "fake_claude_projects"),
+        "THREADKEEPER_DISABLE_BG_DAEMONS": "1",
+        "THREADKEEPER_INGEST_INTERVAL_S": "0",
+        "THREADKEEPER_INGEST_CAP": "0",
+        "THREADKEEPER_SKILL_WATCH_INTERVAL_S": "0",
+        "THREADKEEPER_SPAWN_BUDGET_POLL_S": "0",
+        "THREADKEEPER_SEARCH_PROXY_POLL_S": "0",
+        "THREADKEEPER_MEMORY_GUARD_POLL_S": "0",
+        "THREADKEEPER_AUTO_UPDATE_INTERVAL_S": "0",
+        "THREADKEEPER_SHADOW_REVIEW_INTERVAL_S": shadow,
+        "THREADKEEPER_CONFIG_WATCH_INTERVAL_S": watch_interval,
+        "THREADKEEPER_CONFIG_WATCH_PATH": str(settings_json),
+        "THREADKEEPER_CLIENT": "pytest",
+        "THREADKEEPER_FORCE_CID": "aaaa1111-2222-3333-4444-555566667777",
+    }
+    for k, v in env.items():
+        monkeypatch.setenv(k, v)
+    Path(env["CLAUDE_PROJECTS_DIR"]).mkdir(parents=True, exist_ok=True)
+    for name in [m for m in list(sys.modules) if m.startswith("threadkeeper")]:
+        del sys.modules[name]
+    import threadkeeper.server  # noqa: F401  (registers tools)
+    from threadkeeper import config, config_watcher, shadow_review
+    from threadkeeper.tools import shadow_review as shadow_tool
+    return {
+        "config": config,
+        "watcher": config_watcher,
+        "shadow_review": shadow_review,
+        "shadow_tool": shadow_tool,
+        "settings_json": settings_json,
+    }
+
+
+def _write_env(path: Path, env: dict) -> None:
+    """Rewrite settings.json and bump mtime so the watcher sees a change."""
+    path.write_text(json.dumps({"env": env}))
+    # Some filesystems have coarse mtime resolution; nudge it forward.
+    st = path.stat()
+    import os
+    os.utime(path, (st.st_atime, st.st_mtime + 1))
+
+
+# ── config.reload_settings ────────────────────────────────────────────────
+
+def test_reload_settings_propagates_to_consumer_module(tmp_path, monkeypatch):
+    pkg = _bootstrap(tmp_path, monkeypatch, shadow="0")
+    config = pkg["config"]
+    sr = pkg["shadow_review"]
+    assert config.SHADOW_REVIEW_INTERVAL_S == 0.0
+    assert sr.SHADOW_REVIEW_INTERVAL_S == 0.0
+
+    monkeypatch.setenv("THREADKEEPER_SHADOW_REVIEW_INTERVAL_S", "777")
+    changed = config.reload_settings()
+
+    assert "SHADOW_REVIEW_INTERVAL_S" in changed
+    assert changed["SHADOW_REVIEW_INTERVAL_S"]["new"] == 777.0
+    # The module that did `from .config import SHADOW_REVIEW_INTERVAL_S` sees it.
+    assert config.SHADOW_REVIEW_INTERVAL_S == 777.0
+    assert sr.SHADOW_REVIEW_INTERVAL_S == 777.0
+
+
+def test_reload_settings_no_change_returns_empty(tmp_path, monkeypatch):
+    pkg = _bootstrap(tmp_path, monkeypatch, shadow="60")
+    changed = pkg["config"].reload_settings()
+    assert changed == {}
+
+
+# ── config_watcher pass semantics ─────────────────────────────────────────
+
+def test_first_pass_initializes_without_reload(tmp_path, monkeypatch):
+    pkg = _bootstrap(tmp_path, monkeypatch, shadow="600")
+    w = pkg["watcher"]
+    assert w._last_mtime is None
+    assert w.run_config_watch_pass() == "initialized"
+    assert w._last_mtime is not None
+    # baseline captured the present key so a later deletion can be reverted
+    assert "THREADKEEPER_SHADOW_REVIEW_INTERVAL_S" in w._applied_keys
+
+
+def test_unchanged_file_is_debounced(tmp_path, monkeypatch):
+    pkg = _bootstrap(tmp_path, monkeypatch, shadow="600")
+    w = pkg["watcher"]
+    w.run_config_watch_pass()  # initialize
+    assert w.run_config_watch_pass() == "unchanged"
+
+
+def test_change_hot_applies_new_interval(tmp_path, monkeypatch):
+    """The acceptance test from the issue: change the interval in
+    settings.json and confirm shadow_review_status reflects it — no restart."""
+    pkg = _bootstrap(tmp_path, monkeypatch, shadow="600")
+    w = pkg["watcher"]
+    w.run_config_watch_pass()  # initialize baseline
+
+    _write_env(pkg["settings_json"],
+               {"THREADKEEPER_SHADOW_REVIEW_INTERVAL_S": "1234"})
+    out = w.run_config_watch_pass()
+    assert out.startswith("reloaded changed=")
+
+    assert pkg["config"].SHADOW_REVIEW_INTERVAL_S == 1234.0
+    assert pkg["shadow_review"].SHADOW_REVIEW_INTERVAL_S == 1234.0
+    # status MCP tool (reads its own imported copy) reflects the new value
+    from threadkeeper._mcp import mcp
+    status = mcp._tool_manager._tools["shadow_review_status"].fn()
+    assert "interval_s=1234" in status
+
+
+def test_malformed_json_is_skipped_and_retried(tmp_path, monkeypatch):
+    pkg = _bootstrap(tmp_path, monkeypatch, shadow="600")
+    w = pkg["watcher"]
+    w.run_config_watch_pass()  # initialize
+    cursor_before = w._last_mtime
+
+    # Half-written file: invalid JSON.
+    pkg["settings_json"].write_text('{"env": {"THREADKEEPER_')
+    st = pkg["settings_json"].stat()
+    import os
+    os.utime(pkg["settings_json"], (st.st_atime, st.st_mtime + 1))
+
+    out = w.run_config_watch_pass()
+    assert out.startswith("parse_error")
+    # cursor NOT advanced -> next clean tick still reloads
+    assert w._last_mtime == cursor_before
+
+
+def test_deleting_key_reverts_to_default(tmp_path, monkeypatch):
+    pkg = _bootstrap(tmp_path, monkeypatch, shadow="600")
+    config = pkg["config"]
+    w = pkg["watcher"]
+    w.run_config_watch_pass()  # initialize (key present, interval 600)
+    assert config.SHADOW_REVIEW_INTERVAL_S == 600.0
+
+    # User removes the knob entirely -> revert to the field default (0.0).
+    _write_env(pkg["settings_json"], {})
+    out = w.run_config_watch_pass()
+    assert out.startswith("reloaded")
+    assert config.SHADOW_REVIEW_INTERVAL_S == 0.0
+    assert "THREADKEEPER_SHADOW_REVIEW_INTERVAL_S" not in w._applied_keys
+
+
+def test_disabled_watcher_is_noop(tmp_path, monkeypatch):
+    pkg = _bootstrap(tmp_path, monkeypatch, watch_interval="0", shadow="600")
+    w = pkg["watcher"]
+    assert w.run_config_watch_pass() == "disabled"
+    # force overrides the disable gate
+    assert w.run_config_watch_pass(force=True) != "disabled"
+
+
+# ── daemon enable on interval 0 → >0 ──────────────────────────────────────
+
+def test_enable_transition_starts_daemon(tmp_path, monkeypatch):
+    pkg = _bootstrap(tmp_path, monkeypatch, shadow="0")
+    w = pkg["watcher"]
+    w.run_config_watch_pass()  # initialize (shadow disabled)
+
+    calls = []
+    monkeypatch.setattr(
+        pkg["shadow_review"], "start_shadow_daemon",
+        lambda: calls.append("started"),
+    )
+    _write_env(pkg["settings_json"],
+               {"THREADKEEPER_SHADOW_REVIEW_INTERVAL_S": "300"})
+    w.run_config_watch_pass()
+    assert calls == ["started"]
+
+
+def test_interval_change_does_not_restart_running_daemon(tmp_path, monkeypatch):
+    """600 → 900 is not an enable transition; the running loop self-adjusts."""
+    pkg = _bootstrap(tmp_path, monkeypatch, shadow="600")
+    w = pkg["watcher"]
+    w.run_config_watch_pass()
+
+    calls = []
+    monkeypatch.setattr(
+        pkg["shadow_review"], "start_shadow_daemon",
+        lambda: calls.append("started"),
+    )
+    _write_env(pkg["settings_json"],
+               {"THREADKEEPER_SHADOW_REVIEW_INTERVAL_S": "900"})
+    w.run_config_watch_pass()
+    assert calls == []
+    assert pkg["config"].SHADOW_REVIEW_INTERVAL_S == 900.0
+
+
+# ── start_config_watcher guards ───────────────────────────────────────────
+
+def test_start_config_watcher_disabled_when_interval_zero(tmp_path, monkeypatch):
+    pkg = _bootstrap(tmp_path, monkeypatch, watch_interval="0")
+    w = pkg["watcher"]
+    w.start_config_watcher()
+    assert w._started is False
+
+
+def test_start_config_watcher_refuses_in_non_foreground(tmp_path, monkeypatch):
+    # DISABLE_BG_DAEMONS=1 (set in _bootstrap) => BACKGROUND_DAEMONS_ALLOWED False
+    pkg = _bootstrap(tmp_path, monkeypatch, watch_interval="2")
+    w = pkg["watcher"]
+    assert pkg["config"].BACKGROUND_DAEMONS_ALLOWED is False
+    w.start_config_watcher()
+    assert w._started is False
+
+
+# ── daemon_sleep busy-spin guard ──────────────────────────────────────────
+
+def test_daemon_sleep_idles_when_interval_zero(tmp_path, monkeypatch):
+    pkg = _bootstrap(tmp_path, monkeypatch)
+    from threadkeeper import helpers
+    seen = []
+    monkeypatch.setattr(helpers.time, "sleep", lambda s: seen.append(s))
+    helpers.daemon_sleep(0, idle_s=0.05)
+    helpers.daemon_sleep(7.5)
+    helpers.daemon_sleep(-3, idle_s=0.05)
+    assert seen == [0.05, 7.5, 0.05]
+
+
+# ── MCP tools ─────────────────────────────────────────────────────────────
+
+def test_config_reload_tool(tmp_path, monkeypatch):
+    pkg = _bootstrap(tmp_path, monkeypatch, shadow="600")
+    pkg["watcher"].run_config_watch_pass()  # initialize
+    _write_env(pkg["settings_json"],
+               {"THREADKEEPER_SHADOW_REVIEW_INTERVAL_S": "4321"})
+    from threadkeeper._mcp import mcp
+    out = mcp._tool_manager._tools["config_reload"].fn()
+    assert out.startswith("reloaded")
+    assert pkg["config"].SHADOW_REVIEW_INTERVAL_S == 4321.0
+
+
+def test_config_watch_status_tool(tmp_path, monkeypatch):
+    pkg = _bootstrap(tmp_path, monkeypatch, shadow="600")
+    pkg["watcher"].run_config_watch_pass()
+    from threadkeeper._mcp import mcp
+    out = mcp._tool_manager._tools["config_watch_status"].fn()
+    assert "interval_s=" in out
+    assert "settings.json" in out

--- a/threadkeeper/candidate_reviewer.py
+++ b/threadkeeper/candidate_reviewer.py
@@ -47,6 +47,7 @@ from .config import (
     DB_PATH,
 )
 from .db import get_db
+from .helpers import daemon_sleep
 from . import identity
 
 logger = logging.getLogger(__name__)
@@ -393,7 +394,7 @@ def _serve_loop() -> None:
             run_review_pass()
         except Exception:
             logger.debug("candidate_reviewer tick failed", exc_info=True)
-        time.sleep(CANDIDATE_REVIEW_INTERVAL_S)
+        daemon_sleep(CANDIDATE_REVIEW_INTERVAL_S)
 
 
 def start_candidate_reviewer_daemon() -> None:

--- a/threadkeeper/config.py
+++ b/threadkeeper/config.py
@@ -103,6 +103,15 @@ class Settings(BaseSettings):
     auto_update_restart: bool = True
     auto_update_timeout_s: int = 600
 
+    # ── Hot-config reload (config_watcher daemon) ────────────────────────────
+    # Poll interval for the watcher that re-reads ~/.claude/settings.json and
+    # hot-reloads threadkeeper config in-process (no Claude Code restart). The
+    # poll is a single mtime stat — cheap, so it defaults ON. 0 = off.
+    config_watch_interval_s: float = 2.0
+    # Override the watched file. "" => the host CLI's settings.json
+    # (~/.claude/settings.json). Tests point this at a tmp file.
+    config_watch_path: str = ""
+
     # ── Ingest ───────────────────────────────────────────────────────────────
     # env: THREADKEEPER_INGEST_CAP (not INGEST_CAP_PER_CALL)
     ingest_cap: int = Field(
@@ -259,90 +268,174 @@ class Settings(BaseSettings):
 
 settings = Settings()
 
-# ── Derived paths that depend on db field ────────────────────────────────────
-
-# CURATOR_REPORTS_DIR: if not explicitly set, anchor to DB_PATH.parent/curator
-# so a custom THREADKEEPER_DB co-locates its curator reports.
-_curator_reports_dir: Path = (
-    settings.curator_reports_dir
-    if settings.curator_reports_dir is not None
-    else (settings.db.parent / "curator")
-)
-
 
 # ── Compat shim: re-export all prior module-level names ──────────────────────
-# Every name listed here is imported by ≥1 call site in the package.
+# Every name listed here is imported by ≥1 call site in the package. They are
+# computed from `settings` by `_derive_constants` so that `reload_settings()`
+# (the hot-config-reload path, issue #2) can recompute and re-publish them in
+# place without a process restart. Consumers that did `from .config import X`
+# still see updates because `reload_settings` propagates the new value into
+# every loaded `threadkeeper.*` module that holds a copy (see `_propagate`).
 
-DB_PATH: Path = settings.db
-EMBED_MODEL_NAME: str = settings.embed_model
-EMBED_BACKEND: str = settings.embed_backend  # already normalized to lower
-NO_EMBEDDINGS: bool = settings.no_embeddings
-CLIENT_LABEL: str = settings.client
-WRITE_ORIGIN: str = settings.write_origin
-SPAWNED_CHILD: bool = settings.spawned_child
-DISABLE_BG_DAEMONS: bool = settings.disable_bg_daemons
-MENUBAR_AUTO_LAUNCH: bool = settings.menubar_auto_launch
-AUTO_UPDATE_INTERVAL_S: float = settings.auto_update_interval_s
-AUTO_UPDATE_RESTART: bool = settings.auto_update_restart
-AUTO_UPDATE_TIMEOUT_S: int = settings.auto_update_timeout_s
-CLAUDE_SKILLS_DIR: Path = settings.claude_skills_dir
-CLAUDE_PROJECTS_DIR: Path = settings.claude_projects_dir
-TASK_LOG_DIR: Path = settings.task_log_dir
-DIALOG_LOG: Path = TASK_LOG_DIR / "dialog.log"
-INGEST_CAP_PER_CALL: int = settings.ingest_cap
-INGEST_INTERVAL_S: float = settings.ingest_interval_s
-INGEST_RECENT_WINDOW_S: int = settings.ingest_window_s
-SELF_CID_TTL_S: float = settings.self_cid_ttl_s
-MEMORY_NUDGE_INTERVAL: int = settings.memory_nudge_interval
-SKILL_NUDGE_INTERVAL: int = settings.skill_nudge_interval
-BRIEF_LEAN: bool = settings.brief_lean
-BRIEF_NO_THREAD_NUDGE: bool = settings.brief_no_thread_nudge
-AUTO_REVIEW_ENABLED: bool = settings.auto_review
-SPAWN_BUDGET_MB: int = settings.spawn_budget_mb
-SPAWN_ESTIMATE_SLIM_MB: int = settings.spawn_estimate_slim_mb
-SPAWN_ESTIMATE_FULL_MB: int = settings.spawn_estimate_full_mb
-SPAWN_BUDGET_POLL_S: float = settings.spawn_budget_poll_s
-MEMORY_GUARD_POLL_S: float = settings.memory_guard_poll_s
-MEMORY_GUARD_WARN_MB: int = settings.memory_guard_warn_mb
-MEMORY_GUARD_KILL_MB: int = settings.memory_guard_kill_mb
-MEMORY_GUARD_AGG_WARN_MB: int = settings.memory_guard_agg_warn_mb
-MEMORY_GUARD_AGG_KILL_MB: int = settings.memory_guard_agg_kill_mb
-MEMORY_GUARD_RECLAIM_MB: int = settings.memory_guard_reclaim_mb
-MEMORY_GUARD_TARGET_SERVERS: int = settings.memory_guard_target_servers
-MEMORY_GUARD_RETIRE_IDLE_S: int = settings.memory_guard_retire_idle_s
-MEMORY_GUARD_RETIRE_LIVE: bool = settings.memory_guard_retire_live
-MEMORY_GUARD_NOTIFY: bool = settings.memory_guard_notify
-MEMORY_GUARD_COOLDOWN_S: int = settings.memory_guard_cooldown_s
-SHADOW_REVIEW_INTERVAL_S: float = settings.shadow_review_interval_s
-SHADOW_REVIEW_WINDOW_S: int = settings.shadow_review_window_s
-SHADOW_REVIEW_MIN_CHARS: int = settings.shadow_review_min_chars
-CURATOR_INTERVAL_S: float = settings.curator_interval_s
-CURATOR_MIN_LESSONS: int = settings.curator_min_lessons
-CURATOR_REPORTS_DIR: Path = _curator_reports_dir
-CURATOR_DESTRUCTIVE: bool = settings.curator_destructive
-EXTRACT_INTERVAL_S: float = settings.extract_interval_s
-EXTRACT_WINDOW_MIN: int = settings.extract_window_min
-CANDIDATE_REVIEW_INTERVAL_S: float = settings.candidate_review_interval_s
-CANDIDATE_REVIEW_MIN: int = settings.candidate_review_min
-PROBE_INTERVAL_S: float = settings.probe_interval_s
-PROBE_COOLDOWN_S: int = settings.probe_cooldown_s
-PANEL_SIZE: int = settings.panel_size
-PANEL_ROLES: list[str] = settings.panel_roles
-PANEL_REQUIRE_SKEPTIC: bool = settings.panel_require_skeptic
-PANEL_VOTE_WEIGHT: float = settings.panel_vote_weight
-PANEL_MODEL: str = settings.panel_model
-PANEL_EFFORT: str = settings.panel_effort
-EVOLVE_REVIEW_INTERVAL_S: float = settings.evolve_review_interval_s
-EVOLVE_REVIEW_MIN: int = settings.evolve_review_min
-EVOLVE_APPLY_INTERVAL_S: float = settings.evolve_apply_interval_s
-ROADMAP_CLAIM_RACE_WINDOW_S: float = settings.roadmap_claim_race_window_s
-THREAD_JANITOR_INTERVAL_S: float = settings.thread_janitor_interval_s
-THREAD_IDLE_CLOSE_DAYS: float = settings.thread_idle_close_days
-DIALECTIC_MINE_INTERVAL_S: float = settings.dialectic_mine_interval_s
-DIALECTIC_VALIDATE_INTERVAL_S: float = settings.dialectic_validate_interval_s
-DIALECTIC_VALIDATE_MIN: int = settings.dialectic_validate_min
-DIALECTIC_VALIDATE_BATCH_SIZE: int = settings.dialectic_validate_batch_size
-DIALECTIC_MAX_NEW_CLAIMS: int = settings.dialectic_max_new_claims
+
+def _derive_constants(s: "Settings") -> dict:
+    """Map a Settings instance to the package's UPPER_CASE constants.
+
+    Pure: no side effects, no globals touched. Used once at import and again
+    on every `reload_settings()`. Only operational knobs live here — identity
+    flags (SEMANTIC_AVAILABLE, BACKGROUND_DAEMONS_ALLOWED) and the embedding
+    backend are computed once below and are NOT hot-reloaded.
+    """
+    # CURATOR_REPORTS_DIR: if not explicitly set, anchor to DB_PATH.parent/curator
+    # so a custom THREADKEEPER_DB co-locates its curator reports.
+    curator_reports_dir = (
+        s.curator_reports_dir
+        if s.curator_reports_dir is not None
+        else (s.db.parent / "curator")
+    )
+    return {
+        "DB_PATH": s.db,
+        "EMBED_MODEL_NAME": s.embed_model,
+        "EMBED_BACKEND": s.embed_backend,  # already normalized to lower
+        "NO_EMBEDDINGS": s.no_embeddings,
+        "CLIENT_LABEL": s.client,
+        "WRITE_ORIGIN": s.write_origin,
+        "SPAWNED_CHILD": s.spawned_child,
+        "DISABLE_BG_DAEMONS": s.disable_bg_daemons,
+        "MENUBAR_AUTO_LAUNCH": s.menubar_auto_launch,
+        "AUTO_UPDATE_INTERVAL_S": s.auto_update_interval_s,
+        "AUTO_UPDATE_RESTART": s.auto_update_restart,
+        "AUTO_UPDATE_TIMEOUT_S": s.auto_update_timeout_s,
+        "CONFIG_WATCH_INTERVAL_S": s.config_watch_interval_s,
+        "CONFIG_WATCH_PATH": s.config_watch_path,
+        "CLAUDE_SKILLS_DIR": s.claude_skills_dir,
+        "CLAUDE_PROJECTS_DIR": s.claude_projects_dir,
+        "TASK_LOG_DIR": s.task_log_dir,
+        "DIALOG_LOG": s.task_log_dir / "dialog.log",
+        "INGEST_CAP_PER_CALL": s.ingest_cap,
+        "INGEST_INTERVAL_S": s.ingest_interval_s,
+        "INGEST_RECENT_WINDOW_S": s.ingest_window_s,
+        "SELF_CID_TTL_S": s.self_cid_ttl_s,
+        "MEMORY_NUDGE_INTERVAL": s.memory_nudge_interval,
+        "SKILL_NUDGE_INTERVAL": s.skill_nudge_interval,
+        "BRIEF_LEAN": s.brief_lean,
+        "BRIEF_NO_THREAD_NUDGE": s.brief_no_thread_nudge,
+        "AUTO_REVIEW_ENABLED": s.auto_review,
+        "SPAWN_BUDGET_MB": s.spawn_budget_mb,
+        "SPAWN_ESTIMATE_SLIM_MB": s.spawn_estimate_slim_mb,
+        "SPAWN_ESTIMATE_FULL_MB": s.spawn_estimate_full_mb,
+        "SPAWN_BUDGET_POLL_S": s.spawn_budget_poll_s,
+        "MEMORY_GUARD_POLL_S": s.memory_guard_poll_s,
+        "MEMORY_GUARD_WARN_MB": s.memory_guard_warn_mb,
+        "MEMORY_GUARD_KILL_MB": s.memory_guard_kill_mb,
+        "MEMORY_GUARD_AGG_WARN_MB": s.memory_guard_agg_warn_mb,
+        "MEMORY_GUARD_AGG_KILL_MB": s.memory_guard_agg_kill_mb,
+        "MEMORY_GUARD_RECLAIM_MB": s.memory_guard_reclaim_mb,
+        "MEMORY_GUARD_TARGET_SERVERS": s.memory_guard_target_servers,
+        "MEMORY_GUARD_RETIRE_IDLE_S": s.memory_guard_retire_idle_s,
+        "MEMORY_GUARD_RETIRE_LIVE": s.memory_guard_retire_live,
+        "MEMORY_GUARD_NOTIFY": s.memory_guard_notify,
+        "MEMORY_GUARD_COOLDOWN_S": s.memory_guard_cooldown_s,
+        "SHADOW_REVIEW_INTERVAL_S": s.shadow_review_interval_s,
+        "SHADOW_REVIEW_WINDOW_S": s.shadow_review_window_s,
+        "SHADOW_REVIEW_MIN_CHARS": s.shadow_review_min_chars,
+        "CURATOR_INTERVAL_S": s.curator_interval_s,
+        "CURATOR_MIN_LESSONS": s.curator_min_lessons,
+        "CURATOR_REPORTS_DIR": curator_reports_dir,
+        "CURATOR_DESTRUCTIVE": s.curator_destructive,
+        "EXTRACT_INTERVAL_S": s.extract_interval_s,
+        "EXTRACT_WINDOW_MIN": s.extract_window_min,
+        "CANDIDATE_REVIEW_INTERVAL_S": s.candidate_review_interval_s,
+        "CANDIDATE_REVIEW_MIN": s.candidate_review_min,
+        "PROBE_INTERVAL_S": s.probe_interval_s,
+        "PROBE_COOLDOWN_S": s.probe_cooldown_s,
+        "PANEL_SIZE": s.panel_size,
+        "PANEL_ROLES": s.panel_roles,
+        "PANEL_REQUIRE_SKEPTIC": s.panel_require_skeptic,
+        "PANEL_VOTE_WEIGHT": s.panel_vote_weight,
+        "PANEL_MODEL": s.panel_model,
+        "PANEL_EFFORT": s.panel_effort,
+        "EVOLVE_REVIEW_INTERVAL_S": s.evolve_review_interval_s,
+        "EVOLVE_REVIEW_MIN": s.evolve_review_min,
+        "EVOLVE_APPLY_INTERVAL_S": s.evolve_apply_interval_s,
+        "ROADMAP_CLAIM_RACE_WINDOW_S": s.roadmap_claim_race_window_s,
+        "THREAD_JANITOR_INTERVAL_S": s.thread_janitor_interval_s,
+        "THREAD_IDLE_CLOSE_DAYS": s.thread_idle_close_days,
+        "DIALECTIC_MINE_INTERVAL_S": s.dialectic_mine_interval_s,
+        "DIALECTIC_VALIDATE_INTERVAL_S": s.dialectic_validate_interval_s,
+        "DIALECTIC_VALIDATE_MIN": s.dialectic_validate_min,
+        "DIALECTIC_VALIDATE_BATCH_SIZE": s.dialectic_validate_batch_size,
+        "DIALECTIC_MAX_NEW_CLAIMS": s.dialectic_max_new_claims,
+    }
+
+
+# Publish the initial constants into this module's namespace.
+globals().update(_derive_constants(settings))
+
+
+def _propagate(new_values: dict) -> None:
+    """Push reloaded constant values into every loaded `threadkeeper.*` module
+    that imported a copy via `from .config import X`.
+
+    This is what makes hot-reload reach consumers. A function reading a
+    module-global name resolves it against that module's `__dict__` at call
+    time, so overwriting the copy makes the next daemon tick / tool call see
+    the new value — no re-import needed. Only names a module already defines
+    are touched; we never inject new globals into unrelated modules.
+    """
+    import sys as _sys
+
+    me = _sys.modules.get(__name__)
+    for mod_name, mod in list(_sys.modules.items()):
+        if mod is me or mod is None:
+            continue
+        if not mod_name.startswith("threadkeeper"):
+            continue
+        d = getattr(mod, "__dict__", None)
+        if not d:
+            continue
+        for cname, val in new_values.items():
+            if cname in d:
+                d[cname] = val
+
+
+def reload_settings(env: Optional[dict] = None,
+                    remove: Optional[list] = None) -> dict:
+    """Re-read configuration in place (hot-config reload — issue #2).
+
+    Steps:
+      1. Optionally mutate `os.environ`: drop `remove` keys, set `env` keys.
+         (The config_watcher uses this to mirror ~/.claude/settings.json.)
+      2. Re-instantiate `Settings()` (re-reads os.environ + the .env file).
+      3. Recompute the UPPER_CASE constants and republish them on this module.
+      4. Propagate every CHANGED constant to all loaded `threadkeeper.*`
+         modules so daemons/tools that imported a copy observe the new value.
+
+    Returns a dict of changed constants: ``{NAME: {"old": ..., "new": ...}}``.
+    Embedding availability / process-identity flags are intentionally NOT
+    reloaded (hot-swapping the embedding backend in a live process is unsafe).
+    """
+    global settings
+    if remove:
+        for k in remove:
+            os.environ.pop(k, None)
+    if env:
+        for k, v in env.items():
+            os.environ[k] = str(v)
+
+    old = _derive_constants(settings)
+    settings = Settings()
+    new = _derive_constants(settings)
+
+    globals().update(new)
+    changed = {
+        name: {"old": old.get(name), "new": val}
+        for name, val in new.items()
+        if old.get(name) != val
+    }
+    if changed:
+        _propagate({name: c["new"] for name, c in changed.items()})
+    return changed
 
 # ── Derived constants (unchanged logic, computed after settings) ──────────────
 

--- a/threadkeeper/config_watcher.py
+++ b/threadkeeper/config_watcher.py
@@ -1,0 +1,235 @@
+"""Hot-config reload daemon (issue #2).
+
+Problem: the MCP server receives its env at stdio-spawn time (Claude Code
+injects the `env` block of `~/.claude/settings.json` into the process). When
+the user edits an env knob — e.g. `THREADKEEPER_SHADOW_REVIEW_INTERVAL_S` —
+the running server never re-reads it, so a full Claude Code restart is the
+only way the change takes effect.
+
+This daemon closes that gap. It polls `~/.claude/settings.json` (a single
+mtime stat per tick — cheap), and when the file changes it:
+
+1. parses the file's `env` block,
+2. mirrors the threadkeeper-relevant keys into `os.environ` (applying new
+   values and dropping keys the user deleted),
+3. calls `config.reload_settings()` which re-instantiates `Settings`,
+   re-publishes the module constants, and propagates every changed value
+   into the loaded `threadkeeper.*` modules that imported a copy, and
+4. starts any daemon that was just enabled (interval 0 → >0). Daemons that
+   were already running pick up a changed interval on their next tick
+   (their `_serve_loop` reads the interval module-global dynamically); a
+   daemon disabled at runtime (interval → 0) idles via `daemon_sleep`.
+
+Caveats (from the roadmap item):
+- Does NOT help host-CLI hooks — those are read by the CLI, not by us.
+- Racy multi-writer edits are handled by debounce (poll granularity) + a
+  JSON-parse guard: a half-written file is skipped and retried next tick,
+  and the mtime cursor is only advanced on a clean read.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import sqlite3
+import threading
+import time
+from pathlib import Path
+from typing import Optional
+
+from . import config
+from .db import get_db
+from .helpers import daemon_sleep
+from . import identity
+
+logger = logging.getLogger(__name__)
+
+_started = False
+
+# Per-process watcher state. Each MCP server watches and reloads its OWN
+# in-process config — this is intentionally not shared via the DB.
+_last_mtime: Optional[float] = None
+_applied_keys: set[str] = set()
+
+# Unprefixed env names threadkeeper honors (see config.AliasChoices). Pulled
+# from settings.json alongside every THREADKEEPER_* key.
+_UNPREFIXED_KEYS: frozenset[str] = frozenset(
+    {"CLAUDE_SKILLS_DIR", "CLAUDE_PROJECTS_DIR"}
+)
+
+# Interval constant -> (module, start-fn). After a reload, a daemon whose
+# interval crossed 0 → >0 is (re)started here; the rest self-adjust on their
+# next tick. Kept in sync with identity._ensure_session's daemon wiring.
+_DAEMON_FOR_INTERVAL: dict[str, tuple[str, str]] = {
+    "SHADOW_REVIEW_INTERVAL_S": ("shadow_review", "start_shadow_daemon"),
+    "CURATOR_INTERVAL_S": ("curator", "start_curator_daemon"),
+    "EXTRACT_INTERVAL_S": ("extract_daemon", "start_extract_daemon"),
+    "CANDIDATE_REVIEW_INTERVAL_S": (
+        "candidate_reviewer", "start_candidate_reviewer_daemon"),
+    "PROBE_INTERVAL_S": ("probe_daemon", "start_probe_daemon"),
+    "EVOLVE_REVIEW_INTERVAL_S": ("evolve_daemon", "start_evolve_daemon"),
+    "EVOLVE_APPLY_INTERVAL_S": ("evolve_applier", "start_evolve_applier_daemon"),
+    "THREAD_JANITOR_INTERVAL_S": ("thread_janitor", "start_thread_janitor"),
+    "DIALECTIC_MINE_INTERVAL_S": (
+        "dialectic_miner", "start_dialectic_miner_daemon"),
+    "DIALECTIC_VALIDATE_INTERVAL_S": (
+        "dialectic_validator", "start_dialectic_validator_daemon"),
+}
+
+
+def _settings_path() -> Path:
+    """The watched file. `THREADKEEPER_CONFIG_WATCH_PATH` overrides; default
+    is the Claude Code per-user settings (`~/.claude/settings.json`)."""
+    override = config.CONFIG_WATCH_PATH
+    if override:
+        return Path(override).expanduser()
+    return Path("~/.claude/settings.json").expanduser()
+
+
+def _is_relevant(key: str) -> bool:
+    return key.startswith("THREADKEEPER_") or key in _UNPREFIXED_KEYS
+
+
+def _relevant_env(path: Path) -> dict[str, str]:
+    """Parse the settings file's `env` block down to the threadkeeper knobs.
+
+    Raises `json.JSONDecodeError` on a malformed (e.g. half-written) file so
+    the caller can skip and retry. A missing `env` block yields `{}`.
+    """
+    with open(path, "r", encoding="utf-8") as fh:
+        data = json.load(fh)
+    env = data.get("env") if isinstance(data, dict) else None
+    if not isinstance(env, dict):
+        return {}
+    return {
+        str(k): str(v)
+        for k, v in env.items()
+        if _is_relevant(str(k)) and v is not None
+    }
+
+
+def _record_pass(conn: sqlite3.Connection, mtime: float, outcome: str) -> None:
+    """Write a `config_watch_pass` event for observability (status tool +
+    dashboards). `target` carries the mtime cursor, `summary` the outcome."""
+    try:
+        conn.execute(
+            "INSERT INTO events (session_id, kind, target, summary, created_at) "
+            "VALUES (?, 'config_watch_pass', ?, ?, ?)",
+            (identity._session_id or "", f"{mtime:.3f}",
+             outcome[:300], int(time.time())),
+        )
+        conn.commit()
+    except sqlite3.OperationalError:
+        logger.debug("config_watch: failed to record pass", exc_info=True)
+
+
+def _restart_changed_daemons(changed: dict) -> list[str]:
+    """Start daemons whose interval just crossed 0 → >0. Returns the names of
+    daemons (re)started. Already-running daemons need nothing: their loop
+    reads the interval global dynamically each tick."""
+    started: list[str] = []
+    for const, (mod_name, fn_name) in _DAEMON_FOR_INTERVAL.items():
+        delta = changed.get(const)
+        if not delta:
+            continue
+        old = delta.get("old") or 0
+        new = delta.get("new") or 0
+        try:
+            became_enabled = float(old) <= 0 < float(new)
+        except (TypeError, ValueError):
+            continue
+        if not became_enabled:
+            continue
+        try:
+            mod = __import__(f"threadkeeper.{mod_name}", fromlist=[fn_name])
+            getattr(mod, fn_name)()
+            started.append(mod_name)
+        except Exception:
+            logger.debug("config_watch: start %s failed", mod_name, exc_info=True)
+    return started
+
+
+def run_config_watch_pass(force: bool = False) -> str:
+    """Execute one watch tick synchronously (also the MCP manual trigger).
+
+    Returns a short status string:
+      - 'disabled'      — watcher off (interval<=0) and not forced
+      - 'no_file'       — the settings file does not exist
+      - 'unchanged'     — mtime has not moved since the last pass
+      - 'initialized'   — first sighting; baseline recorded, no reload
+      - 'parse_error: …'— file unreadable/half-written; retried next tick
+      - 'reloaded changed=N started=[…]' — config re-read and republished
+    """
+    global _last_mtime, _applied_keys
+    if config.CONFIG_WATCH_INTERVAL_S <= 0 and not force:
+        return "disabled"
+
+    path = _settings_path()
+    try:
+        mtime = path.stat().st_mtime
+    except FileNotFoundError:
+        return "no_file"
+    except OSError as e:
+        return f"stat_error: {e}"
+
+    if not force and _last_mtime is not None and mtime == _last_mtime:
+        return "unchanged"
+
+    # First sighting (cold process): the env was already applied by the host
+    # CLI at spawn, so just record the baseline + which keys are present (so a
+    # later deletion can be reverted). No reload — nothing changed yet.
+    if not force and _last_mtime is None:
+        try:
+            _applied_keys = set(_relevant_env(path))
+        except (json.JSONDecodeError, OSError):
+            return "parse_error: malformed settings.json (will retry)"
+        _last_mtime = mtime
+        return "initialized"
+
+    try:
+        desired = _relevant_env(path)
+    except (json.JSONDecodeError, OSError) as e:
+        # Do NOT advance the cursor — retry on the next tick once the writer
+        # has finished. This is the debounce/lock guard for racy writers.
+        return f"parse_error: {e}"
+
+    remove = sorted(_applied_keys - set(desired))
+    changed = config.reload_settings(env=desired, remove=remove)
+    _applied_keys = set(desired)
+    _last_mtime = mtime
+
+    started = _restart_changed_daemons(changed)
+    outcome = f"reloaded changed={len(changed)} started={started}"
+    try:
+        _record_pass(get_db(), mtime, outcome)
+    except Exception:
+        logger.debug("config_watch: record failed", exc_info=True)
+    return outcome
+
+
+def _serve_loop() -> None:
+    """Daemon body. Sleep → tick → sleep, until process dies."""
+    while True:
+        try:
+            run_config_watch_pass()
+        except Exception:
+            logger.debug("config_watcher tick failed", exc_info=True)
+        daemon_sleep(config.CONFIG_WATCH_INTERVAL_S)
+
+
+def start_config_watcher() -> None:
+    """Idempotent starter. No-op when CONFIG_WATCH_INTERVAL_S<=0 or in a
+    non-foreground process (spawned children must not hot-reload config)."""
+    global _started
+    if _started:
+        return
+    if config.CONFIG_WATCH_INTERVAL_S <= 0:
+        return
+    if not config.BACKGROUND_DAEMONS_ALLOWED:
+        return
+    t = threading.Thread(
+        target=_serve_loop, name="config_watcher", daemon=True,
+    )
+    t.start()
+    _started = True

--- a/threadkeeper/curator.py
+++ b/threadkeeper/curator.py
@@ -45,6 +45,7 @@ from .config import (
     CURATOR_DESTRUCTIVE,
 )
 from .db import get_db
+from .helpers import daemon_sleep
 from . import identity, lessons
 
 logger = logging.getLogger(__name__)
@@ -444,7 +445,7 @@ def _serve_loop() -> None:
             run_curator_pass()
         except Exception:
             logger.debug("curator tick failed", exc_info=True)
-        time.sleep(CURATOR_INTERVAL_S)
+        daemon_sleep(CURATOR_INTERVAL_S)
 
 
 def start_curator_daemon() -> None:

--- a/threadkeeper/dialectic_miner.py
+++ b/threadkeeper/dialectic_miner.py
@@ -16,6 +16,7 @@ import time
 
 from .config import DIALECTIC_MINE_INTERVAL_S
 from .db import get_db
+from .helpers import daemon_sleep
 from . import identity
 from .identity import _ensure_session, _emit
 
@@ -431,7 +432,7 @@ def _serve_loop() -> None:
             run_mine_pass()
         except Exception:
             logger.debug("dialectic_miner tick failed", exc_info=True)
-        time.sleep(DIALECTIC_MINE_INTERVAL_S)
+        daemon_sleep(DIALECTIC_MINE_INTERVAL_S)
 
 
 def start_dialectic_miner_daemon() -> None:

--- a/threadkeeper/dialectic_validator.py
+++ b/threadkeeper/dialectic_validator.py
@@ -20,6 +20,7 @@ from .config import (
     DIALECTIC_MAX_NEW_CLAIMS,
 )
 from .db import get_db
+from .helpers import daemon_sleep
 from . import identity
 from .identity import _ensure_session
 
@@ -535,7 +536,7 @@ def _serve_loop() -> None:
             run_validate_pass()
         except Exception:
             logger.debug("dialectic_validator tick failed", exc_info=True)
-        time.sleep(DIALECTIC_VALIDATE_INTERVAL_S)
+        daemon_sleep(DIALECTIC_VALIDATE_INTERVAL_S)
 
 
 def start_dialectic_validator_daemon() -> None:

--- a/threadkeeper/evolve_applier.py
+++ b/threadkeeper/evolve_applier.py
@@ -42,6 +42,7 @@ from .config import (
     ROADMAP_CLAIM_RACE_WINDOW_S,
 )
 from .db import get_db
+from .helpers import daemon_sleep
 from . import identity
 
 logger = logging.getLogger(__name__)
@@ -1423,7 +1424,7 @@ def _serve_loop() -> None:
             run_evolve_apply_pass()
         except Exception:
             logger.debug("evolve_applier tick failed", exc_info=True)
-        time.sleep(EVOLVE_APPLY_INTERVAL_S)
+        daemon_sleep(EVOLVE_APPLY_INTERVAL_S)
 
 
 def start_evolve_applier_daemon() -> None:

--- a/threadkeeper/evolve_daemon.py
+++ b/threadkeeper/evolve_daemon.py
@@ -22,6 +22,7 @@ import time
 
 from .config import EVOLVE_REVIEW_INTERVAL_S, EVOLVE_REVIEW_MIN
 from .db import get_db
+from .helpers import daemon_sleep
 from . import identity
 
 logger = logging.getLogger(__name__)
@@ -243,7 +244,7 @@ def _serve_loop() -> None:
             run_evolve_pass()
         except Exception:
             logger.debug("evolve_daemon tick failed", exc_info=True)
-        time.sleep(EVOLVE_REVIEW_INTERVAL_S)
+        daemon_sleep(EVOLVE_REVIEW_INTERVAL_S)
 
 
 def start_evolve_daemon() -> None:

--- a/threadkeeper/extract_daemon.py
+++ b/threadkeeper/extract_daemon.py
@@ -31,6 +31,7 @@ import time
 
 from .config import EXTRACT_INTERVAL_S, EXTRACT_WINDOW_MIN
 from .db import get_db
+from .helpers import daemon_sleep
 from . import identity
 
 logger = logging.getLogger(__name__)
@@ -102,7 +103,7 @@ def _serve_loop() -> None:
             run_extract_pass()
         except Exception:
             logger.debug("extract_daemon tick failed", exc_info=True)
-        time.sleep(EXTRACT_INTERVAL_S)
+        daemon_sleep(EXTRACT_INTERVAL_S)
 
 
 def start_extract_daemon() -> None:

--- a/threadkeeper/helpers.py
+++ b/threadkeeper/helpers.py
@@ -6,7 +6,25 @@ import os
 import secrets
 import sqlite3
 import subprocess
+import time
 from typing import Optional
+
+
+def daemon_sleep(interval_s, idle_s: float = 30.0) -> None:
+    """Sleep one daemon tick without ever busy-spinning.
+
+    Daemon `_serve_loop`s read their interval from a module global that the
+    hot-config reload (issue #2) can rewrite at runtime. If a live interval is
+    lowered to 0 ("daemon off"), a bare `time.sleep(0)` would turn the loop
+    into a CPU-pegging spin. This helper idles for `idle_s` instead so the
+    daemon goes quiet (its `run_*_pass` already short-circuits on interval<=0)
+    until the knob is raised again.
+    """
+    try:
+        interval = float(interval_s)
+    except (TypeError, ValueError):
+        interval = 0.0
+    time.sleep(interval if interval > 0 else idle_s)
 
 
 def fmt_age(seconds: int) -> str:

--- a/threadkeeper/identity.py
+++ b/threadkeeper/identity.py
@@ -151,6 +151,11 @@ def _ensure_session(conn: sqlite3.Connection, client: Optional[str] = None) -> s
         except Exception:
             pass
         try:
+            from . import config_watcher
+            config_watcher.start_config_watcher()
+        except Exception:
+            pass
+        try:
             from . import shadow_review
             shadow_review.start_shadow_daemon()
         except Exception:

--- a/threadkeeper/probe_daemon.py
+++ b/threadkeeper/probe_daemon.py
@@ -254,7 +254,7 @@ def _serve_loop() -> None:
             run_probe_pass()
         except Exception:
             logger.debug("probe_daemon tick failed", exc_info=True)
-        time.sleep(PROBE_INTERVAL_S)
+        daemon_sleep(PROBE_INTERVAL_S)
 
 
 def start_probe_daemon() -> None:

--- a/threadkeeper/server.py
+++ b/threadkeeper/server.py
@@ -57,6 +57,7 @@ from .tools import evolve_applier  # noqa: F401
 from .tools import dialectic_feed  # noqa: F401
 from .tools import dashboard  # noqa: F401
 from .tools import agent_status  # noqa: F401
+from .tools import config_watch  # noqa: F401
 
 
 if __name__ == "__main__":

--- a/threadkeeper/shadow_review.py
+++ b/threadkeeper/shadow_review.py
@@ -36,7 +36,7 @@ from .config import (
     SHADOW_REVIEW_WINDOW_S,
 )
 from .db import get_db
-from .helpers import alive
+from .helpers import alive, daemon_sleep
 from . import identity
 
 logger = logging.getLogger(__name__)
@@ -407,7 +407,7 @@ def _serve_loop() -> None:
             run_shadow_pass()
         except Exception:
             logger.debug("shadow_review tick failed", exc_info=True)
-        time.sleep(SHADOW_REVIEW_INTERVAL_S)
+        daemon_sleep(SHADOW_REVIEW_INTERVAL_S)
 
 
 def start_shadow_daemon() -> None:

--- a/threadkeeper/thread_janitor.py
+++ b/threadkeeper/thread_janitor.py
@@ -34,6 +34,7 @@ import time
 
 from .config import THREAD_JANITOR_INTERVAL_S, THREAD_IDLE_CLOSE_DAYS
 from .db import get_db
+from .helpers import daemon_sleep
 from . import identity
 
 logger = logging.getLogger(__name__)
@@ -114,7 +115,7 @@ def _serve_loop() -> None:
             run_janitor_pass()
         except Exception:
             logger.debug("thread_janitor tick failed", exc_info=True)
-        time.sleep(THREAD_JANITOR_INTERVAL_S)
+        daemon_sleep(THREAD_JANITOR_INTERVAL_S)
 
 
 def start_thread_janitor() -> None:

--- a/threadkeeper/tools/config_watch.py
+++ b/threadkeeper/tools/config_watch.py
@@ -1,0 +1,74 @@
+"""MCP tools for hot-config reload (issue #2).
+
+  config_reload(force=True)
+    Re-read ~/.claude/settings.json NOW and republish changed knobs across
+    the live process. `force=True` (default) bypasses the mtime/interval
+    gates so a manual call always re-reads.
+
+  config_watch_status()
+    Diagnostic snapshot: watched file, interval, cursor, applied keys, and
+    the last few reload passes.
+"""
+
+from __future__ import annotations
+
+import time
+
+from .._mcp import mcp
+from ..db import get_db
+from ..identity import _ensure_session
+from .. import config
+from .. import config_watcher
+
+
+@mcp.tool()
+def config_reload(force: bool = True) -> str:
+    """Re-read the watched settings file and hot-apply changed env knobs.
+
+    Mirrors the threadkeeper-relevant `env` keys from
+    `~/.claude/settings.json` into the live process (no Claude Code restart),
+    then republishes the changed constants to every daemon and tool. Newly
+    enabled daemons are started; changed intervals take effect on the next
+    daemon tick. Returns the pass outcome (e.g. `reloaded changed=2 ...`).
+    """
+    conn = get_db()
+    _ensure_session(conn)
+    return config_watcher.run_config_watch_pass(force=force)
+
+
+@mcp.tool()
+def config_watch_status() -> str:
+    """Show hot-config-reload state + the last 5 reload passes."""
+    conn = get_db()
+    _ensure_session(conn)
+    now = int(time.time())
+    path = config_watcher._settings_path()
+    last_mtime = config_watcher._last_mtime
+    applied = sorted(config_watcher._applied_keys)
+    lines = [
+        f"interval_s={config.CONFIG_WATCH_INTERVAL_S:.0f} "
+        f"file={path} exists={path.exists()}",
+        f"cursor_mtime={last_mtime if last_mtime is not None else '(none)'} "
+        f"applied_keys={len(applied)}",
+    ]
+    if applied:
+        lines.append("  " + ", ".join(applied))
+    lines.append("")
+    lines.append("recent passes (newest first):")
+    try:
+        rows = conn.execute(
+            "SELECT created_at, summary FROM events "
+            "WHERE kind='config_watch_pass' "
+            "ORDER BY id DESC LIMIT 5"
+        ).fetchall()
+    except Exception:
+        rows = []
+    if not rows:
+        lines.append("  (none)")
+    else:
+        for r in rows:
+            ts = r["created_at"]
+            age = now - int(ts) if ts else 0
+            snip = (r["summary"] or "")[:120]
+            lines.append(f"  {age}s_ago  {snip}")
+    return "\n".join(lines)


### PR DESCRIPTION
Closes #2

## Problem
Changing env vars in `~/.claude/settings.json` (e.g. `THREADKEEPER_AUTO_REVIEW`, `THREADKEEPER_SHADOW_REVIEW_INTERVAL_S`) required a full Claude Code restart — the MCP server got its env at stdio-spawn time and never re-read it.

## What this does
A new **`config_watcher`** daemon polls `~/.claude/settings.json` (one mtime stat per tick, `THREADKEEPER_CONFIG_WATCH_INTERVAL_S`, default 2 s; 0 disables). On a change it:

1. parses the file's `env` block and mirrors the threadkeeper-relevant keys (`THREADKEEPER_*` plus the unprefixed `CLAUDE_SKILLS_DIR`/`CLAUDE_PROJECTS_DIR`) into `os.environ` — applying new values and dropping deleted ones;
2. calls the new **`config.reload_settings()`**, which re-instantiates `Settings`, re-publishes the UPPER_CASE module constants, and **propagates each changed value into every loaded `threadkeeper.*` module that did `from .config import X`**. This works because a function resolves a module-global name at call time, so the next daemon tick / tool call sees the new value with no re-import;
3. **starts any daemon that just became enabled** (interval `0 → >0`). Already-running daemons self-adjust on their next tick.

New **`helpers.daemon_sleep()`** replaces bare `time.sleep(INTERVAL)` in the 10 interval daemons so a loop never busy-spins when an interval is hot-reloaded to `0` (it idles instead, and the daemon's `run_*_pass` already short-circuits on `interval<=0`).

### Acceptance test (from the issue)
Change `THREADKEEPER_SHADOW_REVIEW_INTERVAL_S` in `settings.json`, run `shadow_review_status()` → the new interval is reflected without a restart. Covered by `test_change_hot_applies_new_interval`.

## New surface
- MCP tools: **`config_reload(force=True)`** (manual trigger) and **`config_watch_status()`** (diagnostics).
- Env knobs: `THREADKEEPER_CONFIG_WATCH_INTERVAL_S` (default `2`), `THREADKEEPER_CONFIG_WATCH_PATH` (override watched file; tests point it at a tmp file).

## Caveats (as noted in the roadmap item)
- Does **not** help host-CLI hooks — those are read by the CLI, not us.
- Racy multi-writer edits are handled by debounce (poll granularity) + a JSON-parse guard: a half-written file is skipped and retried, and the mtime cursor only advances on a clean read.
- Embedding-backend / process-identity flags are intentionally **not** hot-reloaded (unsafe to hot-swap in a live process).

## Tests
- New `tests/test_config_watcher.py` (15 tests): constant propagation, cold-init/debounce/reload/parse-error/key-deletion semantics, enable-transition vs interval-change daemon handling, `start_config_watcher` guards, `daemon_sleep` busy-spin guard, and both MCP tools.
- Full suite green: **807 passed, 1 skipped, 0 failed**.

## Docs
README (env table), `docs/ARCHITECTURE.md` (daemon list), `docs/ROADMAP.md` (item marked ✅ DONE), `CHANGELOG.md`, `.env.example` updated in the same change-set.