### PR TITLE
feat: shadow_review production-validation telemetry (#6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ version bumps follow semver per the policy in
 
 ### Added
 
+- **Shadow-review production telemetry in `shadow_review_status()` (#6).** The
+  status tool now appends a production-validation rollup for the 24h and 7d
+  windows: how often the daemon fired, the outcome mix (`no_window` /
+  `too_short` / `spawned` / `deferred` / `error`), the **MATERIALIZED-vs-SKIP
+  hit rate** of the evaluator children it spawned (read from each child's
+  captured log tail), the durable skill writes attributable to
+  `write_origin='shadow_review'`, and the **total Claude-spawn time** spent — so
+  "is this loop earning its Opus minutes or just emitting SKIPs?" is a number
+  instead of a guess. A new pure aggregator `shadow_telemetry()` computes it
+  read-only from the trail each pass already leaves (events / tasks / child
+  logs / skill_usage); `shadow_review_status(snapshot_path=…)` additionally
+  dumps a markdown report for human review. Child logs that have aged out of
+  the ephemeral task-log dir (or are skipped past the per-call read cap) are
+  counted as `unknown` so the hit-rate denominator stays honest. The token/$
+  half of spawn cost is tracked separately as #25.
+
 - **Evolve loops work by default on a PyPI / site-packages install (auto-clone).**
   The evolve reviewer and evolve applier branch, run the test suite, and open
   PRs against a git checkout. They previously assumed the repo root was the

--- a/README.md
+++ b/README.md
@@ -667,6 +667,17 @@ them with `dry_run=False` to apply:
   a loop firing constantly while its outcomes stay flat, or a queue
   backing up. Complements the per-loop `*_status` tools (`mp_health`,
   `spawn_budget_status`, `shadow_review_status`).
+- **`shadow_review_status(snapshot_path="")`** — config, recent passes, and a
+  per-loop **production-validation rollup** for the 24h and 7d windows: how
+  often the daemon fired, the outcome mix (`no_window` / `too_short` /
+  `spawned` / `deferred` / `error`), the **MATERIALIZED-vs-SKIP hit rate** of
+  the evaluator children it spawned, the durable skill writes attributable to
+  `write_origin='shadow_review'`, and the **total Claude-spawn time** spent —
+  so you can tell whether the loop earns its Opus minutes or just emits SKIPs.
+  Pass `snapshot_path` to also dump a markdown report for human review. The
+  verdict is read from each child's captured log tail; logs aged out of the
+  ephemeral task-log dir (or skipped past the read cap) are counted as
+  `unknown` so the hit-rate denominator stays honest.
 - **`agent_status(json_output=False, refresh=True)`** — autonomous learning
   loop status, shaped for UI clients. Shows every loop's enabled/running/ready
   state, last pass, backlog, and active spawned-child RSS; running child agents

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -400,7 +400,16 @@ or oversized writes are rejected so the child patches existing memory instead
 of growing the flat lessons list.
 
 Manual hook: `shadow_review_run(force=True)`, observability:
-`shadow_review_status()`.
+`shadow_review_status()`. Beyond the last few passes, the status tool carries a
+production-validation rollup (24h / 7d): fire count, outcome mix
+(no_window / too_short / spawned / deferred / error), the MATERIALIZED-vs-SKIP
+hit rate (read from each evaluator child's captured log tail), shadow-origin
+skill writes (`skill_usage.created_by_origin='shadow_review'`), and total
+Claude-spawn time spent — read-only, computed from the trail every pass already
+leaves (events / tasks / child logs / skill_usage). `shadow_telemetry()` is the
+pure aggregator; `snapshot_path` dumps the same numbers as a markdown table for
+human review. Children whose ephemeral `/tmp` log has aged out (or are skipped
+past the per-call read cap) count as `unknown`, keeping the hit-rate honest.
 
 ## Skills system
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -177,6 +177,17 @@ item below (shadow fires ≫ skills materialized). Possible follow-up:
 periodic dump-to-file for historical trend lines (currently a
 point-in-time snapshot). Scope of follow-up: S.
 
+**Shadow-review production telemetry.** ✅ DONE (#6). `shadow_review_status()`
+now carries a per-loop production-validation rollup for the 24h / 7d windows:
+fire count, outcome mix (no_window / too_short / spawned / deferred / error),
+the MATERIALIZED-vs-SKIP hit rate of spawned evaluator children (read from each
+child's captured log tail), durable skill writes attributable to
+`write_origin='shadow_review'`, and total Claude-spawn time spent — so "is this
+loop earning its Opus minutes or just emitting SKIPs?" is now a number, not a
+guess. Pure aggregator `shadow_telemetry()`; `snapshot_path` dumps a markdown
+table for human review; ephemeral/aged-out child logs count as `unknown` so the
+hit-rate denominator stays honest. The token/$ half of spawn cost remains #25.
+
 **Shadow-review proof in production.** ✅ ANSWERED (~16d of live data,
 read via `mp_dashboard` + an evidence dive). Verdict: **complementary,
 not duplicate — but it was over-firing.** Numbers: 1423 passes, 773

--- a/tests/test_shadow_review.py
+++ b/tests/test_shadow_review.py
@@ -424,3 +424,167 @@ def test_mcp_shadow_review_status_reports_passes(tmp_path, monkeypatch):
     out = tool.fn()
     assert "interval_s=0" in out
     assert "no_window" in out
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Production-validation telemetry (issue #6)
+# ──────────────────────────────────────────────────────────────────────
+
+def _seed_pass(conn, summary, ts, session_id="sess-x"):
+    conn.execute(
+        "INSERT INTO events (session_id, kind, target, summary, created_at) "
+        "VALUES (?, 'shadow_review_pass', ?, ?, ?)",
+        (session_id, str(ts), summary, ts),
+    )
+
+
+def _seed_shadow_task(conn, prefix, tid, started, ended, prompt=None):
+    conn.execute(
+        "INSERT INTO tasks (id, pid, parent_cid, spawned_cid, cwd, prompt, "
+        "started_at, ended_at, rss_kb, rss_updated_at) "
+        "VALUES (?,?,?,?,?,?,?,?,?,?)",
+        (tid, 0, "p", "c", "/tmp",
+         prompt or (prefix + " — evaluate this window"),
+         started, ended, 0, started),
+    )
+
+
+def _write_log(log_dir, tid, verdict_line):
+    log_dir.mkdir(parents=True, exist_ok=True)
+    (log_dir / f"{tid}.log").write_text(
+        "some preamble chatter\n" + verdict_line + "\n", encoding="utf-8"
+    )
+
+
+def test_classify_pass_buckets():
+    from threadkeeper.shadow_review import _classify_pass
+    assert _classify_pass("no_window") == "no_window"
+    assert _classify_pass("too_short") == "too_short"
+    assert _classify_pass("ok task=tk_a pid=1 mode=headless") == "spawned"
+    assert _classify_pass("shadow_child_running n=2") == "deferred"
+    assert _classify_pass("ERR budget_exceeded: ...") == "error"
+    assert _classify_pass("spawn_error: boom") == "error"
+    assert _classify_pass("") == "other"
+    assert _classify_pass(None) == "other"
+
+
+def test_read_verdict(tmp_path):
+    from threadkeeper.shadow_review import _read_verdict
+    mat = tmp_path / "m.log"
+    mat.write_text("blah\nMATERIALIZED: some-skill\n", encoding="utf-8")
+    skip = tmp_path / "s.log"
+    skip.write_text("thinking...\nSKIP: nothing class-level\n", encoding="utf-8")
+    assert _read_verdict(mat) == "materialized"
+    assert _read_verdict(skip) == "skip"
+    # last verdict line wins
+    multi = tmp_path / "x.log"
+    multi.write_text("SKIP: early\nMATERIALIZED: final\n", encoding="utf-8")
+    assert _read_verdict(multi) == "materialized"
+    # missing file → unknown
+    assert _read_verdict(tmp_path / "nope.log") == "unknown"
+
+
+def test_shadow_telemetry_aggregates(tmp_path, monkeypatch):
+    pkg = _bootstrap(tmp_path, monkeypatch)
+    conn = pkg["db"].get_db()
+    import threadkeeper.config as cfg
+    log_dir = cfg.TASK_LOG_DIR
+    prefix = pkg["shadow_review"]._SHADOW_TASK_PROMPT_PREFIX
+    now = int(time.time())
+
+    # Pass events: 5 within 24h (one of each class), 1 older (7d only).
+    _seed_pass(conn, "no_window", now - 100)
+    _seed_pass(conn, "too_short", now - 200)
+    _seed_pass(conn, "ok task=tk_a pid=1 mode=headless", now - 300)
+    _seed_pass(conn, "shadow_child_running n=1", now - 400)
+    _seed_pass(conn, "ERR budget_exceeded: cap", now - 500)
+    _seed_pass(conn, "no_window", now - 2 * 86400)
+
+    # Shadow tasks: 3 within 24h, 1 older (7d only).
+    _seed_shadow_task(conn, prefix, "tk_a", now - 300, now - 300 + 90)
+    _seed_shadow_task(conn, prefix, "tk_b", now - 310, now - 310 + 30)
+    _seed_shadow_task(conn, prefix, "tk_c", now - 320, now - 320 + 10)
+    _seed_shadow_task(conn, prefix, "tk_old", now - 2 * 86400,
+                      now - 2 * 86400 + 60)
+    # A non-shadow task must be ignored entirely.
+    _seed_shadow_task(conn, "You are a PROBE RUNNER", "tk_probe",
+                      now - 50, now - 40,
+                      prompt="You are a PROBE RUNNER doing other work")
+
+    _write_log(log_dir, "tk_a", "MATERIALIZED: foo-skill")
+    _write_log(log_dir, "tk_b", "SKIP: one-off")
+    # tk_c: no log file → unknown
+    _write_log(log_dir, "tk_old", "MATERIALIZED: old-skill")
+
+    # Skill writes attributable to shadow_review (one in-window, one not).
+    conn.execute(
+        "INSERT INTO skill_usage (name, created_at, created_by_origin) "
+        "VALUES ('shadow-skill', ?, 'shadow_review')", (now - 100,))
+    conn.execute(
+        "INSERT INTO skill_usage (name, created_at, created_by_origin) "
+        "VALUES ('manual-skill', ?, 'foreground')", (now - 50,))
+    conn.commit()
+
+    tel = pkg["shadow_review"].shadow_telemetry(conn, now=now, log_dir=log_dir)
+    assert tel["logs_unread"] == 0
+    w24, w7 = tel["windows"]
+    assert (w24["label"], w7["label"]) == ("24h", "7d")
+
+    # 24h window
+    assert w24["ticks"] == 5
+    assert w24["outcomes"] == {
+        "no_window": 1, "too_short": 1, "spawned": 1,
+        "deferred": 1, "error": 1, "other": 0,
+    }
+    assert w24["children"] == 3
+    assert w24["verdicts"] == {"materialized": 1, "skip": 1, "unknown": 1}
+    assert w24["hit_rate"] == 0.5
+    assert w24["skill_writes"] == 1
+    assert w24["ended"] == 3
+    assert w24["spawn_seconds"] == 90 + 30 + 10
+
+    # 7d window picks up the older pass + the older materialized child
+    assert w7["ticks"] == 6
+    assert w7["children"] == 4
+    assert w7["verdicts"] == {"materialized": 2, "skip": 1, "unknown": 1}
+    assert abs(w7["hit_rate"] - (2 / 3)) < 1e-9
+
+
+def test_shadow_telemetry_log_cap_reports_unread(tmp_path, monkeypatch):
+    pkg = _bootstrap(tmp_path, monkeypatch)
+    conn = pkg["db"].get_db()
+    import threadkeeper.config as cfg
+    prefix = pkg["shadow_review"]._SHADOW_TASK_PROMPT_PREFIX
+    now = int(time.time())
+    for i in range(5):
+        _seed_shadow_task(conn, prefix, f"tk_{i}", now - 10 - i, now - 5 - i)
+    conn.commit()
+    tel = pkg["shadow_review"].shadow_telemetry(
+        conn, now=now, log_dir=cfg.TASK_LOG_DIR, log_cap=2)
+    assert tel["logs_unread"] == 3
+
+
+def test_mcp_shadow_review_status_includes_telemetry_and_snapshot(
+    tmp_path, monkeypatch,
+):
+    pkg = _bootstrap(tmp_path, monkeypatch)
+    conn = pkg["db"].get_db()
+    import threadkeeper.config as cfg
+    prefix = pkg["shadow_review"]._SHADOW_TASK_PROMPT_PREFIX
+    now = int(time.time())
+    _seed_pass(conn, "ok task=tk_z pid=1", now - 60)
+    _seed_shadow_task(conn, prefix, "tk_z", now - 60, now - 30)
+    _write_log(cfg.TASK_LOG_DIR, "tk_z", "MATERIALIZED: z-skill")
+    conn.commit()
+
+    from threadkeeper._mcp import mcp
+    tool = mcp._tool_manager._tools["shadow_review_status"]
+    snap = tmp_path / "snap" / "shadow.md"
+    out = tool.fn(snapshot_path=str(snap))
+    assert "telemetry (production validation" in out
+    assert "hit_rate=" in out
+    assert "24h" in out and "7d" in out
+    assert snap.exists()
+    md = snap.read_text(encoding="utf-8")
+    assert "# Shadow-review telemetry" in md
+    assert "| window |" in md

--- a/threadkeeper/shadow_review.py
+++ b/threadkeeper/shadow_review.py
@@ -28,6 +28,7 @@ import os
 import sqlite3
 import threading
 import time
+from pathlib import Path
 from typing import Optional
 
 from .config import (
@@ -333,6 +334,189 @@ def _collect_window(conn: sqlite3.Connection,
         sid = (r["session_id"] or "?")[-6:]
         lines.append(f"[{r['role']} @{sid}]\n{body}\n")
     return ("\n".join(lines), high_water, char_count)
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Production-validation telemetry (issue #6)
+#
+# shadow_review_status() shows the last few passes; in production the real
+# question is "is this loop doing useful work, or burning Opus minutes for
+# SKIPs?". shadow_telemetry() answers it by aggregating the trail every
+# pass already leaves behind — no new bookkeeping, no spawn, no mutate:
+#   events.kind='shadow_review_pass' → tick count + outcome mix
+#   tasks (prompt LIKE shadow prefix) → children spawned + spawn-time cost
+#   each child's captured log tail    → MATERIALIZED vs SKIP verdict
+#   skill_usage.created_by_origin     → durable skill writes it caused
+# ──────────────────────────────────────────────────────────────────────
+
+# The shadow evaluator child's prompt always opens with this line, so it is
+# the LIKE-prefix that singles out its `tasks` rows. Reuse the canonical
+# constant so the prefix can't drift from what we actually spawn.
+_SHADOW_TASK_PROMPT_PREFIX = _INTERNAL_PROMPT_PREFIXES[0]
+
+# Issue #6 asks for 24h / 7d windows.
+SHADOW_TELEMETRY_WINDOWS: tuple[tuple[str, int], ...] = (
+    ("24h", 86400),
+    ("7d", 7 * 86400),
+)
+
+# Cap on how many child logs we crack open per call to read a verdict,
+# newest first. A 7d window can hold a few hundred children and the tail is
+# all that matters; logs skipped past the cap are reported as `logs_unread`
+# so the hit-rate denominator stays honest (no silent truncation).
+_VERDICT_LOG_CAP = 400
+
+
+def _classify_pass(summary: Optional[str]) -> str:
+    """Bucket a `shadow_review_pass` summary into one outcome label.
+
+    Mirrors the status strings run_shadow_pass() records:
+      no_window / too_short / spawned ('ok task=…') /
+      deferred ('shadow_child_running') / error ('ERR…'/'spawn_error…').
+    """
+    s = (summary or "").strip()
+    if s.startswith("no_window"):
+        return "no_window"
+    if s.startswith("too_short"):
+        return "too_short"
+    if s.startswith("ok task="):
+        return "spawned"
+    if s.startswith("shadow_child_running"):
+        return "deferred"
+    if s.startswith("ERR") or s.startswith("spawn_error"):
+        return "error"
+    return "other"
+
+
+def _read_verdict(log_path: Path) -> str:
+    """Return a finished shadow child's self-reported verdict from its
+    captured log: 'materialized', 'skip', or 'unknown'.
+
+    The child's contract is a final line `MATERIALIZED: <slug>` or
+    `SKIP: <reason>`; we take the LAST such line since tool output can
+    follow earlier prose. Missing/unreadable logs → 'unknown' (the task
+    log dir defaults to ephemeral /tmp, so older children legitimately
+    have no log left to read)."""
+    try:
+        text = log_path.read_text(encoding="utf-8", errors="replace")
+    except (OSError, ValueError):
+        return "unknown"
+    verdict = "unknown"
+    for line in text.splitlines():
+        st = line.lstrip()
+        if st.startswith("MATERIALIZED:"):
+            verdict = "materialized"
+        elif st.startswith("SKIP:"):
+            verdict = "skip"
+    return verdict
+
+
+def shadow_telemetry(conn: sqlite3.Connection,
+                     now: Optional[int] = None,
+                     windows: tuple[tuple[str, int], ...] = SHADOW_TELEMETRY_WINDOWS,
+                     log_dir: Optional[Path] = None,
+                     log_cap: int = _VERDICT_LOG_CAP) -> dict:
+    """Aggregate shadow-review production signal over each (label, seconds)
+    window. Read-only; never spawns or mutates. Structured so the MCP tool
+    can render it and tests can assert on it directly.
+
+    Per window:
+      ticks         — shadow_review_pass events (how often the daemon fired)
+      outcomes      — {no_window,too_short,spawned,deferred,error,other}
+      children      — shadow evaluator children actually spawned
+      verdicts      — {materialized,skip,unknown} from child log tails
+      hit_rate      — materialized / (materialized+skip), or None if 0 decided
+      skill_writes  — skill_usage rows with origin 'shadow_review'
+      spawn_seconds — total wall-clock spent in ENDED children (the cost)
+      avg_spawn_s   — mean spawn-time over ended children, or None
+
+    Top-level `logs_unread` counts children whose verdict log we skipped
+    past `log_cap`."""
+    if now is None:
+        now = int(time.time())
+    if log_dir is None:
+        from .config import TASK_LOG_DIR
+        log_dir = TASK_LOG_DIR
+    log_dir = Path(log_dir)
+    win = list(windows)
+    widest = max((s for _, s in win), default=0)
+    cut_widest = now - widest
+
+    try:
+        ev_rows = conn.execute(
+            "SELECT created_at, summary FROM events "
+            "WHERE kind='shadow_review_pass' AND created_at>=?",
+            (cut_widest,),
+        ).fetchall()
+    except sqlite3.OperationalError:
+        ev_rows = []
+
+    try:
+        task_rows = conn.execute(
+            "SELECT id, started_at, ended_at FROM tasks "
+            "WHERE prompt LIKE ? AND started_at>=? "
+            "ORDER BY started_at DESC",
+            (_SHADOW_TASK_PROMPT_PREFIX + "%", cut_widest),
+        ).fetchall()
+    except sqlite3.OperationalError:
+        task_rows = []
+
+    # Read verdicts newest-first, bounded by the cap.
+    verdict_by_task: dict[str, str] = {}
+    logs_unread = 0
+    for i, t in enumerate(task_rows):
+        if i >= log_cap:
+            logs_unread += 1
+            continue
+        verdict_by_task[t["id"]] = _read_verdict(log_dir / f"{t['id']}.log")
+
+    out_windows: list[dict] = []
+    for label, secs in win:
+        cut = now - secs
+        outcomes = {k: 0 for k in
+                    ("no_window", "too_short", "spawned",
+                     "deferred", "error", "other")}
+        ticks = 0
+        for r in ev_rows:
+            if r["created_at"] < cut:
+                continue
+            ticks += 1
+            outcomes[_classify_pass(r["summary"])] += 1
+
+        verdicts = {"materialized": 0, "skip": 0, "unknown": 0}
+        children = ended = spawn_seconds = 0
+        for t in task_rows:
+            if t["started_at"] < cut:
+                continue
+            children += 1
+            if t["ended_at"] is not None:
+                ended += 1
+                spawn_seconds += max(
+                    0, int(t["ended_at"]) - int(t["started_at"]))
+            verdicts[verdict_by_task.get(t["id"], "unknown")] += 1
+        decided = verdicts["materialized"] + verdicts["skip"]
+        hit_rate = (verdicts["materialized"] / decided) if decided else None
+
+        try:
+            skill_writes = conn.execute(
+                "SELECT COUNT(*) FROM skill_usage "
+                "WHERE created_by_origin='shadow_review' AND created_at>=?",
+                (cut,),
+            ).fetchone()[0]
+        except sqlite3.OperationalError:
+            skill_writes = 0
+
+        out_windows.append({
+            "label": label, "seconds": secs,
+            "ticks": ticks, "outcomes": outcomes,
+            "children": children, "verdicts": verdicts,
+            "hit_rate": hit_rate, "skill_writes": int(skill_writes or 0),
+            "ended": ended, "spawn_seconds": spawn_seconds,
+            "avg_spawn_s": (spawn_seconds / ended) if ended else None,
+        })
+
+    return {"windows": out_windows, "logs_unread": logs_unread,
+            "log_dir": str(log_dir)}
 
 
 def run_shadow_pass(force: bool = False) -> str:

--- a/threadkeeper/tools/shadow_review.py
+++ b/threadkeeper/tools/shadow_review.py
@@ -6,17 +6,22 @@
     that WOULD be spawned (no actual spawn) — useful for inspecting
     candidate windows or building tests.
 
-  shadow_review_status()
-    Diagnostic snapshot: env config, cursor position, last 5 passes.
+  shadow_review_status(snapshot_path="")
+    Diagnostic snapshot: env config, cursor position, last 5 passes, and
+    aggregated production telemetry (24h / 7d tick counts, outcome mix,
+    MATERIALIZED-vs-SKIP hit rate, shadow-origin skill writes, spawn-time
+    cost). Pass `snapshot_path` to also dump a markdown report for humans.
 """
 
 from __future__ import annotations
 
 import time
+from pathlib import Path
 from typing import Optional
 
 from .._mcp import mcp
 from ..db import get_db
+from ..helpers import fmt_age
 from ..identity import _ensure_session
 from ..shadow_review import (
     SHADOW_REVIEW_PROMPT,
@@ -24,6 +29,7 @@ from ..shadow_review import (
     _last_shadow_ts,
     _record_shadow_pass,
     run_shadow_pass,
+    shadow_telemetry,
 )
 from ..config import (
     SHADOW_REVIEW_INTERVAL_S,
@@ -66,13 +72,90 @@ def shadow_review_run(force: bool = False, dry_run: bool = False) -> str:
     return run_shadow_pass(force=force)
 
 
-@mcp.tool()
-def shadow_review_status() -> str:
-    """Show shadow-review configuration + last 5 passes.
+def _fmt_hit_rate(hit_rate: Optional[float]) -> str:
+    return f"{hit_rate:.0%}" if hit_rate is not None else "n/a"
 
-    Snapshot for sanity-checking that the daemon is alive and
-    advancing its cursor. Counts how many spawned passes vs how many
-    were skipped for being too short or empty."""
+
+def _telemetry_lines(tel: dict) -> list[str]:
+    """Render shadow_telemetry() output as compact human-readable lines."""
+    lines = ["", "telemetry (production validation — spawn cost vs hit rate)"]
+    for w in tel["windows"]:
+        oc = w["outcomes"]
+        vd = w["verdicts"]
+        avg = fmt_age(int(w["avg_spawn_s"])) if w["avg_spawn_s"] else "-"
+        lines.append(
+            f"  {w['label']:<4} ticks={w['ticks']}  "
+            f"no_window={oc['no_window']} too_short={oc['too_short']} "
+            f"spawned={oc['spawned']} deferred={oc['deferred']} "
+            f"error={oc['error']}"
+        )
+        lines.append(
+            f"       children={w['children']}  "
+            f"materialized={vd['materialized']} skip={vd['skip']} "
+            f"unknown={vd['unknown']}  hit_rate={_fmt_hit_rate(w['hit_rate'])}"
+        )
+        lines.append(
+            f"       skill_writes(shadow)={w['skill_writes']}  "
+            f"spawn_time={fmt_age(w['spawn_seconds'])} "
+            f"(avg {avg}, ended {w['ended']})"
+        )
+    if tel.get("logs_unread"):
+        lines.append(
+            f"  note: {tel['logs_unread']} child verdict log(s) skipped past "
+            f"the read cap (counted as unknown)"
+        )
+    return lines
+
+
+def _telemetry_markdown(tel: dict, now: int) -> str:
+    """Side-channel markdown snapshot of the telemetry for human review."""
+    when = time.strftime("%Y-%m-%dT%H:%MZ", time.gmtime(now))
+    out = [
+        "# Shadow-review telemetry",
+        "",
+        f"_snapshot {when} — read-only; reads only the trail each pass "
+        f"already leaves (events, tasks, child logs, skill_usage)._",
+        "",
+        f"config: interval_s={SHADOW_REVIEW_INTERVAL_S:.0f} "
+        f"window_s={SHADOW_REVIEW_WINDOW_S} min_chars={SHADOW_REVIEW_MIN_CHARS}",
+        "",
+        "| window | ticks | no_window | too_short | spawned | deferred | "
+        "error | children | materialized | skip | unknown | hit_rate | "
+        "skill_writes | spawn_time | avg |",
+        "|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|",
+    ]
+    for w in tel["windows"]:
+        oc, vd = w["outcomes"], w["verdicts"]
+        avg = fmt_age(int(w["avg_spawn_s"])) if w["avg_spawn_s"] else "-"
+        out.append(
+            f"| {w['label']} | {w['ticks']} | {oc['no_window']} | "
+            f"{oc['too_short']} | {oc['spawned']} | {oc['deferred']} | "
+            f"{oc['error']} | {w['children']} | {vd['materialized']} | "
+            f"{vd['skip']} | {vd['unknown']} | {_fmt_hit_rate(w['hit_rate'])} "
+            f"| {w['skill_writes']} | {fmt_age(w['spawn_seconds'])} | {avg} |"
+        )
+    if tel.get("logs_unread"):
+        out += ["", f"> {tel['logs_unread']} child verdict log(s) skipped "
+                f"past the read cap (counted as unknown)."]
+    out += ["", f"task log dir: `{tel['log_dir']}`", ""]
+    return "\n".join(out)
+
+
+@mcp.tool()
+def shadow_review_status(snapshot_path: str = "") -> str:
+    """Show shadow-review config, recent passes, and production telemetry.
+
+    Snapshot for sanity-checking that the daemon is alive and advancing
+    its cursor, PLUS the production-validation rollup (issue #6): for the
+    24h and 7d windows it aggregates how often the daemon fired, the
+    outcome mix (no_window / too_short / spawned / deferred / error), the
+    MATERIALIZED-vs-SKIP hit rate of spawned evaluator children, durable
+    skill writes attributable to shadow_review, and the total Claude-spawn
+    time spent — so you can tell whether the loop earns its Opus minutes or
+    just emits SKIPs.
+
+    `snapshot_path`: when set, also writes a markdown report to that path
+    for human review (the side-channel snapshot)."""
     conn = get_db()
     _ensure_session(conn)
     floor = _last_shadow_ts(conn)
@@ -103,4 +186,16 @@ def shadow_review_status() -> str:
             age = now - int(ts) if ts else 0
             snip = (r["summary"] or "")[:120]
             lines.append(f"  {age}s_ago  {snip}")
+
+    tel = shadow_telemetry(conn, now=now)
+    lines += _telemetry_lines(tel)
+
+    if snapshot_path:
+        try:
+            p = Path(snapshot_path).expanduser()
+            p.parent.mkdir(parents=True, exist_ok=True)
+            p.write_text(_telemetry_markdown(tel, now), encoding="utf-8")
+            lines.append(f"\nwrote markdown snapshot to {p}")
+        except OSError as e:
+            lines.append(f"\nsnapshot write failed: {e}")
     return "\n".join(lines)


### PR DESCRIPTION
## What

Extends `shadow_review_status()` with a per-loop **production-validation rollup** for the 24h and 7d windows, so the recurring question — *"is the shadow-review loop doing useful work in the wild, or burning Opus minutes for SKIPs?"* — is now a number instead of a guess.

Per window:
- **ticks** — how often the daemon fired
- **outcome mix** — `no_window` / `too_short` / `spawned` / `deferred` / `error`, classified from the `shadow_review_pass` event summary
- **MATERIALIZED-vs-SKIP hit rate** of the evaluator children it spawned, read from each child's captured log tail
- **skill writes** attributable to `write_origin='shadow_review'` (in `skill_usage`)
- **total Claude-spawn time** spent on shadow evaluation (the cost)

## How

- New pure aggregator `shadow_telemetry()` in `threadkeeper/shadow_review.py` — read-only, computed entirely from the trail every pass already leaves (`events` / `tasks` / child logs / `skill_usage`). No new bookkeeping, no spawn, no mutate.
- `shadow_review_status(snapshot_path="")` renders the rollup inline and, when `snapshot_path` is given, also dumps a markdown table for human review (the side-channel snapshot the issue mentions).
- Child logs that have aged out of the ephemeral `/tmp` task-log dir (or are skipped past a per-call read cap) are counted as `unknown`, so the hit-rate denominator stays honest (no silent truncation).

The token/$ half of spawn-cost accounting is intentionally left to #25, which extends this.

## Grounding

Validated read-only against the live production DB: 7d shows 1414 ticks, 411 spawned children, ~10h total spawn time, with the readable recent verdicts giving a ~55% hit rate (older verdict logs aged out of `/tmp` and correctly report as `unknown`).

## Tests

Added focused tests in `tests/test_shadow_review.py`: `_classify_pass` buckets, `_read_verdict` log parsing, `shadow_telemetry` window aggregation (ticks/outcomes/verdicts/hit_rate/skill_writes/cost), log-cap `logs_unread` reporting, and the MCP tool's telemetry block + markdown snapshot.

Full suite: **823 passed, 1 skipped, 0 failed**.

Docs updated: README, `docs/ARCHITECTURE.md`, `docs/ROADMAP.md`, `CHANGELOG.md`.

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)