### PR TITLE
feat: make evolve reviewer/applier work by default on PyPI installs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -81,6 +81,7 @@
 # THREADKEEPER_EVOLVE_REVIEW_INTERVAL_S=0
 # THREADKEEPER_EVOLVE_REVIEW_MIN=2
 # THREADKEEPER_EVOLVE_APPLY_INTERVAL_S=0       # applier tick (s); applies latest complete Curator report first, then promoted evolve PR work. 0=off (manual tools still work)
+# THREADKEEPER_EVOLVE_REPO_ROOT=               # absolute path to the thread-keeper git checkout the reviewer/applier branch+test+PR against. Empty=package parent (editable install.sh). SET THIS for a PyPI/site-packages install, else evolve reviewer + code/PR applier return ERR repo_root_not_git
 # THREADKEEPER_ROADMAP_CLAIM_RACE_WINDOW_S=3   # multi-host TOCTOU window: after posting a claim, wait this long before re-fetching to detect a competing claim. 0=skip race detection (single-host setups)
 # THREADKEEPER_THREAD_JANITOR_INTERVAL_S=0
 # THREADKEEPER_THREAD_IDLE_CLOSE_DAYS=1

--- a/.env.example
+++ b/.env.example
@@ -81,7 +81,10 @@
 # THREADKEEPER_EVOLVE_REVIEW_INTERVAL_S=0
 # THREADKEEPER_EVOLVE_REVIEW_MIN=2
 # THREADKEEPER_EVOLVE_APPLY_INTERVAL_S=0       # applier tick (s); applies latest complete Curator report first, then promoted evolve PR work. 0=off (manual tools still work)
-# THREADKEEPER_EVOLVE_REPO_ROOT=               # absolute path to the thread-keeper git checkout the reviewer/applier branch+test+PR against. Empty=package parent (editable install.sh). SET THIS for a PyPI/site-packages install, else evolve reviewer + code/PR applier return ERR repo_root_not_git
+# THREADKEEPER_EVOLVE_REPO_ROOT=               # pin the thread-keeper checkout the reviewer/applier branch+test+PR against. Empty=auto: package parent (editable install.sh) else an auto-cloned managed checkout under the DB dir
+# THREADKEEPER_EVOLVE_AUTO_CLONE=1             # auto-provision (clone + .venv with [semantic,dev]) a managed checkout on PyPI/site-packages installs so the evolve loops work by default. 0=disable (then needs an editable install or EVOLVE_REPO_ROOT)
+# THREADKEEPER_EVOLVE_REPO_URL=https://github.com/po4erk91/thread-keeper   # git URL the managed checkout is cloned from
+# THREADKEEPER_EVOLVE_REPO_BRANCH=main         # branch the managed checkout tracks
 # THREADKEEPER_ROADMAP_CLAIM_RACE_WINDOW_S=3   # multi-host TOCTOU window: after posting a claim, wait this long before re-fetching to detect a competing claim. 0=skip race detection (single-host setups)
 # THREADKEEPER_THREAD_JANITOR_INTERVAL_S=0
 # THREADKEEPER_THREAD_IDLE_CLOSE_DAYS=1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,18 +9,26 @@ version bumps follow semver per the policy in
 
 ### Added
 
