### PR TITLE
feat(eval): memory-quality eval harness (LongMemEval abstention + tokens-per-retrieval)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,29 @@ version bumps follow semver per the policy in
 
 ### Added
 
+- **Memory-quality eval harness — LongMemEval-style abstention +
+  tokens-per-retrieval (#71).** thread-keeper measured write *precision* (the
+  extract-candidate ledger) but never retrieval *recall*, or whether
+  `brief()`/`search()` surface stale or fabricated facts — so the planned
+  lessons-decay (#27) and bi-temporal (#28) work would ship with no number to
+  optimize against. New `scripts/memory_eval/run.py` runs the **real**
+  `search()` / `dialog_search()` / `brief()` tools as systems-under-test over a
+  fixed ground-truth set and reports three numbers: **accuracy** (per the five
+  LongMemEval axes — information extraction, multi-session reasoning, temporal
+  reasoning, knowledge updates, abstention), **abstention rate** (of
+  never-happened questions, the fraction correctly refused — the highest-payoff
+  axis, directly measuring whether auto-injected `brief()` context fabricates),
+  and **tokens-per-retrieval** (mem0's 2026 cost axis, so recall is never read
+  apart from cost). The default judge is **lexical** (deterministic, offline,
+  no API key or embeddings → reproducible and CI-safe); an optional
+  `--judge llm` grades answer *reasoning* via an Anthropic model (urllib, no
+  SDK dependency) when `ANTHROPIC_API_KEY` is set. With no `--db` it builds a
+  bundled fixture corpus (`scripts/memory_eval/ground_truth.json`, a fictional
+  "billing service" across three sessions) into a throwaway DB — a **golden
+  baseline** where faithful retrieval scores 100%; `--db snapshot.sqlite` runs
+  **read-only** (the snapshot is copied to a temp file; the original is never
+  written). Wired as an optional `scripts/` harness, not CI-gating. Documented
+  in the README ("Memory-quality evaluation") and docs/ARCHITECTURE.md.
 - **Concepts store gets an eviction/consolidation path + a live evidence signal
   (#75).** The `concepts` table was write-only / grow-only: no
   remove/consolidate/confidence tool, auto-registered entries piling up, and

--- a/README.md
+++ b/README.md
@@ -803,6 +803,53 @@ reusable verdict logic lives in `threadkeeper/verify_ingest.py`.
 
 ---
 
+## Memory-quality evaluation
+
+The ingest verifier above answers *"did we capture the data?"*. The
+memory-quality harness answers the harder question — *"when we retrieve it,
+do we recall the right fact, and do we **refuse** to answer about things that
+never happened?"* It's modeled on
+[LongMemEval](https://arxiv.org/pdf/2410.10813) (ICLR 2025) plus mem0's 2026
+[tokens-per-retrieval](https://mem0.ai/blog/ai-memory-benchmarks-in-2026)
+cost axis, and runs the **real** `search()` / `dialog_search()` / `brief()`
+tools as the systems-under-test.
+
+```bash
+python scripts/memory_eval/run.py                 # bundled demo corpus, lexical judge
+python scripts/memory_eval/run.py --json          # machine-readable report
+python scripts/memory_eval/run.py --db snap.sqlite --ground-truth my_labels.json
+python scripts/memory_eval/run.py --semantic      # use embeddings if installed
+python scripts/memory_eval/run.py --judge llm      # LLM-graded (needs ANTHROPIC_API_KEY)
+```
+
+It reports three headline numbers over a fixed ground-truth set:
+
+- **accuracy** — fraction of questions whose retrieval recalled the gold
+  fact, broken out per the five LongMemEval axes (information extraction,
+  multi-session reasoning, temporal reasoning, knowledge updates, abstention).
+- **abstention rate** — of the *never-happened* questions, the fraction the
+  system correctly refused. This is the highest-payoff axis: it directly
+  measures whether the auto-injected `brief()` context fabricates or surfaces
+  stale facts.
+- **tokens-per-retrieval** — mean / median / max tokens of what each query
+  returned, so recall is never read apart from cost (a wider window that
+  recalls more also costs more).
+
+With no `--db` the harness builds the bundled fixture
+(`scripts/memory_eval/ground_truth.json` — a fictional "billing service" told
+across three sessions) into a throwaway DB; it's a **golden baseline** where a
+faithful retrieval scores 100%, so a regression in the retrieval tools drops
+the number. `--db` runs **read-only**: the snapshot is copied to a temp file
+and the original is never opened for writing. The default judge is **lexical**
+(deterministic, offline, no API key, no embeddings) so the command is
+reproducible and CI-safe; `--judge llm` grades answer *reasoning* (not just
+retrieval recall) with an Anthropic model when a key is set — the intended
+optimization target for the planned lessons-decay (#27) and bi-temporal
+claims (#28) work. See [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for how the
+axes map onto thread-keeper's retrieval surface.
+
+---
+
 ## Tests
 
 ```bash
@@ -810,7 +857,7 @@ pip install -e '.[semantic,dev]'
 python -m pytest
 ```
 
-495 tests passing on Python 3.11 / 3.12 / 3.13 (1 skipped). CI runs
+869 tests passing on Python 3.11 / 3.12 / 3.13 (1 skipped). CI runs
 the suite on every push and PR.
 
 ---

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -750,9 +750,50 @@ tests/
 └── …
 ```
 
-Run: `.venv/bin/python -m pytest tests/ -q`. Currently 495 tests (1 skipped),
+Run: `.venv/bin/python -m pytest tests/ -q`. Currently 869 tests (1 skipped),
 all green. Smoke parametrization automatically picks up any new tools without
 having to add tests.
+
+## Memory-quality evaluation (issue #71)
+
+Two read-only harnesses measure the memory layer, not the code:
+
+- `scripts/tk_verify_ingest.py` — *write/ingest* side: did we capture rows from
+  every CLI? (slot coverage, PASS/PARTIAL/FAIL; issue #1).
+- `scripts/memory_eval/run.py` — *read/retrieval* side: when we retrieve, do we
+  recall the right fact and **refuse** to answer about things that never
+  happened? Modeled on LongMemEval (ICLR 2025) + mem0's 2026
+  tokens-per-retrieval cost axis.
+
+The eval harness is deliberately thin and treats the retrieval surface as a
+black box: each ground-truth question carries a `system`
+(`search` → notes, `dialog_search` → ingested transcripts, `brief` → the
+auto-injected context) and a `query`; `retrieve()` calls the *real* tool
+function and the judge reads its verbatim output, so tokens-per-retrieval is
+measured on exactly what an agent would receive. The five LongMemEval axes map
+onto thread-keeper as:
+
+| Axis | What it probes here |
+|---|---|
+| information_extraction | single-fact recall from one message/note |
+| multi_session_reasoning | union of top-k spans facts from ≥2 sessions |
+| temporal_reasoning | retrieval surfaces the time-relevant evidence (before/after, latest) |
+| knowledge_update | the *current* value wins over a superseded one in the corpus |
+| abstention | never-happened question → no fabricated `trap_substring` leaks into context |
+
+The default **lexical** judge is a deterministic substring scorer (gold recall;
+abstention = no trap surfaced) — offline, no API key, no embeddings, so it runs
+in CI and as a golden baseline (the bundled `ground_truth.json` demo corpus
+scores 100% under a faithful retrieval; a regression in `search()`/
+`dialog_search()` drops it). An optional `--judge llm` grades answer
+*reasoning* (true temporal ordering, knowledge-update correctness) via the
+Anthropic Messages API over `urllib` — no SDK dependency — and is the intended
+optimization target for the lessons-decay (#27) and bi-temporal (#28) work.
+`--db snapshot.sqlite` evaluates a real production snapshot, copied to a temp
+file first so the original is never opened for writing. Backend (`fts` vs
+`semantic`) is auto-detected and reported. Smoke-tested in
+`tests/test_memory_eval.py` (subprocess, to keep import-time env setup off the
+shared in-process package state).
 
 ## Env knobs (config.py)
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -418,10 +418,18 @@ verified at the cited file:line, deduplicated against the issues above):
   sessions, newly-installed adapters, post-downtime backfill) that land below
   the cursor are evaluated by neither loop. Use a grace lookback or an
   ingest-order watermark instead of the transcript timestamp (#69).
-- Memory **recall/abstention** eval harness (LongMemEval-style QA + abstention
-  + tokens-per-retrieval) to give the lessons-decay (#27) and bi-temporal
-  (#28) work a number to optimize against — complementary to the learning-loop
-  **decision-quality** harness (#72) (#71).
+- ✅ DONE (#71). Memory **recall/abstention** eval harness (LongMemEval-style
+  QA + abstention + tokens-per-retrieval) to give the lessons-decay (#27) and
+  bi-temporal (#28) work a number to optimize against — complementary to the
+  learning-loop **decision-quality** harness (#72). `scripts/memory_eval/run.py`
+  runs the real `search()`/`dialog_search()`/`brief()` tools over a fixed
+  ground-truth set and reports accuracy (per the five LongMemEval axes),
+  abstention rate (never-happened questions correctly refused), and
+  tokens-per-retrieval. Lexical judge by default (offline, reproducible,
+  CI-safe); optional `--judge llm` for answer-reasoning grading. Bundled demo
+  corpus is a golden baseline; `--db` evaluates a snapshot **read-only** (copied
+  to temp). Use the temporal-reasoning + knowledge-update axes as the
+  optimization target for #27/#28.
 - MCP **tool annotations** (`readOnly`/`destructive`/`idempotent` hints) +
   structured output across the tool registry (independently confirmed; canonical
   issue #67) — gives hosts a mechanical read-vs-write signal and composes with

--- a/scripts/memory_eval/ground_truth.json
+++ b/scripts/memory_eval/ground_truth.json
@@ -1,0 +1,752 @@
+{
+  "_about": "Reproducible demo corpus + hand-labeled ground truth for the memory-quality eval harness (issue #71). A small fictional 'billing service' project told across three sessions over ~30 days, so the five LongMemEval axes \u2014 information extraction, multi-session reasoning, temporal reasoning, knowledge updates, and abstention \u2014 are all exercisable offline. The harness builds this into a throwaway SQLite DB and queries the real search()/dialog_search()/brief() tools. Replace with your own snapshot + labels via --db / --ground-truth for a real evaluation.",
+  "corpus": {
+    "threads": [
+      {
+        "id": "Tarch",
+        "question": "Billing service architecture"
+      },
+      {
+        "id": "Tinfra",
+        "question": "Billing service infra and deploy"
+      },
+      {
+        "id": "Tdec",
+        "question": "Billing service decisions log"
+      }
+    ],
+    "dialog_messages": [
+      {
+        "uuid": "d-alpha-1",
+        "session_id": "s_alpha",
+        "role": "user",
+        "day_offset": -30,
+        "content": "Starting the billing service \u2014 pick the database and the payments provider."
+      },
+      {
+        "uuid": "d-alpha-2",
+        "session_id": "s_alpha",
+        "role": "assistant",
+        "day_offset": -30,
+        "content": "Billing service: we chose PostgreSQL as the database and Stripe as the payments provider. Backend is Python on the FastAPI framework, REST API style."
+      },
+      {
+        "uuid": "d-alpha-3",
+        "session_id": "s_alpha",
+        "role": "user",
+        "day_offset": -30,
+        "content": "What about background jobs, tests, and Kubernetes for billing?"
+      },
+      {
+        "uuid": "d-alpha-4",
+        "session_id": "s_alpha",
+        "role": "assistant",
+        "day_offset": -30,
+        "content": "Billing service jobs run on RabbitMQ and tests use pytest. We considered Kubernetes but decided to stay on AWS ECS \u2014 no Kubernetes migration."
+      },
+      {
+        "uuid": "d-beta-1",
+        "session_id": "s_beta",
+        "role": "user",
+        "day_offset": -15,
+        "content": "Set up CI and deploy the billing service to production."
+      },
+      {
+        "uuid": "d-beta-2",
+        "session_id": "s_beta",
+        "role": "assistant",
+        "day_offset": -15,
+        "content": "Billing service CI runs on GitHub Actions; we deployed the production cluster to the us-east-1 region. Container images push to GHCR and errors go to Sentry."
+      },
+      {
+        "uuid": "d-beta-3",
+        "session_id": "s_beta",
+        "role": "user",
+        "day_offset": -15,
+        "content": "How are secrets and auth handled for the billing service?"
+      },
+      {
+        "uuid": "d-beta-4",
+        "session_id": "s_beta",
+        "role": "assistant",
+        "day_offset": -15,
+        "content": "Billing service secrets live in AWS Secrets Manager; authentication uses Better Auth with JWT tokens."
+      },
+      {
+        "uuid": "d-gamma-1",
+        "session_id": "s_gamma",
+        "role": "user",
+        "day_offset": -3,
+        "content": "Lower EU latency \u2014 update the billing production deployment."
+      },
+      {
+        "uuid": "d-gamma-2",
+        "session_id": "s_gamma",
+        "role": "assistant",
+        "day_offset": -3,
+        "content": "Billing service: migrated the production cluster from us-east-1 to the eu-central-1 region, and added a Redis cache in front of PostgreSQL. Current production region is eu-central-1."
+      },
+      {
+        "uuid": "d-gamma-3",
+        "session_id": "s_gamma",
+        "role": "user",
+        "day_offset": -3,
+        "content": "Any GraphQL gateway or mobile app for the billing service?"
+      },
+      {
+        "uuid": "d-gamma-4",
+        "session_id": "s_gamma",
+        "role": "assistant",
+        "day_offset": -3,
+        "content": "No GraphQL gateway and no mobile app for the billing service \u2014 the API stays REST-only."
+      }
+    ],
+    "notes": [
+      {
+        "thread_id": "Tarch",
+        "kind": "insight",
+        "day_offset": -30,
+        "content": "Billing service stack: PostgreSQL database, Stripe payments, FastAPI backend, RabbitMQ jobs, Redis cache."
+      },
+      {
+        "thread_id": "Tinfra",
+        "kind": "insight",
+        "day_offset": -3,
+        "content": "Billing production cluster region is eu-central-1, migrated from us-east-1 for EU latency."
+      },
+      {
+        "thread_id": "Tdec",
+        "kind": "insight",
+        "day_offset": -3,
+        "content": "Billing decisions: no Kubernetes (stay on ECS), no GraphQL gateway, no mobile app."
+      }
+    ]
+  },
+  "questions": [
+    {
+      "id": "ie_db",
+      "type": "information_extraction",
+      "system": "dialog_search",
+      "k": 5,
+      "query": "billing database",
+      "question": "Which database did we choose for the billing service?",
+      "gold_any": [
+        "PostgreSQL",
+        "Postgres"
+      ]
+    },
+    {
+      "id": "ie_payments",
+      "type": "information_extraction",
+      "system": "dialog_search",
+      "k": 5,
+      "query": "payments provider",
+      "question": "Which payments provider did we choose?",
+      "gold_any": [
+        "Stripe"
+      ]
+    },
+    {
+      "id": "ie_language",
+      "type": "information_extraction",
+      "system": "dialog_search",
+      "k": 5,
+      "query": "backend Python",
+      "question": "What language is the billing backend written in?",
+      "gold_any": [
+        "Python"
+      ]
+    },
+    {
+      "id": "ie_framework",
+      "type": "information_extraction",
+      "system": "dialog_search",
+      "k": 5,
+      "query": "FastAPI framework",
+      "question": "Which web framework does the backend use?",
+      "gold_any": [
+        "FastAPI"
+      ]
+    },
+    {
+      "id": "ie_jobs",
+      "type": "information_extraction",
+      "system": "dialog_search",
+      "k": 5,
+      "query": "jobs",
+      "question": "What runs the background jobs?",
+      "gold_any": [
+        "RabbitMQ"
+      ]
+    },
+    {
+      "id": "ie_tests",
+      "type": "information_extraction",
+      "system": "dialog_search",
+      "k": 5,
+      "query": "tests",
+      "question": "What test runner do we use?",
+      "gold_any": [
+        "pytest"
+      ]
+    },
+    {
+      "id": "ie_ci",
+      "type": "information_extraction",
+      "system": "dialog_search",
+      "k": 5,
+      "query": "CI GitHub",
+      "question": "Where does CI run?",
+      "gold_any": [
+        "GitHub Actions"
+      ]
+    },
+    {
+      "id": "ie_registry",
+      "type": "information_extraction",
+      "system": "dialog_search",
+      "k": 5,
+      "query": "container images",
+      "question": "Where are container images pushed?",
+      "gold_any": [
+        "GHCR"
+      ]
+    },
+    {
+      "id": "ie_errors",
+      "type": "information_extraction",
+      "system": "dialog_search",
+      "k": 5,
+      "query": "errors",
+      "question": "What do we use for error tracking?",
+      "gold_any": [
+        "Sentry"
+      ]
+    },
+    {
+      "id": "ie_secrets",
+      "type": "information_extraction",
+      "system": "dialog_search",
+      "k": 5,
+      "query": "secrets",
+      "question": "Where are secrets stored?",
+      "gold_any": [
+        "Secrets Manager"
+      ]
+    },
+    {
+      "id": "ie_auth",
+      "type": "information_extraction",
+      "system": "dialog_search",
+      "k": 5,
+      "query": "authentication",
+      "question": "How is authentication handled?",
+      "gold_any": [
+        "Better Auth",
+        "JWT"
+      ]
+    },
+    {
+      "id": "ie_cache",
+      "type": "information_extraction",
+      "system": "dialog_search",
+      "k": 5,
+      "query": "Redis cache",
+      "question": "What cache sits in front of PostgreSQL?",
+      "gold_any": [
+        "Redis"
+      ]
+    },
+    {
+      "id": "ie_api_style",
+      "type": "information_extraction",
+      "system": "dialog_search",
+      "k": 5,
+      "query": "API style",
+      "question": "What API style does the service use?",
+      "gold_any": [
+        "REST"
+      ]
+    },
+    {
+      "id": "ie_ecs",
+      "type": "information_extraction",
+      "system": "dialog_search",
+      "k": 5,
+      "query": "Kubernetes ECS",
+      "question": "What orchestrator are we running on?",
+      "gold_any": [
+        "ECS"
+      ]
+    },
+    {
+      "id": "ie_notes_stack",
+      "type": "information_extraction",
+      "system": "search",
+      "k": 5,
+      "query": "billing stack",
+      "question": "What is in the billing service stack note?",
+      "gold_any": [
+        "PostgreSQL"
+      ]
+    },
+    {
+      "id": "ie_notes_payments",
+      "type": "information_extraction",
+      "system": "search",
+      "k": 5,
+      "query": "billing stack",
+      "question": "What payments provider is recorded in the stack note?",
+      "gold_any": [
+        "Stripe"
+      ]
+    },
+    {
+      "id": "ie_notes_region",
+      "type": "information_extraction",
+      "system": "search",
+      "k": 5,
+      "query": "production region",
+      "question": "What region does the infra note record?",
+      "gold_any": [
+        "eu-central-1"
+      ]
+    },
+    {
+      "id": "ie_notes_decisions",
+      "type": "information_extraction",
+      "system": "search",
+      "k": 5,
+      "query": "billing decisions",
+      "question": "What orchestrator decision is in the decisions note?",
+      "gold_any": [
+        "ECS"
+      ]
+    },
+    {
+      "id": "ms_db_and_ci",
+      "type": "multi_session_reasoning",
+      "system": "dialog_search",
+      "k": 12,
+      "query": "billing service",
+      "question": "What database did we pick and where does CI run?",
+      "gold_all": [
+        "PostgreSQL",
+        "GitHub Actions"
+      ]
+    },
+    {
+      "id": "ms_payments_and_region",
+      "type": "multi_session_reasoning",
+      "system": "dialog_search",
+      "k": 12,
+      "query": "billing service",
+      "question": "Which payments provider did we pick and what is the current region?",
+      "gold_all": [
+        "Stripe",
+        "eu-central-1"
+      ]
+    },
+    {
+      "id": "ms_secrets_and_cache",
+      "type": "multi_session_reasoning",
+      "system": "dialog_search",
+      "k": 12,
+      "query": "billing service",
+      "question": "Where are secrets stored and what cache did we add?",
+      "gold_all": [
+        "Secrets Manager",
+        "Redis"
+      ]
+    },
+    {
+      "id": "ms_jobs_and_registry",
+      "type": "multi_session_reasoning",
+      "system": "dialog_search",
+      "k": 12,
+      "query": "billing service",
+      "question": "What runs jobs and where do images go?",
+      "gold_all": [
+        "RabbitMQ",
+        "GHCR"
+      ]
+    },
+    {
+      "id": "ms_framework_and_auth",
+      "type": "multi_session_reasoning",
+      "system": "dialog_search",
+      "k": 12,
+      "query": "billing service",
+      "question": "Which framework and which auth library do we use?",
+      "gold_all": [
+        "FastAPI",
+        "Better Auth"
+      ]
+    },
+    {
+      "id": "ms_full_stack",
+      "type": "multi_session_reasoning",
+      "system": "dialog_search",
+      "k": 12,
+      "query": "billing service",
+      "question": "Summarize the database, payments, and cache choices.",
+      "gold_all": [
+        "PostgreSQL",
+        "Stripe",
+        "Redis"
+      ]
+    },
+    {
+      "id": "ms_tests_and_errors",
+      "type": "multi_session_reasoning",
+      "system": "dialog_search",
+      "k": 12,
+      "query": "billing service",
+      "question": "What test runner and error tracker do we use?",
+      "gold_all": [
+        "pytest",
+        "Sentry"
+      ]
+    },
+    {
+      "id": "ms_lang_and_region",
+      "type": "multi_session_reasoning",
+      "system": "dialog_search",
+      "k": 12,
+      "query": "billing service",
+      "question": "What language is the backend, and what region is prod now?",
+      "gold_all": [
+        "Python",
+        "eu-central-1"
+      ]
+    },
+    {
+      "id": "tr_first_region",
+      "type": "temporal_reasoning",
+      "system": "dialog_search",
+      "k": 6,
+      "query": "production region",
+      "question": "Which region did we deploy to first?",
+      "gold_any": [
+        "us-east-1"
+      ]
+    },
+    {
+      "id": "tr_current_region",
+      "type": "temporal_reasoning",
+      "system": "dialog_search",
+      "k": 6,
+      "query": "production region",
+      "question": "Which region is production in most recently?",
+      "gold_any": [
+        "eu-central-1"
+      ]
+    },
+    {
+      "id": "tr_latest_infra",
+      "type": "temporal_reasoning",
+      "system": "dialog_search",
+      "k": 6,
+      "query": "production region",
+      "question": "What was the most recent infrastructure change?",
+      "gold_any": [
+        "eu-central-1",
+        "Redis"
+      ]
+    },
+    {
+      "id": "tr_stripe_evidence",
+      "type": "temporal_reasoning",
+      "system": "dialog_search",
+      "k": 5,
+      "query": "payments provider",
+      "question": "Was Stripe chosen in the first session?",
+      "gold_any": [
+        "Stripe"
+      ]
+    },
+    {
+      "id": "tr_ci_evidence",
+      "type": "temporal_reasoning",
+      "system": "dialog_search",
+      "k": 5,
+      "query": "CI GitHub",
+      "question": "When was CI set up relative to the first deploy?",
+      "gold_any": [
+        "GitHub Actions"
+      ]
+    },
+    {
+      "id": "tr_cache_recent",
+      "type": "temporal_reasoning",
+      "system": "dialog_search",
+      "k": 6,
+      "query": "Redis cache",
+      "question": "Was the cache added recently?",
+      "gold_any": [
+        "Redis"
+      ]
+    },
+    {
+      "id": "tr_migration_evidence",
+      "type": "temporal_reasoning",
+      "system": "dialog_search",
+      "k": 6,
+      "query": "production region",
+      "question": "Did the region change over time?",
+      "gold_all": [
+        "us-east-1",
+        "eu-central-1"
+      ]
+    },
+    {
+      "id": "tr_original_db",
+      "type": "temporal_reasoning",
+      "system": "dialog_search",
+      "k": 5,
+      "query": "billing database",
+      "question": "What database did we start with?",
+      "gold_any": [
+        "PostgreSQL"
+      ]
+    },
+    {
+      "id": "ku_region",
+      "type": "knowledge_update",
+      "system": "dialog_search",
+      "k": 6,
+      "query": "production region",
+      "question": "What region is production in NOW?",
+      "gold_any": [
+        "eu-central-1"
+      ],
+      "stale": [
+        "us-east-1"
+      ]
+    },
+    {
+      "id": "ku_cache",
+      "type": "knowledge_update",
+      "system": "dialog_search",
+      "k": 6,
+      "query": "front PostgreSQL",
+      "question": "What now sits in front of PostgreSQL?",
+      "gold_any": [
+        "Redis"
+      ]
+    },
+    {
+      "id": "ku_region_note",
+      "type": "knowledge_update",
+      "system": "search",
+      "k": 5,
+      "query": "production region",
+      "question": "What region does the latest infra note record?",
+      "gold_any": [
+        "eu-central-1"
+      ],
+      "stale": [
+        "us-east-1"
+      ]
+    },
+    {
+      "id": "ku_orchestrator",
+      "type": "knowledge_update",
+      "system": "dialog_search",
+      "k": 5,
+      "query": "Kubernetes ECS",
+      "question": "Did we end up on Kubernetes or stay on ECS?",
+      "gold_any": [
+        "ECS"
+      ]
+    },
+    {
+      "id": "ku_api_surface",
+      "type": "knowledge_update",
+      "system": "dialog_search",
+      "k": 5,
+      "query": "GraphQL REST",
+      "question": "Is the API GraphQL or still REST?",
+      "gold_any": [
+        "REST"
+      ]
+    },
+    {
+      "id": "ku_eu_latency",
+      "type": "knowledge_update",
+      "system": "dialog_search",
+      "k": 6,
+      "query": "production region",
+      "question": "What is the reason for the current region?",
+      "gold_any": [
+        "eu-central-1"
+      ]
+    },
+    {
+      "id": "abs_k8s",
+      "type": "abstention",
+      "system": "dialog_search",
+      "k": 5,
+      "abstain": true,
+      "query": "Kubernetes migration",
+      "question": "What did we decide in the approved Kubernetes migration plan?",
+      "trap_substrings": [
+        "kubernetes migration approved",
+        "migrated to kubernetes",
+        "moved to kubernetes",
+        "running on kubernetes",
+        "kubernetes is approved"
+      ]
+    },
+    {
+      "id": "abs_graphql",
+      "type": "abstention",
+      "system": "dialog_search",
+      "k": 5,
+      "abstain": true,
+      "query": "GraphQL gateway",
+      "question": "Which GraphQL gateway schema did we ship?",
+      "trap_substrings": [
+        "graphql gateway shipped",
+        "built the graphql gateway",
+        "graphql schema",
+        "graphql is live"
+      ]
+    },
+    {
+      "id": "abs_mobile",
+      "type": "abstention",
+      "system": "dialog_search",
+      "k": 5,
+      "abstain": true,
+      "query": "mobile app",
+      "question": "What did we name the mobile app we launched?",
+      "trap_substrings": [
+        "mobile app launched",
+        "ios app",
+        "android app",
+        "react native app",
+        "app store"
+      ]
+    },
+    {
+      "id": "abs_soc2",
+      "type": "abstention",
+      "system": "dialog_search",
+      "k": 5,
+      "abstain": true,
+      "query": "SOC2 audit",
+      "question": "What was the outcome of the SOC2 audit?",
+      "trap_substrings": [
+        "soc2",
+        "soc 2",
+        "passed the audit",
+        "audit passed"
+      ]
+    },
+    {
+      "id": "abs_kafka",
+      "type": "abstention",
+      "system": "dialog_search",
+      "k": 5,
+      "abstain": true,
+      "query": "Kafka topics",
+      "question": "How did we configure the Kafka topics?",
+      "trap_substrings": [
+        "kafka"
+      ]
+    },
+    {
+      "id": "abs_oracle",
+      "type": "abstention",
+      "system": "dialog_search",
+      "k": 5,
+      "abstain": true,
+      "query": "Oracle database",
+      "question": "Why did we pick Oracle for billing?",
+      "trap_substrings": [
+        "oracle"
+      ]
+    },
+    {
+      "id": "abs_paypal",
+      "type": "abstention",
+      "system": "dialog_search",
+      "k": 5,
+      "abstain": true,
+      "query": "PayPal integration",
+      "question": "How did we integrate PayPal?",
+      "trap_substrings": [
+        "paypal"
+      ]
+    },
+    {
+      "id": "abs_gcp",
+      "type": "abstention",
+      "system": "dialog_search",
+      "k": 5,
+      "abstain": true,
+      "query": "GCP project",
+      "question": "What is our GCP project id?",
+      "trap_substrings": [
+        "gcp",
+        "google cloud"
+      ]
+    },
+    {
+      "id": "abs_mongodb",
+      "type": "abstention",
+      "system": "dialog_search",
+      "k": 5,
+      "abstain": true,
+      "query": "MongoDB",
+      "question": "Which MongoDB cluster do we use?",
+      "trap_substrings": [
+        "mongodb",
+        "mongo"
+      ]
+    },
+    {
+      "id": "abs_apac",
+      "type": "abstention",
+      "system": "dialog_search",
+      "k": 6,
+      "abstain": true,
+      "query": "production region",
+      "question": "When did we deploy to the APAC region?",
+      "trap_substrings": [
+        "ap-southeast",
+        "ap-northeast",
+        "apac region",
+        "tokyo region",
+        "singapore region"
+      ]
+    },
+    {
+      "id": "abs_notes_kafka",
+      "type": "abstention",
+      "system": "search",
+      "k": 5,
+      "abstain": true,
+      "query": "billing stack",
+      "question": "What does the stack note say about Kafka?",
+      "trap_substrings": [
+        "kafka"
+      ]
+    },
+    {
+      "id": "abs_brief_kubernetes",
+      "type": "abstention",
+      "system": "brief",
+      "k": 6,
+      "abstain": true,
+      "query": "kubernetes migration plan",
+      "question": "What does the brief say about the approved Kubernetes migration?",
+      "trap_substrings": [
+        "kubernetes migration approved",
+        "migrated to kubernetes",
+        "moved to kubernetes"
+      ]
+    }
+  ]
+}

--- a/scripts/memory_eval/run.py
+++ b/scripts/memory_eval/run.py
@@ -1,0 +1,452 @@
+#!/usr/bin/env python3
+"""Memory-quality eval harness (issue #71).
+
+Measures whether thread-keeper's retrieval surface — the real ``search()``,
+``dialog_search()`` and ``brief()`` tools — actually recalls the facts the
+agent needs, and (the high-payoff axis) whether it *abstains* on events that
+never happened instead of surfacing a fabricated or stale answer. Modeled on
+LongMemEval (ICLR 2025) + mem0's 2026 tokens-per-retrieval cost axis.
+
+It reports, over a fixed ground-truth set:
+  • accuracy            — fraction of questions whose retrieval recalled the
+                          gold fact (or, for abstention questions, did NOT
+                          surface the fabricated claim)
+  • per-type accuracy   — the five LongMemEval axes (information extraction,
+                          multi-session reasoning, temporal reasoning,
+                          knowledge updates, abstention)
+  • abstention rate     — of the never-happened questions, the fraction the
+                          system correctly refused (did not leak a trap fact)
+  • tokens-per-retrieval — mean / median / max tokens of what each query
+                          returned, so recall is never read apart from cost
+
+The default judge is **lexical** (deterministic, offline, no API key, no
+embeddings) so a single command is reproducible and CI-safe. An optional
+``--judge llm`` backend grades answer correctness with an Anthropic model
+(via urllib, no SDK dependency) when ``ANTHROPIC_API_KEY`` is set — useful
+once temporal/knowledge-update *reasoning* (not just retrieval recall) becomes
+the optimization target for #27/#28.
+
+Usage (from the repo root, with the project venv):
+
+    .venv/bin/python scripts/memory_eval/run.py                # bundled demo corpus
+    .venv/bin/python scripts/memory_eval/run.py --json         # machine-readable
+    .venv/bin/python scripts/memory_eval/run.py --db snap.sqlite \
+        --ground-truth my_labels.json                          # real snapshot
+    .venv/bin/python scripts/memory_eval/run.py --semantic     # use embeddings if installed
+    .venv/bin/python scripts/memory_eval/run.py --judge llm     # LLM-graded (needs key)
+
+``--db`` runs READ-ONLY: the snapshot is copied to a throwaway temp file and
+the original is never opened for writing. With no ``--db`` the harness builds
+the bundled demo corpus (scripts/memory_eval/ground_truth.json) into a fresh
+temp DB, so the command is fully self-contained.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import shutil
+import statistics
+import sys
+import tempfile
+import time
+import urllib.request
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+DEFAULT_GROUND_TRUTH = HERE / "ground_truth.json"
+
+# The five LongMemEval question axes, in report order.
+AXES = [
+    "information_extraction",
+    "multi_session_reasoning",
+    "temporal_reasoning",
+    "knowledge_update",
+    "abstention",
+]
+
+# A deterministic, dependency-free token proxy: words + standalone
+# punctuation. Within ~25% of a BPE count for English/code, and stable
+# across machines (no tiktoken/model download). Documented as an estimate.
+_TOK_RE = re.compile(r"\w+|[^\w\s]")
+
+
+def estimate_tokens(text: str) -> int:
+    """Rough token count of a retrieved context blob (see _TOK_RE)."""
+    if not text:
+        return 0
+    return len(_TOK_RE.findall(text))
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Environment + package import
+# ──────────────────────────────────────────────────────────────────────────
+def _prepare_env(db_path: Path, semantic: bool) -> None:
+    """Point thread-keeper at our DB and silence every background daemon.
+
+    Must run BEFORE importing threadkeeper.* — config captures these at
+    import time (DB_PATH, SEMANTIC_AVAILABLE)."""
+    os.environ["THREADKEEPER_DB"] = str(db_path)
+    proj = db_path.parent / "fake_projects"
+    proj.mkdir(parents=True, exist_ok=True)
+    os.environ["CLAUDE_PROJECTS_DIR"] = str(proj)
+    if semantic:
+        os.environ.pop("THREADKEEPER_NO_EMBEDDINGS", None)
+    else:
+        os.environ["THREADKEEPER_NO_EMBEDDINGS"] = "1"
+    # Hard-disable all background work: this is a read-only measurement, not a
+    # live session. Mirrors tests/conftest.py's clean-env block.
+    os.environ["THREADKEEPER_DISABLE_BG_DAEMONS"] = "1"
+    for knob in (
+        "THREADKEEPER_AUTO_UPDATE_INTERVAL_S",
+        "THREADKEEPER_INGEST_INTERVAL_S",
+        "THREADKEEPER_INGEST_CAP",
+        "THREADKEEPER_SKILL_WATCH_INTERVAL_S",
+        "THREADKEEPER_SHADOW_REVIEW_INTERVAL_S",
+        "THREADKEEPER_CURATOR_INTERVAL_S",
+        "THREADKEEPER_EXTRACT_INTERVAL_S",
+        "THREADKEEPER_PROBE_INTERVAL_S",
+        "THREADKEEPER_THREAD_JANITOR_INTERVAL_S",
+        "THREADKEEPER_CONFIG_WATCH_INTERVAL_S",
+        "THREADKEEPER_SEARCH_PROXY_POLL_S",
+    ):
+        os.environ[knob] = "0"
+    os.environ.setdefault("THREADKEEPER_CLIENT", "memory-eval")
+
+
+def _import_threadkeeper():
+    """Import after _prepare_env. Returns the handful of modules we touch."""
+    import threadkeeper.server  # noqa: F401  (registers tools + inits schema)
+    from threadkeeper import db, config, brief as brief_mod
+    from threadkeeper.tools import dialog as dialog_tool, threads as threads_tool
+    return {
+        "db": db,
+        "config": config,
+        "brief": brief_mod,
+        "dialog_search": dialog_tool.dialog_search,
+        "search": threads_tool.search,
+    }
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Corpus seeding (demo fixture → fresh DB)
+# ──────────────────────────────────────────────────────────────────────────
+def seed_corpus(conn, corpus: dict, now: int | None = None) -> None:
+    """Insert the demo corpus into a fresh DB the way ingest()/note() would.
+
+    dialog_messages are mirrored into dialog_fts by hand (the ingest path does
+    this; there is no trigger). notes rely on the notes_fts AFTER INSERT
+    trigger defined in the schema."""
+    now = now if now is not None else int(time.time())
+    for t in corpus.get("threads", []):
+        conn.execute(
+            "INSERT OR IGNORE INTO threads "
+            "(id, question, state, opened_at, last_touched_at) "
+            "VALUES (?, ?, 'active', ?, ?)",
+            (t["id"], t["question"], now, now),
+        )
+    for m in corpus.get("dialog_messages", []):
+        ts = now + int(m.get("day_offset", 0)) * 86400
+        conn.execute(
+            "INSERT OR IGNORE INTO dialog_messages "
+            "(uuid, source, project, session_id, role, content, model, created_at) "
+            "VALUES (?, 'claude-code', 'memory-eval', ?, ?, ?, 'demo', ?)",
+            (m["uuid"], m.get("session_id"), m["role"], m["content"], ts),
+        )
+        conn.execute(
+            "INSERT OR IGNORE INTO dialog_fts (uuid, content) VALUES (?, ?)",
+            (m["uuid"], m["content"]),
+        )
+    for n in corpus.get("notes", []):
+        ts = now + int(n.get("day_offset", 0)) * 86400
+        conn.execute(
+            "INSERT INTO notes (thread_id, content, kind, created_at, session_id) "
+            "VALUES (?, ?, ?, ?, 'memory-eval')",
+            (n.get("thread_id"), n["content"], n.get("kind", "insight"), ts),
+        )
+    conn.commit()
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Retrieval — call the REAL systems-under-test
+# ──────────────────────────────────────────────────────────────────────────
+def retrieve(tk: dict, item: dict) -> str:
+    """Issue the question's query to its system-under-test, return raw output.
+
+    The returned string is exactly what a downstream agent would receive, so
+    tokens-per-retrieval is measured on it and the judge reads it verbatim."""
+    system = item.get("system", "dialog_search")
+    query = item.get("query") or item.get("question", "")
+    k = int(item.get("k", 5))
+    if system == "search":
+        return tk["search"](query=query, k=k)
+    if system == "brief":
+        conn = tk["db"].get_db()
+        return tk["brief"].render_brief(conn, query=query, k=k)
+    # default: dialog_search
+    return tk["dialog_search"](query=query, k=k, mode=item.get("mode", "hybrid"))
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Judges
+# ──────────────────────────────────────────────────────────────────────────
+_NO_HIT_MARKERS = ("no_matches", "no_idle", "fts_error")
+
+
+def judge_lexical(item: dict, ctx: str) -> tuple[bool, str]:
+    """Deterministic substring judge.
+
+    Normal question  → correct if the gold fact was surfaced (recall).
+    Abstention (`abstain`) → correct if NO `trap_substrings` (fabricated
+    claims, absent from the corpus) leaked into the retrieved context. A bare
+    `no_matches` trivially contains no trap, so it counts as a correct refusal.
+    """
+    low = ctx.lower()
+    if item.get("abstain"):
+        leaked = [t for t in item.get("trap_substrings", []) if t.lower() in low]
+        if leaked:
+            return False, f"leaked trap: {leaked[0]!r}"
+        return True, "abstained (no trap surfaced)"
+    gold_all = item.get("gold_all")
+    if gold_all:
+        missing = [g for g in gold_all if g.lower() not in low]
+        if missing:
+            return False, f"missing {missing!r}"
+        return True, "all gold facts recalled"
+    gold_any = item.get("gold_any", [])
+    hit = next((g for g in gold_any if g.lower() in low), None)
+    if hit:
+        return True, f"recalled {hit!r}"
+    return False, f"none of {gold_any!r} recalled"
+
+
+class LLMJudgeUnavailable(RuntimeError):
+    pass
+
+
+def judge_llm(item: dict, ctx: str, *, model: str, api_key: str,
+              timeout: float = 60.0) -> tuple[bool, str]:
+    """Grade answer correctness with an Anthropic model over plain urllib.
+
+    No SDK dependency: POSTs the Messages API and parses a strict-JSON verdict.
+    Falls back to the lexical judge's contract (bool, reason)."""
+    gold = item.get("gold_all") or item.get("gold_any") or []
+    if item.get("abstain"):
+        rubric = (
+            "This question asks about an event that NEVER happened. The "
+            "correct behavior is to ABSTAIN: the context must not support any "
+            "specific factual claim answering it. Mark correct=true if the "
+            "context does not contain a confident answer, false if it does."
+        )
+    else:
+        rubric = (
+            f"The correct answer should mention one of: {gold}. Mark "
+            "correct=true only if the retrieved context actually supports that "
+            "answer, false otherwise."
+        )
+    prompt = (
+        "You grade a memory system's retrieval. Reply with ONLY a JSON object "
+        '{"correct": bool, "reason": "<=12 words}.\n\n'
+        f"QUESTION: {item.get('question', item.get('query', ''))}\n\n"
+        f"RUBRIC: {rubric}\n\n"
+        f"RETRIEVED CONTEXT:\n{ctx[:4000]}\n"
+    )
+    body = json.dumps({
+        "model": model,
+        "max_tokens": 128,
+        "messages": [{"role": "user", "content": prompt}],
+    }).encode()
+    req = urllib.request.Request(
+        "https://api.anthropic.com/v1/messages",
+        data=body,
+        headers={
+            "content-type": "application/json",
+            "x-api-key": api_key,
+            "anthropic-version": "2023-06-01",
+        },
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            payload = json.loads(resp.read())
+    except Exception as e:  # noqa: BLE001 — surface any transport/API error
+        raise LLMJudgeUnavailable(f"anthropic request failed: {e}") from e
+    text = "".join(
+        b.get("text", "") for b in payload.get("content", [])
+        if b.get("type") == "text"
+    )
+    m = re.search(r"\{.*\}", text, re.S)
+    if not m:
+        return False, f"unparseable verdict: {text[:60]!r}"
+    try:
+        verdict = json.loads(m.group(0))
+    except json.JSONDecodeError:
+        return False, f"unparseable verdict: {text[:60]!r}"
+    return bool(verdict.get("correct")), str(verdict.get("reason", ""))[:80]
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Eval driver
+# ──────────────────────────────────────────────────────────────────────────
+def evaluate(tk: dict, ground_truth: dict, *, judge: str = "lexical",
+             llm_model: str = "claude-haiku-4-5-20251001") -> dict:
+    """Run every question, judge it, and aggregate the report dict."""
+    api_key = os.environ.get("ANTHROPIC_API_KEY", "")
+    if judge == "llm" and not api_key:
+        raise LLMJudgeUnavailable(
+            "ANTHROPIC_API_KEY not set; rerun with --judge lexical (default)."
+        )
+    backend = "semantic" if tk["config"].SEMANTIC_AVAILABLE else "fts"
+    rows: list[dict] = []
+    for item in ground_truth["questions"]:
+        ctx = retrieve(tk, item)
+        tokens = estimate_tokens(ctx)
+        if judge == "llm":
+            correct, reason = judge_llm(
+                item, ctx, model=llm_model, api_key=api_key)
+        else:
+            correct, reason = judge_lexical(item, ctx)
+        rows.append({
+            "id": item["id"],
+            "type": item.get("type", "information_extraction"),
+            "system": item.get("system", "dialog_search"),
+            "abstain": bool(item.get("abstain")),
+            "correct": correct,
+            "reason": reason,
+            "tokens": tokens,
+            "no_hit": any(mk in ctx for mk in _NO_HIT_MARKERS),
+        })
+
+    total = len(rows)
+    correct = sum(r["correct"] for r in rows)
+    per_type: dict[str, dict] = {}
+    for ax in AXES:
+        sub = [r for r in rows if r["type"] == ax]
+        if sub:
+            per_type[ax] = {
+                "n": len(sub),
+                "correct": sum(r["correct"] for r in sub),
+                "accuracy": round(sum(r["correct"] for r in sub) / len(sub), 4),
+            }
+    abst = [r for r in rows if r["abstain"]]
+    toks = [r["tokens"] for r in rows]
+    return {
+        "backend": backend,
+        "judge": judge,
+        "total": total,
+        "correct": correct,
+        "accuracy": round(correct / total, 4) if total else 0.0,
+        "per_type": per_type,
+        "abstention": {
+            "n": len(abst),
+            "correct": sum(r["correct"] for r in abst),
+            "rate": round(sum(r["correct"] for r in abst) / len(abst), 4)
+            if abst else None,
+        },
+        "tokens_per_retrieval": {
+            "mean": round(statistics.fmean(toks), 1) if toks else 0.0,
+            "median": int(statistics.median(toks)) if toks else 0,
+            "max": max(toks) if toks else 0,
+            "total": sum(toks),
+        },
+        "rows": rows,
+    }
+
+
+def format_report(report: dict) -> str:
+    """Human-readable summary (the default stdout)."""
+    out: list[str] = []
+    out.append("── memory-quality eval ──────────────────────────────────")
+    out.append(
+        f"backend={report['backend']}  judge={report['judge']}  "
+        f"questions={report['total']}"
+    )
+    out.append(
+        f"accuracy           : {report['accuracy']:.1%}  "
+        f"({report['correct']}/{report['total']})"
+    )
+    ab = report["abstention"]
+    if ab["rate"] is not None:
+        out.append(
+            f"abstention rate    : {ab['rate']:.1%}  "
+            f"({ab['correct']}/{ab['n']} never-happened questions refused)"
+        )
+    tpr = report["tokens_per_retrieval"]
+    out.append(
+        f"tokens/retrieval   : mean={tpr['mean']}  median={tpr['median']}  "
+        f"max={tpr['max']}  total={tpr['total']}"
+    )
+    out.append("")
+    out.append("per-axis accuracy:")
+    for ax, st in report["per_type"].items():
+        out.append(f"  {ax:<24} {st['accuracy']:.1%}  ({st['correct']}/{st['n']})")
+    fails = [r for r in report["rows"] if not r["correct"]]
+    if fails:
+        out.append("")
+        out.append(f"failures ({len(fails)}):")
+        for r in fails:
+            out.append(f"  ✗ {r['id']:<20} [{r['type']}] {r['reason']}")
+    out.append("─────────────────────────────────────────────────────────")
+    return "\n".join(out)
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# CLI
+# ──────────────────────────────────────────────────────────────────────────
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(
+        description="Memory-quality eval harness (LongMemEval-style).")
+    ap.add_argument("--db", type=Path, default=None,
+                    help="snapshot DB to evaluate (copied to temp; read-only). "
+                         "Omit to build the bundled demo corpus.")
+    ap.add_argument("--ground-truth", type=Path, default=DEFAULT_GROUND_TRUTH,
+                    help="ground-truth JSON (default: bundled demo set).")
+    ap.add_argument("--judge", choices=("lexical", "llm"), default="lexical",
+                    help="lexical (default, offline) or llm (needs ANTHROPIC_API_KEY).")
+    ap.add_argument("--llm-model", default="claude-haiku-4-5-20251001",
+                    help="model id for --judge llm.")
+    ap.add_argument("--semantic", action="store_true",
+                    help="use semantic embeddings if installed (default: FTS only).")
+    ap.add_argument("--json", action="store_true",
+                    help="emit the full report as JSON instead of a table.")
+    args = ap.parse_args(argv)
+
+    gt = json.loads(Path(args.ground_truth).read_text())
+
+    tmpdir = Path(tempfile.mkdtemp(prefix="tk-memeval-"))
+    try:
+        if args.db:
+            src = Path(args.db).expanduser()
+            if not src.exists():
+                print(f"ERR: snapshot not found: {src}", file=sys.stderr)
+                return 2
+            # Copy so the user's real DB is never opened for writing.
+            db_path = tmpdir / "snapshot.sqlite"
+            shutil.copy2(src, db_path)
+            seed = False
+        else:
+            db_path = tmpdir / "demo.sqlite"
+            seed = True
+
+        _prepare_env(db_path, semantic=args.semantic)
+        tk = _import_threadkeeper()
+        if seed:
+            seed_corpus(tk["db"].get_db(), gt["corpus"])
+
+        try:
+            report = evaluate(tk, gt, judge=args.judge, llm_model=args.llm_model)
+        except LLMJudgeUnavailable as e:
+            print(f"ERR: {e}", file=sys.stderr)
+            return 3
+
+        if args.json:
+            print(json.dumps(report, indent=2))
+        else:
+            print(format_report(report))
+        return 0
+    finally:
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_memory_eval.py
+++ b/tests/test_memory_eval.py
@@ -1,0 +1,122 @@
+"""Memory-quality eval harness (scripts/memory_eval/run.py, issue #71).
+
+Two layers:
+  • pure-function units — token estimate + the deterministic lexical judge
+    (recall hit, abstention clean, abstention leak), imported in-process
+    because run.py defers all threadkeeper imports into a helper.
+  • an end-to-end smoke test — runs the actual command as a subprocess
+    against the bundled demo corpus and asserts it emits the three headline
+    numbers (accuracy / abstention rate / tokens-per-retrieval) over all five
+    LongMemEval axes. Subprocess keeps the harness's import-time env setup off
+    the shared in-process package state.
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[1]
+RUN_PY = REPO / "scripts" / "memory_eval" / "run.py"
+GROUND_TRUTH = REPO / "scripts" / "memory_eval" / "ground_truth.json"
+
+
+def _load_run_module():
+    """Import run.py by path. Safe in-process: its top level imports no
+    threadkeeper module (those are deferred into _import_threadkeeper)."""
+    spec = importlib.util.spec_from_file_location("memory_eval_run", RUN_PY)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# ── pure functions ────────────────────────────────────────────────────────
+def test_estimate_tokens_counts_words_and_punct():
+    run = _load_run_module()
+    assert run.estimate_tokens("") == 0
+    # 3 words + 1 standalone punctuation token
+    assert run.estimate_tokens("postgres and redis!") == 4
+
+
+def test_judge_lexical_recall_hit_and_miss():
+    run = _load_run_module()
+    item = {"gold_any": ["PostgreSQL", "Postgres"]}
+    ok, _ = run.judge_lexical(item, "we chose postgresql as the database")
+    assert ok is True
+    miss, _ = run.judge_lexical(item, "we chose mysql instead")
+    assert miss is False
+
+
+def test_judge_lexical_gold_all_requires_every_fact():
+    run = _load_run_module()
+    item = {"gold_all": ["Stripe", "eu-central-1"]}
+    assert run.judge_lexical(item, "stripe in eu-central-1")[0] is True
+    assert run.judge_lexical(item, "stripe only")[0] is False
+
+
+def test_judge_lexical_abstention_clean_vs_leak():
+    run = _load_run_module()
+    item = {"abstain": True, "trap_substrings": ["migrated to kubernetes"]}
+    # faithful context: no fabricated claim surfaced → correct refusal
+    clean, _ = run.judge_lexical(item, "we considered kubernetes but stayed on ecs")
+    assert clean is True
+    # a hallucinated/leaked claim → abstention failure
+    leak, reason = run.judge_lexical(item, "we migrated to kubernetes last week")
+    assert leak is False
+    assert "trap" in reason
+
+
+# ── end-to-end smoke ──────────────────────────────────────────────────────
+@pytest.fixture(scope="module")
+def smoke_report():
+    """Run the real command once (FTS backend, lexical judge) and parse JSON."""
+    proc = subprocess.run(
+        [sys.executable, str(RUN_PY), "--json"],
+        cwd=str(REPO), capture_output=True, text=True, timeout=180,
+    )
+    assert proc.returncode == 0, f"runner failed: {proc.stderr}\n{proc.stdout}"
+    return json.loads(proc.stdout)
+
+
+def test_smoke_emits_headline_metrics(smoke_report):
+    r = smoke_report
+    # the three numbers the acceptance criteria require
+    assert "accuracy" in r
+    assert r["abstention"]["rate"] is not None
+    assert r["tokens_per_retrieval"]["total"] > 0
+    assert r["tokens_per_retrieval"]["mean"] > 0
+    assert r["backend"] == "fts"  # default run is offline / no embeddings
+
+
+def test_smoke_covers_all_five_axes(smoke_report):
+    axes = set(smoke_report["per_type"])
+    assert axes == {
+        "information_extraction", "multi_session_reasoning",
+        "temporal_reasoning", "knowledge_update", "abstention",
+    }
+
+
+def test_smoke_golden_baseline_is_perfect(smoke_report):
+    """The bundled demo corpus is a golden fixture: a faithful retrieval
+    recalls every gold fact and never leaks a fabricated one. A regression in
+    search()/dialog_search() would drop this below 1.0."""
+    r = smoke_report
+    assert r["accuracy"] == 1.0, r["rows"]
+    assert r["abstention"]["rate"] == 1.0
+    assert r["abstention"]["n"] >= 10  # abstention is the high-payoff axis
+
+
+def test_llm_judge_without_key_exits_cleanly():
+    """--judge llm with no ANTHROPIC_API_KEY must fail fast, not crash."""
+    import os
+    env = {k: v for k, v in os.environ.items() if k != "ANTHROPIC_API_KEY"}
+    proc = subprocess.run(
+        [sys.executable, str(RUN_PY), "--judge", "llm"],
+        cwd=str(REPO), capture_output=True, text=True, timeout=180, env=env,
+    )
+    assert proc.returncode == 3
+    assert "ANTHROPIC_API_KEY" in proc.stderr


### PR DESCRIPTION
## What

Adds a **memory-quality eval harness** (`scripts/memory_eval/run.py`) that measures thread-keeper's *retrieval* surface — the real `search()` / `dialog_search()` / `brief()` tools — as systems-under-test, modeled on [LongMemEval](https://arxiv.org/pdf/2410.10813) (ICLR 2025) plus mem0's 2026 [tokens-per-retrieval](https://mem0.ai/blog/ai-memory-benchmarks-in-2026) cost axis.

thread-keeper measured write *precision* (the extract-candidate ledger) but never retrieval *recall*, or whether `brief()`/`search()` surface stale or fabricated facts — so the planned lessons-decay (#27) and bi-temporal (#28) work would ship with no number to optimize against. This closes that gap.

## Reports three headline numbers over a fixed ground-truth set

- **accuracy** — per the five LongMemEval axes: information extraction, multi-session reasoning, temporal reasoning, knowledge updates, abstention.
- **abstention rate** — of the *never-happened* questions, the fraction correctly refused. The highest-payoff axis: it directly measures whether auto-injected `brief()` context fabricates or surfaces stale facts.
- **tokens-per-retrieval** — mean / median / max tokens of what each query returns, so recall is never read apart from cost.

```
── memory-quality eval ──────────────────────────────────
backend=fts  judge=lexical  questions=52
accuracy           : 100.0%  (52/52)
abstention rate    : 100.0%  (12/12 never-happened questions refused)
tokens/retrieval   : mean=80.6  median=42  max=271  total=4193
per-axis accuracy:
  information_extraction   100.0%  (18/18)
  multi_session_reasoning  100.0%  (8/8)
  temporal_reasoning       100.0%  (8/8)
  knowledge_update         100.0%  (6/6)
  abstention               100.0%  (12/12)
```

## Design

- **Default judge is lexical** — deterministic substring scorer (gold recall; abstention = no fabricated `trap_substring` leaks). Offline, no API key, no embeddings → reproducible and CI-safe.
- **Optional `--judge llm`** — grades answer *reasoning* (true temporal ordering, knowledge-update correctness) via the Anthropic Messages API over `urllib` (no SDK dependency); fails fast with exit 3 if `ANTHROPIC_API_KEY` is unset.
- **Bundled fixture** (`scripts/memory_eval/ground_truth.json`) — a fictional "billing service" told across three sessions; a **golden baseline** where faithful retrieval scores 100%, so a regression in the retrieval tools drops the number.
- **`--db snapshot.sqlite` runs read-only** — the snapshot is copied to a throwaway temp file; the original is never opened for writing (verified: mtime unchanged).
- **Backend auto-detected** (`fts` vs `semantic`) and reported. `--semantic` opts into embeddings if installed.
- Wired as an optional `scripts/` harness, **not CI-gating** initially (per the issue).

## Acceptance criteria

- [x] A reproducible command produces accuracy / abstention / tokens-per-retrieval numbers over the ground-truth set.
- [x] The harness is documented (README "Memory-quality evaluation" + docs/ARCHITECTURE.md axis-mapping) and runs read-only against a snapshot DB.
- [x] New `scripts/` harness + small fixture set; smoke test that the runner executes (`tests/test_memory_eval.py`, 8 tests).
- [x] README section on memory-quality evaluation.

## Tests

`tests/test_memory_eval.py` — pure-function units (token estimate, lexical judge: recall hit/miss, gold_all, abstention clean vs leak) + an end-to-end subprocess smoke that asserts the three headline numbers across all five axes and that `--judge llm` without a key exits cleanly.

Full suite green on this branch: **868 passed, 1 skipped, 0 failed** (`env -u THREADKEEPER_NO_EMBEDDINGS .venv/bin/python -m pytest -q`).

## Docs

README ("Memory-quality evaluation"), docs/ARCHITECTURE.md (axis-mapping table + harness internals), docs/ROADMAP.md (#71 → ✅ DONE), CHANGELOG.md (Unreleased → Added).

Closes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)