-- **`THREADKEEPER_EVOLVE_REPO_ROOT` — make the evolve loops work on a PyPI /
-  site-packages install.** The evolve reviewer and evolve applier branch, run
-  the test suite, and open PRs against a git checkout. They previously assumed
-  the repo root was the package's parent dir, which holds only for the
-  editable-from-checkout `install.sh`. When thread-keeper is installed from
-  PyPI into site-packages, that parent is not a git tree, so both loops would
-  fail with cryptic `gh`/`git` errors. They now resolve the repo root from
-  `EVOLVE_REPO_ROOT` when set, the reviewer child runs with `cwd` pinned to
-  that root instead of the host CLI's working directory, and the reviewer plus
-  the code/PR applier paths fail fast with a clear `ERR repo_root_not_git=<path>`
-  (pointing at the new variable) when the resolved root is not a git checkout.
-  Curator report apply is memory-only and continues to run without a checkout.
+- **Evolve loops work by default on a PyPI / site-packages install (auto-clone).**
+  The evolve reviewer and evolve applier branch, run the test suite, and open
+  PRs against a git checkout. They previously assumed the repo root was the
+  package's parent dir, which holds only for the editable-from-checkout
+  `install.sh`; on a PyPI/site-packages install that parent is not a git tree,
+  so both loops failed with cryptic `gh`/`git` errors. Now a new
+  `_ensure_repo_ready()` resolves the checkout in order — explicit
+  `THREADKEEPER_EVOLVE_REPO_ROOT`, the package parent when it carries `.git`,
+  else a managed checkout under the DB dir (`~/.threadkeeper/evolve-repo`) — and
+  **auto-provisions the managed checkout on first use** (git clone +
+  per-checkout `.venv` with the `[semantic,dev]` extras) so the loops work with
+  no configuration. The reviewer child now runs with `cwd` pinned to that root
+  instead of the host CLI's working directory. Auto-provisioning is ON by
+  default and can be turned off with `THREADKEEPER_EVOLVE_AUTO_CLONE=0`, in
+  which case a non-checkout install reports a clear
+  `ERR evolve_repo_unavailable`; the clone source/branch are configurable via
+  `THREADKEEPER_EVOLVE_REPO_URL` / `THREADKEEPER_EVOLVE_REPO_BRANCH`. An explicit
+  override that is not itself a checkout is never auto-cloned into and reports
+  `ERR repo_root_not_git`. Curator report apply is memory-only and runs without
+  a checkout regardless.
 
 - **Hot-config reload — no Claude Code restart on env changes (#2).** A new
   `config_watcher` daemon polls `~/.claude/settings.json`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ version bumps follow semver per the policy in
 
 ### Added
 
+- **`THREADKEEPER_EVOLVE_REPO_ROOT` — make the evolve loops work on a PyPI /
+  site-packages install.** The evolve reviewer and evolve applier branch, run
+  the test suite, and open PRs against a git checkout. They previously assumed
+  the repo root was the package's parent dir, which holds only for the
+  editable-from-checkout `install.sh`. When thread-keeper is installed from
+  PyPI into site-packages, that parent is not a git tree, so both loops would
+  fail with cryptic `gh`/`git` errors. They now resolve the repo root from
+  `EVOLVE_REPO_ROOT` when set, the reviewer child runs with `cwd` pinned to
+  that root instead of the host CLI's working directory, and the reviewer plus
+  the code/PR applier paths fail fast with a clear `ERR repo_root_not_git=<path>`
+  (pointing at the new variable) when the resolved root is not a git checkout.
+  Curator report apply is memory-only and continues to run without a checkout.
+
 - **Hot-config reload — no Claude Code restart on env changes (#2).** A new
   `config_watcher` daemon polls `~/.claude/settings.json`
   (`THREADKEEPER_CONFIG_WATCH_INTERVAL_S`, default 2 s; 0 disables) and, when

--- a/README.md
+++ b/README.md
@@ -574,7 +574,10 @@ The most-used env knobs (full list in `threadkeeper/config.py`):
 | `THREADKEEPER_DIALECTIC_VALIDATE_BATCH_SIZE` | 50 | max observations sent to one validator child; prevents oversized prompts and drains large queues incrementally |
 | `THREADKEEPER_EVOLVE_REVIEW_INTERVAL_S` | 0 (off) | evolve-reviewer daemon tick (s); audits thread-keeper for safety/leaks/optimization/new ideas, researches current approaches, updates roadmap/issues, and includes legacy evolve suggestions as input |
 | `THREADKEEPER_EVOLVE_APPLY_INTERVAL_S` | 0 (off) | evolve-applier daemon tick (s); implements one open GitHub issue at a time, then falls back to Curator reports and promoted legacy evolve suggestions. Empty checks are throttled between intervals; actionable work and manual apply tools still dispatch |
-| `THREADKEEPER_EVOLVE_REPO_ROOT` | (package parent) | absolute path to the thread-keeper git checkout the evolve reviewer/applier branch, test, and open PRs against. Defaults to the package's parent dir (correct for the editable `install.sh`). **Set this when installed from PyPI into site-packages** — otherwise the evolve reviewer and code/PR applier return `ERR repo_root_not_git`. Curator report apply needs no checkout |
+| `THREADKEEPER_EVOLVE_REPO_ROOT` | (auto) | absolute path to the thread-keeper git checkout the evolve reviewer/applier branch, test, and open PRs against. When empty, the repo is resolved automatically: the package's parent dir for an editable `install.sh`, else a managed checkout under the DB dir that is auto-cloned on first use. Set this to pin an explicit checkout |
+| `THREADKEEPER_EVOLVE_AUTO_CLONE` | true | auto-provision (git clone + `.venv` with `[semantic,dev]`) a managed checkout when installed without a source tree (PyPI/site-packages), so the evolve loops work by default. Set `0`/`false` to disable — then a non-checkout install requires an editable install or an explicit `EVOLVE_REPO_ROOT`, otherwise the loops return `ERR evolve_repo_unavailable` |
+| `THREADKEEPER_EVOLVE_REPO_URL` | upstream repo | git URL the managed checkout is cloned from |
+| `THREADKEEPER_EVOLVE_REPO_BRANCH` | `main` | branch the managed checkout tracks |
 | `THREADKEEPER_DIALECTIC_MAX_NEW_CLAIMS` | 3 | max new dialectic claims the validator may create per pass |
 
 Persist them in `~/.threadkeeper/.env` (copy from `.env.example`) — one file,

--- a/README.md
+++ b/README.md
@@ -574,6 +574,7 @@ The most-used env knobs (full list in `threadkeeper/config.py`):
 | `THREADKEEPER_DIALECTIC_VALIDATE_BATCH_SIZE` | 50 | max observations sent to one validator child; prevents oversized prompts and drains large queues incrementally |
 | `THREADKEEPER_EVOLVE_REVIEW_INTERVAL_S` | 0 (off) | evolve-reviewer daemon tick (s); audits thread-keeper for safety/leaks/optimization/new ideas, researches current approaches, updates roadmap/issues, and includes legacy evolve suggestions as input |
 | `THREADKEEPER_EVOLVE_APPLY_INTERVAL_S` | 0 (off) | evolve-applier daemon tick (s); implements one open GitHub issue at a time, then falls back to Curator reports and promoted legacy evolve suggestions. Empty checks are throttled between intervals; actionable work and manual apply tools still dispatch |
+| `THREADKEEPER_EVOLVE_REPO_ROOT` | (package parent) | absolute path to the thread-keeper git checkout the evolve reviewer/applier branch, test, and open PRs against. Defaults to the package's parent dir (correct for the editable `install.sh`). **Set this when installed from PyPI into site-packages** — otherwise the evolve reviewer and code/PR applier return `ERR repo_root_not_git`. Curator report apply needs no checkout |
 | `THREADKEEPER_DIALECTIC_MAX_NEW_CLAIMS` | 3 | max new dialectic claims the validator may create per pass |
 
 Persist them in `~/.threadkeeper/.env` (copy from `.env.example`) — one file,

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -250,7 +250,14 @@ All daemon threads are cheap (ticks 0.5–30 s), no-op when env-knobs disable th
   interval to avoid duplicate issue workers across foreground server startups;
   manual apply tools still dispatch immediately. If no roadmap issue is
   startable, the pass falls back to Curator reports and then legacy promoted
-  `evolve_format` suggestions.
+  `evolve_format` suggestions. Both the reviewer and the code/PR applier paths
+  operate on a real git checkout: the repo root defaults to the package's parent
+  dir (correct for the editable-from-checkout `install.sh`) but can be pointed
+  elsewhere with `EVOLVE_REPO_ROOT` (`THREADKEEPER_EVOLVE_REPO_ROOT`). When
+  thread-keeper is installed from PyPI into site-packages — where the package
+  parent is not a git tree — these paths return a clear
+  `ERR repo_root_not_git=<path>` until that variable points at a checkout.
+  Curator report apply needs no git tree and runs regardless.
 - **curator → evolve bridge** — the Curator's lessons/skills audit remains
   report-first, but when a skill or lesson exposes a concrete improvement for
   thread-keeper itself it may call `evolve_format(...)` and record an

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -251,13 +251,22 @@ All daemon threads are cheap (ticks 0.5–30 s), no-op when env-knobs disable th
   manual apply tools still dispatch immediately. If no roadmap issue is
   startable, the pass falls back to Curator reports and then legacy promoted
   `evolve_format` suggestions. Both the reviewer and the code/PR applier paths
-  operate on a real git checkout: the repo root defaults to the package's parent
-  dir (correct for the editable-from-checkout `install.sh`) but can be pointed
-  elsewhere with `EVOLVE_REPO_ROOT` (`THREADKEEPER_EVOLVE_REPO_ROOT`). When
-  thread-keeper is installed from PyPI into site-packages — where the package
-  parent is not a git tree — these paths return a clear
-  `ERR repo_root_not_git=<path>` until that variable points at a checkout.
-  Curator report apply needs no git tree and runs regardless.
+  operate on a real git checkout, resolved by `_ensure_repo_ready()` in this
+  order: (1) an explicit `EVOLVE_REPO_ROOT` (`THREADKEEPER_EVOLVE_REPO_ROOT`);
+  (2) the package's parent dir when it carries a `.git` entry — the
+  editable-from-checkout `install.sh`; (3) otherwise a **managed checkout**
+  under the DB dir (`~/.threadkeeper/evolve-repo`). On a PyPI/site-packages
+  install where no source tree exists, the managed checkout is **auto-cloned on
+  first use** (from `EVOLVE_REPO_URL`/`EVOLVE_REPO_BRANCH`, defaulting to the
+  upstream repo) and given its own `.venv` with the `[semantic,dev]` extras so
+  the children can branch, run the suite, and open PRs. This makes the loops
+  work by default with no configuration. Set `THREADKEEPER_EVOLVE_AUTO_CLONE=0`
+  to disable provisioning — then a non-checkout install reports
+  `ERR evolve_repo_unavailable=<path>` until an editable install or an explicit
+  `EVOLVE_REPO_ROOT` is provided. An explicit override that is not itself a
+  checkout is never auto-cloned into and reports `ERR repo_root_not_git`.
+  Provisioning is serialized by `evolve-repo-provision.lock`. Curator report
+  apply needs no git tree and runs regardless.
 - **curator → evolve bridge** — the Curator's lessons/skills audit remains
   report-first, but when a skill or lesson exposes a concrete improvement for
   thread-keeper itself it may call `evolve_format(...)` and record an

--- a/tests/test_evolve_applier.py
+++ b/tests/test_evolve_applier.py
@@ -1113,11 +1113,11 @@ def test_run_apply_pass_picks_oldest_promoted(tmp_path, monkeypatch):
     assert pkg["ea"]._last_apply_ts(conn) > 0
 
 
-# ── repo-root resolution + git-checkout guard ──────────────────────────────
+# ── repo-root resolution + auto-provisioning ───────────────────────────────
 
 def test_repo_root_prefers_env_override(tmp_path, monkeypatch):
-    """When installed outside a checkout (PyPI/site-packages), the repo root is
-    taken from THREADKEEPER_EVOLVE_REPO_ROOT instead of the package parent."""
+    """An explicit THREADKEEPER_EVOLVE_REPO_ROOT pins the checkout and skips
+    auto-resolution."""
     external = tmp_path / "external_repo"
     external.mkdir()
     monkeypatch.setenv("THREADKEEPER_EVOLVE_REPO_ROOT", str(external))
@@ -1125,43 +1125,130 @@ def test_repo_root_prefers_env_override(tmp_path, monkeypatch):
     assert pkg["ea"]._repo_root() == external
 
 
-def test_repo_root_defaults_to_package_parent(tmp_path, monkeypatch):
+def test_repo_root_defaults_to_package_checkout(tmp_path, monkeypatch):
+    """With no override, an editable-from-checkout install resolves to the
+    package's parent dir (which carries a .git entry)."""
     pkg = _bootstrap(tmp_path, monkeypatch)
     from pathlib import Path as _P
     expected = _P(pkg["ea"].__file__).resolve().parent.parent
     assert pkg["ea"]._repo_root() == expected
 
 
-def test_apply_evolve_blocks_when_repo_not_git(tmp_path, monkeypatch):
-    """Code/PR path refuses to dispatch when the repo root is not a git tree —
-    the PyPI/site-packages failure mode — with a clear, actionable error."""
+def test_managed_repo_dir_is_under_db_dir(tmp_path, monkeypatch):
+    """The auto-cloned checkout lives next to the DB so it is stable across
+    restarts (PyPI/site-packages installs resolve here)."""
+    pkg = _bootstrap(tmp_path, monkeypatch)
+    assert pkg["ea"]._managed_repo_dir() == (
+        pkg["ea"].DB_PATH.parent / "evolve-repo"
+    )
+
+
+def test_ensure_repo_ready_uses_existing_checkout(tmp_path, monkeypatch):
+    """The common path: the resolved root is already a git tree (editable
+    install / dev checkout) → ready, no provisioning."""
+    pkg = _bootstrap(tmp_path, monkeypatch)
+
+    def _no_provision(dest):
+        raise AssertionError("must not provision when a checkout exists")
+    monkeypatch.setattr(pkg["ea"], "_provision_managed_repo", _no_provision)
+
+    root, err = pkg["ea"]._ensure_repo_ready()
+    assert err == ""
+    assert root == pkg["ea"]._repo_root()
+
+
+def test_ensure_repo_ready_auto_clones_when_missing(tmp_path, monkeypatch):
+    """Default behaviour on a PyPI install: no checkout → auto-provision a
+    managed one. Works out of the box, no env var required."""
+    pkg = _bootstrap(tmp_path, monkeypatch)
+    managed = tmp_path / "managed-repo"
+    monkeypatch.setattr(pkg["ea"], "_resolve_repo_root", lambda: managed)
+    monkeypatch.setattr(pkg["ea"], "_is_git_repo", lambda path: False)
+    provisioned = []
+    monkeypatch.setattr(
+        pkg["ea"], "_provision_managed_repo",
+        lambda dest: provisioned.append(dest) or "",
+    )
+
+    root, err = pkg["ea"]._ensure_repo_ready()
+    assert err == ""
+    assert root == managed
+    assert provisioned == [managed]
+
+
+def test_ensure_repo_ready_disabled_flag_blocks_auto_clone(tmp_path, monkeypatch):
+    """The flag only DISABLES the default: with auto-clone off and no checkout,
+    the loops report a clear error and never provision."""
+    pkg = _bootstrap(tmp_path, monkeypatch)
+    managed = tmp_path / "managed-repo"
+    monkeypatch.setattr(pkg["ea"], "_resolve_repo_root", lambda: managed)
+    monkeypatch.setattr(pkg["ea"], "_is_git_repo", lambda path: False)
+    monkeypatch.setattr(pkg["ea"], "EVOLVE_AUTO_CLONE", False)
+
+    def _no_provision(dest):
+        raise AssertionError("must not provision when auto-clone is disabled")
+    monkeypatch.setattr(pkg["ea"], "_provision_managed_repo", _no_provision)
+
+    root, err = pkg["ea"]._ensure_repo_ready()
+    assert root == managed
+    assert err.startswith("ERR evolve_repo_unavailable="), err
+    assert "THREADKEEPER_EVOLVE_AUTO_CLONE" in err
+
+
+def test_ensure_repo_ready_override_not_checkout_errors(tmp_path, monkeypatch):
+    """An explicit override that isn't a checkout is never auto-cloned into —
+    the user is told to fix the path."""
+    pkg = _bootstrap(tmp_path, monkeypatch)
+    bad = tmp_path / "not-a-repo"
+    bad.mkdir()
+    monkeypatch.setattr(pkg["ea"], "EVOLVE_REPO_ROOT", str(bad))
+    monkeypatch.setattr(pkg["ea"], "_is_git_repo", lambda path: False)
+
+    def _no_provision(dest):
+        raise AssertionError("must not provision into an explicit override path")
+    monkeypatch.setattr(pkg["ea"], "_provision_managed_repo", _no_provision)
+
+    root, err = pkg["ea"]._ensure_repo_ready()
+    assert root == bad
+    assert err.startswith("ERR repo_root_not_git="), err
+    assert "THREADKEEPER_EVOLVE_REPO_ROOT" in err
+
+
+def test_apply_evolve_blocks_when_repo_unavailable(tmp_path, monkeypatch):
+    """Code/PR path surfaces a repo-provisioning error and never spawns."""
     pkg = _bootstrap(tmp_path, monkeypatch)
     conn = pkg["db"].get_db()
     eid = _add_evolve(conn, "some promoted change", status="promoted")
-    monkeypatch.setattr(pkg["ea"], "_is_git_repo", lambda path: False)
+    from pathlib import Path as _P
+    monkeypatch.setattr(
+        pkg["ea"], "_ensure_repo_ready",
+        lambda: (_P("/x"), "ERR evolve_repo_clone_failed=/x: network down"),
+    )
 
     def _boom(**kw):
-        raise AssertionError("must not spawn without a git checkout")
+        raise AssertionError("must not spawn without a ready checkout")
     import threadkeeper.tools.spawn as spawn_mod
     monkeypatch.setattr(spawn_mod, "spawn", _boom)
 
     out = pkg["ea"].apply_evolve(eid)
-    assert out.startswith("ERR repo_root_not_git="), out
-    assert "THREADKEEPER_EVOLVE_REPO_ROOT" in out
+    assert out == "ERR evolve_repo_clone_failed=/x: network down"
 
 
-def test_apply_roadmap_issue_blocks_when_repo_not_git(tmp_path, monkeypatch):
+def test_apply_roadmap_issue_blocks_when_repo_unavailable(tmp_path, monkeypatch):
     pkg = _bootstrap(tmp_path, monkeypatch)
-    monkeypatch.setattr(pkg["ea"], "_is_git_repo", lambda path: False)
+    from pathlib import Path as _P
+    monkeypatch.setattr(
+        pkg["ea"], "_ensure_repo_ready",
+        lambda: (_P("/x"), "ERR evolve_repo_unavailable=/x (... auto-clone ...)"),
+    )
 
     def _boom(**kw):
-        raise AssertionError("must not spawn without a git checkout")
+        raise AssertionError("must not spawn without a ready checkout")
     import threadkeeper.tools.spawn as spawn_mod
     monkeypatch.setattr(spawn_mod, "spawn", _boom)
 
     out = pkg["ea"].apply_roadmap_issue()
-    assert out.startswith("ERR repo_root_not_git="), out
-    assert "THREADKEEPER_EVOLVE_REPO_ROOT" in out
+    assert out.startswith("ERR evolve_repo_unavailable="), out
 
 
 def test_run_apply_pass_single_flight(tmp_path, monkeypatch):

--- a/tests/test_evolve_applier.py
+++ b/tests/test_evolve_applier.py
@@ -1113,6 +1113,57 @@ def test_run_apply_pass_picks_oldest_promoted(tmp_path, monkeypatch):
     assert pkg["ea"]._last_apply_ts(conn) > 0
 
 
+# ── repo-root resolution + git-checkout guard ──────────────────────────────
+
+def test_repo_root_prefers_env_override(tmp_path, monkeypatch):
+    """When installed outside a checkout (PyPI/site-packages), the repo root is
+    taken from THREADKEEPER_EVOLVE_REPO_ROOT instead of the package parent."""
+    external = tmp_path / "external_repo"
+    external.mkdir()
+    monkeypatch.setenv("THREADKEEPER_EVOLVE_REPO_ROOT", str(external))
+    pkg = _bootstrap(tmp_path, monkeypatch)
+    assert pkg["ea"]._repo_root() == external
+
+
+def test_repo_root_defaults_to_package_parent(tmp_path, monkeypatch):
+    pkg = _bootstrap(tmp_path, monkeypatch)
+    from pathlib import Path as _P
+    expected = _P(pkg["ea"].__file__).resolve().parent.parent
+    assert pkg["ea"]._repo_root() == expected
+
+
+def test_apply_evolve_blocks_when_repo_not_git(tmp_path, monkeypatch):
+    """Code/PR path refuses to dispatch when the repo root is not a git tree —
+    the PyPI/site-packages failure mode — with a clear, actionable error."""
+    pkg = _bootstrap(tmp_path, monkeypatch)
+    conn = pkg["db"].get_db()
+    eid = _add_evolve(conn, "some promoted change", status="promoted")
+    monkeypatch.setattr(pkg["ea"], "_is_git_repo", lambda path: False)
+
+    def _boom(**kw):
+        raise AssertionError("must not spawn without a git checkout")
+    import threadkeeper.tools.spawn as spawn_mod
+    monkeypatch.setattr(spawn_mod, "spawn", _boom)
+
+    out = pkg["ea"].apply_evolve(eid)
+    assert out.startswith("ERR repo_root_not_git="), out
+    assert "THREADKEEPER_EVOLVE_REPO_ROOT" in out
+
+
+def test_apply_roadmap_issue_blocks_when_repo_not_git(tmp_path, monkeypatch):
+    pkg = _bootstrap(tmp_path, monkeypatch)
+    monkeypatch.setattr(pkg["ea"], "_is_git_repo", lambda path: False)
+
+    def _boom(**kw):
+        raise AssertionError("must not spawn without a git checkout")
+    import threadkeeper.tools.spawn as spawn_mod
+    monkeypatch.setattr(spawn_mod, "spawn", _boom)
+
+    out = pkg["ea"].apply_roadmap_issue()
+    assert out.startswith("ERR repo_root_not_git="), out
+    assert "THREADKEEPER_EVOLVE_REPO_ROOT" in out
+
+
 def test_run_apply_pass_single_flight(tmp_path, monkeypatch):
     pkg = _bootstrap(tmp_path, monkeypatch)
     conn = pkg["db"].get_db()

--- a/tests/test_evolve_daemon.py
+++ b/tests/test_evolve_daemon.py
@@ -213,6 +213,43 @@ def test_run_evolve_pass_spawns_reviewer(tmp_path, monkeypatch):
     assert pkg["ed"]._last_evolve_ts(conn) > 0
 
 
+def test_run_evolve_pass_runs_reviewer_in_repo_root(tmp_path, monkeypatch):
+    """The reviewer child must run with cwd pinned to the repo checkout, not the
+    host CLI's working directory."""
+    pkg = _bootstrap(tmp_path, monkeypatch, review_min="1")
+    conn = pkg["db"].get_db()
+    _add_evolve(conn, "s1")
+    calls = {}
+    import threadkeeper.tools.spawn as spawn_mod
+    monkeypatch.setattr(spawn_mod, "spawn",
+                        lambda **kw: calls.update(kw) or "ok task=tk_ev pid=1")
+
+    out = pkg["ed"].run_evolve_pass(force=True)
+
+    assert out.startswith("spawned audit")
+    assert calls["cwd"] == str(pkg["ed"]._repo_root())
+
+
+def test_run_evolve_pass_blocks_when_repo_not_git(tmp_path, monkeypatch):
+    """No checkout (PyPI/site-packages) → reviewer refuses to spawn and returns
+    an actionable error instead of running gh/file reads against the wrong dir."""
+    pkg = _bootstrap(tmp_path, monkeypatch, review_min="1")
+    conn = pkg["db"].get_db()
+    _add_evolve(conn, "s1")
+    monkeypatch.setattr(pkg["ed"], "_is_git_repo", lambda path: False)
+
+    def _boom(**kw):
+        raise AssertionError("must not spawn without a git checkout")
+    import threadkeeper.tools.spawn as spawn_mod
+    monkeypatch.setattr(spawn_mod, "spawn", _boom)
+
+    out = pkg["ed"].run_evolve_pass(force=True)
+    assert out.startswith("ERR repo_root_not_git="), out
+    assert "THREADKEEPER_EVOLVE_REPO_ROOT" in out
+    # the failed pass is recorded so the daemon throttles retries
+    assert pkg["ed"]._last_evolve_ts(conn) > 0
+
+
 def test_run_evolve_pass_single_flight(tmp_path, monkeypatch):
     pkg = _bootstrap(tmp_path, monkeypatch, review_min="1")
     conn = pkg["db"].get_db()

--- a/tests/test_evolve_daemon.py
+++ b/tests/test_evolve_daemon.py
@@ -227,25 +227,29 @@ def test_run_evolve_pass_runs_reviewer_in_repo_root(tmp_path, monkeypatch):
     out = pkg["ed"].run_evolve_pass(force=True)
 
     assert out.startswith("spawned audit")
-    assert calls["cwd"] == str(pkg["ed"]._repo_root())
+    expected = str(Path(pkg["ed"].__file__).resolve().parent.parent)
+    assert calls["cwd"] == expected
 
 
-def test_run_evolve_pass_blocks_when_repo_not_git(tmp_path, monkeypatch):
-    """No checkout (PyPI/site-packages) → reviewer refuses to spawn and returns
-    an actionable error instead of running gh/file reads against the wrong dir."""
+def test_run_evolve_pass_blocks_when_repo_unavailable(tmp_path, monkeypatch):
+    """When the checkout can't be provisioned (e.g. auto-clone disabled on a
+    PyPI install), the reviewer refuses to spawn and records an actionable
+    error instead of running gh/file reads against the wrong dir."""
     pkg = _bootstrap(tmp_path, monkeypatch, review_min="1")
     conn = pkg["db"].get_db()
     _add_evolve(conn, "s1")
-    monkeypatch.setattr(pkg["ed"], "_is_git_repo", lambda path: False)
+    monkeypatch.setattr(
+        pkg["ed"], "_ensure_repo_ready",
+        lambda: (Path("/x"), "ERR evolve_repo_unavailable=/x (... auto-clone ...)"),
+    )
 
     def _boom(**kw):
-        raise AssertionError("must not spawn without a git checkout")
+        raise AssertionError("must not spawn without a ready checkout")
     import threadkeeper.tools.spawn as spawn_mod
     monkeypatch.setattr(spawn_mod, "spawn", _boom)
 
     out = pkg["ed"].run_evolve_pass(force=True)
-    assert out.startswith("ERR repo_root_not_git="), out
-    assert "THREADKEEPER_EVOLVE_REPO_ROOT" in out
+    assert out.startswith("ERR evolve_repo_unavailable="), out
     # the failed pass is recorded so the daemon throttles retries
     assert pkg["ed"]._last_evolve_ts(conn) > 0
 

--- a/threadkeeper/config.py
+++ b/threadkeeper/config.py
@@ -212,12 +212,21 @@ class Settings(BaseSettings):
     # evolve_apply (spawns a child that implements it + opens a PR). 0 = off.
     evolve_apply_interval_s: float = 0.0
     # Absolute path to the thread-keeper git checkout the evolve reviewer and
-    # applier operate on (branch, run tests, open PRs against). Empty => the
-    # package's parent dir, which IS the repo root for the editable-from-checkout
-    # install that install.sh performs. Set this when thread-keeper is installed
-    # from PyPI into site-packages, where the package parent is not a git tree
-    # and the evolve loops would otherwise have no repo to work on.
+    # applier operate on (branch, run tests, open PRs against). Empty => resolve
+    # automatically: the package's parent dir when it is itself a checkout (the
+    # editable-from-checkout install.sh), else a managed checkout under the DB
+    # dir that is auto-cloned on first use (PyPI/site-packages installs). Set
+    # this to pin an explicit checkout and skip auto-provisioning.
     evolve_repo_root: str = ""
+    # Auto-provision (git clone + .venv with test deps) a managed checkout when
+    # thread-keeper is installed without a source tree. ON by default so the
+    # evolve loops work out of the box; set 0/false to disable — then the loops
+    # require an editable install or an explicit EVOLVE_REPO_ROOT.
+    evolve_auto_clone: bool = True
+    # Canonical repo the managed checkout is cloned from, and the branch it
+    # tracks. Defaults to the upstream thread-keeper project.
+    evolve_repo_url: str = "https://github.com/po4erk91/thread-keeper"
+    evolve_repo_branch: str = "main"
     # After posting a roadmap-issue claim comment, wait this long, re-fetch
     # comments, and retract our claim if another host raced us. Cross-host
     # TOCTOU guard. Set to 0 in tests to skip the wait.
@@ -366,6 +375,9 @@ def _derive_constants(s: "Settings") -> dict:
         "EVOLVE_REVIEW_MIN": s.evolve_review_min,
         "EVOLVE_APPLY_INTERVAL_S": s.evolve_apply_interval_s,
         "EVOLVE_REPO_ROOT": s.evolve_repo_root,
+        "EVOLVE_AUTO_CLONE": s.evolve_auto_clone,
+        "EVOLVE_REPO_URL": s.evolve_repo_url,
+        "EVOLVE_REPO_BRANCH": s.evolve_repo_branch,
         "ROADMAP_CLAIM_RACE_WINDOW_S": s.roadmap_claim_race_window_s,
         "THREAD_JANITOR_INTERVAL_S": s.thread_janitor_interval_s,
         "THREAD_IDLE_CLOSE_DAYS": s.thread_idle_close_days,

--- a/threadkeeper/config.py
+++ b/threadkeeper/config.py
@@ -211,6 +211,13 @@ class Settings(BaseSettings):
     # Periodically picks the top promoted+unapplied evolve suggestion and fires
     # evolve_apply (spawns a child that implements it + opens a PR). 0 = off.
     evolve_apply_interval_s: float = 0.0
+    # Absolute path to the thread-keeper git checkout the evolve reviewer and
+    # applier operate on (branch, run tests, open PRs against). Empty => the
+    # package's parent dir, which IS the repo root for the editable-from-checkout
+    # install that install.sh performs. Set this when thread-keeper is installed
+    # from PyPI into site-packages, where the package parent is not a git tree
+    # and the evolve loops would otherwise have no repo to work on.
+    evolve_repo_root: str = ""
     # After posting a roadmap-issue claim comment, wait this long, re-fetch
     # comments, and retract our claim if another host raced us. Cross-host
     # TOCTOU guard. Set to 0 in tests to skip the wait.
@@ -358,6 +365,7 @@ def _derive_constants(s: "Settings") -> dict:
         "EVOLVE_REVIEW_INTERVAL_S": s.evolve_review_interval_s,
         "EVOLVE_REVIEW_MIN": s.evolve_review_min,
         "EVOLVE_APPLY_INTERVAL_S": s.evolve_apply_interval_s,
+        "EVOLVE_REPO_ROOT": s.evolve_repo_root,
         "ROADMAP_CLAIM_RACE_WINDOW_S": s.roadmap_claim_race_window_s,
         "THREAD_JANITOR_INTERVAL_S": s.thread_janitor_interval_s,
         "THREAD_IDLE_CLOSE_DAYS": s.thread_idle_close_days,

--- a/threadkeeper/evolve_applier.py
+++ b/threadkeeper/evolve_applier.py
@@ -39,7 +39,10 @@ from .config import (
     CURATOR_REPORTS_DIR,
     DB_PATH,
     EVOLVE_APPLY_INTERVAL_S,
+    EVOLVE_AUTO_CLONE,
+    EVOLVE_REPO_BRANCH,
     EVOLVE_REPO_ROOT,
+    EVOLVE_REPO_URL,
     ROADMAP_CLAIM_RACE_WINDOW_S,
 )
 from .db import get_db
@@ -283,18 +286,38 @@ or:
 """
 
 
-def _repo_root() -> Path:
-    """Git checkout the evolve loops operate on.
+EVOLVE_CLONE_TIMEOUT_S = 600
+EVOLVE_VENV_TIMEOUT_S = 1800
 
-    Prefers THREADKEEPER_EVOLVE_REPO_ROOT (config EVOLVE_REPO_ROOT) when set —
-    required when thread-keeper is installed from PyPI into site-packages, where
-    the package's parent dir is not a git tree. Falls back to the package parent
-    (threadkeeper/..), which IS the repo root for the editable-from-checkout
-    install that install.sh performs."""
+
+def _managed_repo_dir() -> Path:
+    """Managed checkout used when thread-keeper is installed without a source
+    tree (PyPI/site-packages). Co-located with the DB so it has a stable home
+    across restarts."""
+    return (DB_PATH.parent / "evolve-repo").expanduser()
+
+
+def _resolve_repo_root() -> Path:
+    """Pure repo-root resolution — no network, no git subprocess.
+
+    Order:
+      1. explicit EVOLVE_REPO_ROOT override;
+      2. the package's parent dir when it is itself a checkout (editable
+         install.sh), detected cheaply by a `.git` entry;
+      3. the managed checkout under the DB dir (PyPI/site-packages installs),
+         which `_ensure_repo_ready()` auto-provisions on first use."""
     override = (EVOLVE_REPO_ROOT or "").strip()
     if override:
         return Path(override).expanduser()
-    return Path(__file__).resolve().parent.parent
+    pkg_parent = Path(__file__).resolve().parent.parent
+    if (pkg_parent / ".git").exists():
+        return pkg_parent
+    return _managed_repo_dir()
+
+
+def _repo_root() -> Path:
+    """Git checkout the evolve loops operate on (see `_resolve_repo_root`)."""
+    return _resolve_repo_root()
 
 
 def _is_git_repo(path: Path) -> bool:
@@ -310,14 +333,125 @@ def _is_git_repo(path: Path) -> bool:
     return proc.returncode == 0 and (proc.stdout or "").strip() == "true"
 
 
-def _repo_not_git_error(root: Path) -> str:
-    """Standard error for the code/PR paths when the resolved repo root is not a
-    git checkout — typical of a PyPI/site-packages install with no checkout."""
+def _override_not_git_error(root: Path) -> str:
+    """The explicit EVOLVE_REPO_ROOT is not a checkout — never auto-clone into a
+    user-chosen path; tell them to fix it."""
     return (
-        f"ERR repo_root_not_git={root} (thread-keeper is installed outside a "
-        "git checkout; set THREADKEEPER_EVOLVE_REPO_ROOT to your thread-keeper "
-        "clone so the evolve applier can branch, test, and open PRs)"
+        f"ERR repo_root_not_git={root} (the path in THREADKEEPER_EVOLVE_REPO_ROOT"
+        " is not a git checkout; point it at a real thread-keeper clone)"
     )
+
+
+def _autoclone_disabled_error(root: Path) -> str:
+    """No checkout and auto-clone is turned off — the only way the evolve loops
+    don't work by default."""
+    return (
+        f"ERR evolve_repo_unavailable={root} (no git checkout and auto-clone is "
+        "disabled via THREADKEEPER_EVOLVE_AUTO_CLONE=0; set "
+        "THREADKEEPER_EVOLVE_REPO_ROOT to a checkout or re-enable auto-clone)"
+    )
+
+
+@contextmanager
+def _repo_provision_lock():
+    """Serialize clone/venv provisioning across foreground servers so two ticks
+    don't race a half-finished clone into the same managed dir. Blocking: the
+    loser waits, then re-checks under the lock and reuses the finished clone."""
+    try:
+        import fcntl
+    except ImportError:  # pragma: no cover - thread-keeper runs on Unix CLIs.
+        yield
+        return
+    lock_path = DB_PATH.parent / "evolve-repo-provision.lock"
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    with lock_path.open("w") as lock:
+        fcntl.flock(lock.fileno(), fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(lock.fileno(), fcntl.LOCK_UN)
+
+
+def _run(cmd: list[str], timeout: int, cwd: Optional[Path] = None) -> str:
+    """Run a provisioning subprocess. Returns '' on success or a short error."""
+    try:
+        proc = subprocess.run(
+            cmd,
+            cwd=str(cwd) if cwd else None,
+            text=True, capture_output=True, timeout=timeout, check=False,
+        )
+    except FileNotFoundError:
+        return f"{cmd[0]}_not_found"
+    except subprocess.TimeoutExpired:
+        return f"{cmd[0]}_timeout"
+    except OSError as e:
+        return f"{cmd[0]}_error: {e}"
+    if proc.returncode != 0:
+        err = (proc.stderr or proc.stdout or "").strip().splitlines()
+        return (err[-1] if err else f"exit={proc.returncode}")[:180]
+    return ""
+
+
+def _ensure_managed_venv(dest: Path) -> str:
+    """Create dest/.venv and editable-install thread-keeper with semantic+test
+    extras so the evolve children can run `.venv/bin/python -m pytest`. Idempotent
+    — a present venv python is treated as ready. Returns '' or an ERR string."""
+    import sys
+    venv_py = dest / ".venv" / "bin" / "python"
+    if venv_py.exists():
+        return ""
+    err = _run([sys.executable, "-m", "venv", str(dest / ".venv")],
+               EVOLVE_VENV_TIMEOUT_S)
+    if err:
+        return f"ERR evolve_venv_create_failed={dest}: {err}"
+    pip = dest / ".venv" / "bin" / "pip"
+    err = _run([str(pip), "install", "-q", "-e", f"{dest}[semantic,dev]"],
+               EVOLVE_VENV_TIMEOUT_S)
+    if err:
+        return f"ERR evolve_venv_install_failed={dest}: {err}"
+    return ""
+
+
+def _provision_managed_repo(dest: Path) -> str:
+    """Clone the canonical repo into `dest` and provision its venv. Serialized
+    and idempotent: re-checks under the lock so a concurrent winner's clone is
+    reused. Returns '' on success or an ERR string."""
+    with _repo_provision_lock():
+        if _is_git_repo(dest):
+            return _ensure_managed_venv(dest)
+        if dest.exists() and any(dest.iterdir()):
+            return (
+                f"ERR evolve_repo_dir_not_empty={dest} (cannot auto-clone into a "
+                "non-empty non-git directory; clear it or set "
+                "THREADKEEPER_EVOLVE_REPO_ROOT)"
+            )
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        err = _run(
+            ["git", "clone", "--quiet", "--branch", str(EVOLVE_REPO_BRANCH),
+             str(EVOLVE_REPO_URL), str(dest)],
+            EVOLVE_CLONE_TIMEOUT_S,
+        )
+        if err:
+            return f"ERR evolve_repo_clone_failed={dest}: {err}"
+        return _ensure_managed_venv(dest)
+
+
+def _ensure_repo_ready() -> tuple[Path, str]:
+    """Resolve the repo root and make sure it is a usable git checkout, cloning
+    a managed one on first use when needed. Returns (root, error); error is ''
+    on success. This is the gate every code/PR path and the reviewer call."""
+    root = _resolve_repo_root()
+    if _is_git_repo(root):
+        return root, ""
+    if (EVOLVE_REPO_ROOT or "").strip():
+        # Explicit override that isn't a checkout — never auto-clone there.
+        return root, _override_not_git_error(root)
+    if not EVOLVE_AUTO_CLONE:
+        return root, _autoclone_disabled_error(root)
+    err = _provision_managed_repo(root)
+    if err:
+        return root, err
+    return root, ""
 
 
 def _slug(text: str, maxlen: int = 32) -> str:
@@ -1174,9 +1308,9 @@ def apply_roadmap_issue(issue_number: int = 0) -> str:
             return "applier_running n=1 (single-flight lock)"
 
         conn = get_db()
-        repo_root = _repo_root()
-        if not _is_git_repo(repo_root):
-            return _repo_not_git_error(repo_root)
+        repo_root, repo_err = _ensure_repo_ready()
+        if repo_err:
+            return repo_err
         exact = bool(issue_number)
         issues, err = _open_roadmap_issues(
             conn, skip_claimed=not exact
@@ -1251,7 +1385,12 @@ def apply_curator_report(report_path: str = "") -> str:
         report_text = _read_curator_report(path)
         if not report_text:
             return f"ERR report_empty={path.name}"
+        # Curator apply is memory-only — no git tree required. Use the resolved
+        # repo root when it exists, else fall back to the DB dir so the child's
+        # cwd is always valid even before a managed checkout is cloned.
         repo_root = _repo_root()
+        if not repo_root.exists():
+            repo_root = DB_PATH.parent
         prompt = build_curator_report_apply_prompt(path, report_text,
                                                    repo_root)
 
@@ -1308,9 +1447,9 @@ def apply_evolve(evolve_id: int) -> str:
             return "applier_running n=1 (single-flight lock)"
 
         conn = get_db()
-        repo_root = _repo_root()
-        if not _is_git_repo(repo_root):
-            return _repo_not_git_error(repo_root)
+        repo_root, repo_err = _ensure_repo_ready()
+        if repo_err:
+            return repo_err
         if not _row_exists(conn, evolve_id):
             return f"ERR evolve_not_found={evolve_id}"
         row = _get_promoted_unapplied(conn, evolve_id)
@@ -1421,7 +1560,11 @@ def run_evolve_apply_pass(force: bool = False) -> str:
     if not force and not _pass_due(conn, now_t):
         return "not_due"
 
-    issues, issue_err = _open_roadmap_issues(conn)
+    # Provision the checkout before the gh-dependent roadmap peek so the managed
+    # clone exists on PyPI installs. A repo error is non-fatal here: the Curator
+    # fallback below is memory-only and needs no checkout.
+    _, repo_err = _ensure_repo_ready()
+    issues, issue_err = ([], repo_err) if repo_err else _open_roadmap_issues(conn)
     if issues:
         out = apply_roadmap_issue()
         if out.startswith("spawned roadmap_issue=") or out.startswith(

--- a/threadkeeper/evolve_applier.py
+++ b/threadkeeper/evolve_applier.py
@@ -39,6 +39,7 @@ from .config import (
     CURATOR_REPORTS_DIR,
     DB_PATH,
     EVOLVE_APPLY_INTERVAL_S,
+    EVOLVE_REPO_ROOT,
     ROADMAP_CLAIM_RACE_WINDOW_S,
 )
 from .db import get_db
@@ -283,8 +284,40 @@ or:
 
 
 def _repo_root() -> Path:
-    """Repository root = the package's parent dir (threadkeeper/.. )."""
+    """Git checkout the evolve loops operate on.
+
+    Prefers THREADKEEPER_EVOLVE_REPO_ROOT (config EVOLVE_REPO_ROOT) when set —
+    required when thread-keeper is installed from PyPI into site-packages, where
+    the package's parent dir is not a git tree. Falls back to the package parent
+    (threadkeeper/..), which IS the repo root for the editable-from-checkout
+    install that install.sh performs."""
+    override = (EVOLVE_REPO_ROOT or "").strip()
+    if override:
+        return Path(override).expanduser()
     return Path(__file__).resolve().parent.parent
+
+
+def _is_git_repo(path: Path) -> bool:
+    """True if `path` is inside a git work tree. Best-effort: any probe failure
+    (git missing, path absent, not a repo) yields False rather than raising."""
+    try:
+        proc = subprocess.run(
+            ["git", "-C", str(path), "rev-parse", "--is-inside-work-tree"],
+            text=True, capture_output=True, timeout=5, check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return False
+    return proc.returncode == 0 and (proc.stdout or "").strip() == "true"
+
+
+def _repo_not_git_error(root: Path) -> str:
+    """Standard error for the code/PR paths when the resolved repo root is not a
+    git checkout — typical of a PyPI/site-packages install with no checkout."""
+    return (
+        f"ERR repo_root_not_git={root} (thread-keeper is installed outside a "
+        "git checkout; set THREADKEEPER_EVOLVE_REPO_ROOT to your thread-keeper "
+        "clone so the evolve applier can branch, test, and open PRs)"
+    )
 
 
 def _slug(text: str, maxlen: int = 32) -> str:
@@ -1141,6 +1174,9 @@ def apply_roadmap_issue(issue_number: int = 0) -> str:
             return "applier_running n=1 (single-flight lock)"
 
         conn = get_db()
+        repo_root = _repo_root()
+        if not _is_git_repo(repo_root):
+            return _repo_not_git_error(repo_root)
         exact = bool(issue_number)
         issues, err = _open_roadmap_issues(
             conn, skip_claimed=not exact
@@ -1166,7 +1202,6 @@ def apply_roadmap_issue(issue_number: int = 0) -> str:
         if running:
             return f"applier_running n={len(running)} (single-flight)"
 
-        repo_root = _repo_root()
         failures: list[str] = []
         for issue in candidates:
             started, status = _start_roadmap_issue_child(issue, repo_root)
@@ -1273,6 +1308,9 @@ def apply_evolve(evolve_id: int) -> str:
             return "applier_running n=1 (single-flight lock)"
 
         conn = get_db()
+        repo_root = _repo_root()
+        if not _is_git_repo(repo_root):
+            return _repo_not_git_error(repo_root)
         if not _row_exists(conn, evolve_id):
             return f"ERR evolve_not_found={evolve_id}"
         row = _get_promoted_unapplied(conn, evolve_id)
@@ -1290,7 +1328,6 @@ def apply_evolve(evolve_id: int) -> str:
         if running:
             return f"applier_running n={len(running)} (single-flight)"
 
-        repo_root = _repo_root()
         prompt = build_apply_prompt(
             row["id"], row["suggestion"], row["rationale"], repo_root
         )

--- a/threadkeeper/evolve_daemon.py
+++ b/threadkeeper/evolve_daemon.py
@@ -22,6 +22,7 @@ import time
 
 from .config import EVOLVE_REVIEW_INTERVAL_S, EVOLVE_REVIEW_MIN
 from .db import get_db
+from .evolve_applier import _is_git_repo, _repo_root
 from .helpers import daemon_sleep
 from . import identity
 
@@ -202,6 +203,16 @@ def run_evolve_pass(force: bool = False) -> str:
         _record_evolve_pass(conn, now_t, out)
         return out
 
+    repo_root = _repo_root()
+    if not _is_git_repo(repo_root):
+        out = (
+            f"ERR repo_root_not_git={repo_root} (thread-keeper is installed "
+            "outside a git checkout; set THREADKEEPER_EVOLVE_REPO_ROOT to your "
+            "thread-keeper clone so the reviewer can audit the repo)"
+        )
+        _record_evolve_pass(conn, now_t, out)
+        return out
+
     queue = (
         "\n".join(
             f"#{r['id']}: {r['suggestion']}"
@@ -216,6 +227,7 @@ def run_evolve_pass(force: bool = False) -> str:
     try:
         result = spawn(
             prompt=prompt,
+            cwd=str(repo_root),
             visible=False,
             capture_output=True,
             permission_mode="bypassPermissions",

--- a/threadkeeper/evolve_daemon.py
+++ b/threadkeeper/evolve_daemon.py
@@ -22,7 +22,7 @@ import time
 
 from .config import EVOLVE_REVIEW_INTERVAL_S, EVOLVE_REVIEW_MIN
 from .db import get_db
-from .evolve_applier import _is_git_repo, _repo_root
+from .evolve_applier import _ensure_repo_ready
 from .helpers import daemon_sleep
 from . import identity
 
@@ -203,15 +203,10 @@ def run_evolve_pass(force: bool = False) -> str:
         _record_evolve_pass(conn, now_t, out)
         return out
 
-    repo_root = _repo_root()
-    if not _is_git_repo(repo_root):
-        out = (
-            f"ERR repo_root_not_git={repo_root} (thread-keeper is installed "
-            "outside a git checkout; set THREADKEEPER_EVOLVE_REPO_ROOT to your "
-            "thread-keeper clone so the reviewer can audit the repo)"
-        )
-        _record_evolve_pass(conn, now_t, out)
-        return out
+    repo_root, repo_err = _ensure_repo_ready()
+    if repo_err:
+        _record_evolve_pass(conn, now_t, repo_err)
+        return repo_err
 
     queue = (
         "\n".join(


### PR DESCRIPTION
## Problem

The evolve **reviewer** and evolve **applier** branch, run the test suite, and open PRs against a git checkout. They previously assumed the repo root was the package's parent dir (`threadkeeper/..`), which only holds for the editable-from-checkout `install.sh`. When thread-keeper is installed from PyPI into `site-packages`, that parent is **not a git tree**, so both loops failed with cryptic `gh`/`git` errors and effectively no-op'd. The reviewer was additionally spawned with no `cwd`, so it ran in the host CLI's working directory rather than the repo.

## What changed

A new `_ensure_repo_ready()` resolves the checkout and makes it usable, so the loops **work by default with no configuration**:

1. explicit `THREADKEEPER_EVOLVE_REPO_ROOT` if set;
2. the package's parent dir when it carries a `.git` entry (editable `install.sh`);
3. otherwise a **managed checkout** under the DB dir (`~/.threadkeeper/evolve-repo`), which is **auto-cloned on first use** (git clone + a per-checkout `.venv` with the `[semantic,dev]` extras) so the children can branch, run the suite, and open PRs.

The reviewer child now runs with `cwd` pinned to that root.

### Flag only disables (per request)

- `THREADKEEPER_EVOLVE_AUTO_CLONE=0` turns off auto-provisioning; a non-checkout install then reports a clear `ERR evolve_repo_unavailable=<path>` instead of failing obscurely.
- `THREADKEEPER_EVOLVE_REPO_URL` / `THREADKEEPER_EVOLVE_REPO_BRANCH` configure the clone source/branch (default: upstream repo / `main`).
- An explicit override that is not itself a checkout is never auto-cloned into and reports `ERR repo_root_not_git`.
- Curator report apply is memory-only and runs without a checkout regardless.

Provisioning is serialized by `evolve-repo-provision.lock` and idempotent (re-checks under the lock so a concurrent winner's clone is reused).

## Files

- `threadkeeper/config.py` — new settings `evolve_repo_root`, `evolve_auto_clone`, `evolve_repo_url`, `evolve_repo_branch` + derived constants.
- `threadkeeper/evolve_applier.py` — `_resolve_repo_root` / `_ensure_repo_ready` / `_provision_managed_repo` / venv provisioning; entry points gated on a ready checkout.
- `threadkeeper/evolve_daemon.py` — reviewer uses `_ensure_repo_ready` and runs with `cwd` at the repo root.
- Docs: README env table, `docs/ARCHITECTURE.md`, `.env.example`, `CHANGELOG.md`.
- Tests: `tests/test_evolve_applier.py`, `tests/test_evolve_daemon.py`.

## Testing

All directly-affected test files pass green: `test_evolve_applier`, `test_evolve_daemon`, `test_evolve_apply_2/3`, `test_config_settings` (the `Settings`/`_derive_constants`/hot-reload path touched by the config change), `test_curator`, `test_candidate_reviewer`. The pre-existing `test_vec_search` / `test_delegated_search` failures are environmental (no working `sqlite-vec` / fastembed model in the sandbox) and unrelated to this change, which does not touch embeddings.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HVDWWKCjDCa3gJsrijM1KC)_