### PR TITLE
feat(eval): offline learning-loop decision-quality eval harness (#72)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,31 @@ version bumps follow semver per the policy in
 
 ### Added
 
+- **Offline eval harness for learning-loop decision quality (#72).** The
+  quality-control daemons (`shadow_review`, `candidate_reviewer`, `curator`)
+  each make accept/reject/materialize calls, but there was no way to measure
+  whether those calls were good — the codebase had decision telemetry but no
+  labeled set and no precision/recall. New `threadkeeper/eval/` package
+  (`python -m threadkeeper.eval`) replays the daemon rubrics over a small,
+  hand-labeled, **anonymized** fixture set (`threadkeeper/eval/fixtures/` —
+  dialog windows + expected materialize/skip, candidate snippets + expected
+  accept/reject, skill bodies + a human quality label) and reports
+  **precision / recall / F1** for the shadow-review and candidate decisions plus
+  a calibrated **judge↔human agreement** (accuracy + Cohen's kappa) for the
+  open-ended "is this skill high quality" question, surfaced with the same
+  `PASS/PARTIAL/FAIL` verdict as `verify_ingest`. The default **rubric** judge
+  is deterministic and offline (no API key): each fixture's human-tagged rubric
+  *signals* only count when their anchor phrase is still present in the **live**
+  daemon prompt section, so editing a rubric (dropping a criterion) deactivates
+  those signals and **moves the metric** — a regression CI catches against the
+  golden baseline. `--judge llm` replays the *actual* prompts over the Anthropic
+  Messages API (urllib, no SDK) for the high-fidelity measurement when a key is
+  set. Fixtures are fully synthetic (a test asserts no secrets/private paths);
+  `--fixtures-dir` scores a custom labeled set. Modeled on the evidently.ai
+  LLM-as-a-judge guidance (calibrate judge↔human agreement before trusting
+  scores) and complementary to the memory-recall harness (#71). New
+  `tests/test_eval_harness.py`; ARCHITECTURE gets an "Evaluating the learning
+  loop" section.
 - **Concepts store gets an eviction/consolidation path + a live evidence signal
   (#75).** The `concepts` table was write-only / grow-only: no
   remove/consolidate/confidence tool, auto-registered entries piling up, and

--- a/README.md
+++ b/README.md
@@ -803,6 +803,53 @@ reusable verdict logic lives in `threadkeeper/verify_ingest.py`.
 
 ---
 
+## Evaluating learning-loop decision quality
+
+`verify_ingest` answers *"did we capture the data?"*. The decision-quality
+harness answers the orthogonal question — *"when the shadow-review and
+candidate-reviewer daemons make a materialize/skip or accept/reject call, are
+those calls **right**?"* The codebase has decision telemetry but no labeled
+set and no precision/recall ([roadmap issue
+#72](https://github.com/po4erk91/thread-keeper/issues/72)); this harness adds
+both, modeled on the
+[evidently.ai LLM-as-a-judge guide](https://www.evidentlyai.com/llm-guide/llm-as-a-judge)
+(build a labeled set, measure judge↔human agreement, calibrate before trusting
+a judge).
+
+```bash
+python -m threadkeeper.eval                 # bundled golden fixtures, offline rubric judge
+python -m threadkeeper.eval --json          # machine-readable report
+python -m threadkeeper.eval --judge llm     # replay the real prompt (needs ANTHROPIC_API_KEY)
+python -m threadkeeper.eval --fixtures-dir my_labels/   # your own labeled set
+```
+
+It reports, over a small **hand-labeled, anonymized** fixture set checked into
+`threadkeeper/eval/fixtures/`:
+
+- **precision / recall / F1** for the shadow-review (materialize vs skip) and
+  candidate-reviewer (accept vs reject) decisions, against the human labels.
+- **judge ↔ human agreement** (raw accuracy + Cohen's kappa) for the
+  open-ended *"is this a high-quality skill?"* judgment — the calibration
+  number that makes a drifting judge visible.
+- a `PASS` / `PARTIAL` / `FAIL` verdict on **harness readiness** (enough labels
+  with both classes present), surfaced the same way as `verify_ingest` — *not*
+  a fixed quality threshold.
+
+The default **rubric** judge is deterministic, offline, and needs no API key:
+each fixture carries the human-tagged rubric *signals* it contains, and a
+signal only counts if its anchor phrase is still present in the **live** daemon
+prompt — so editing a rubric (dropping a signal class) deactivates those
+signals and **moves the metric**, which CI catches as a regression against the
+golden baseline. `--judge llm` replays the *actual* `SHADOW_REVIEW_PROMPT` /
+`CANDIDATE_REVIEW_PROMPT` over each item and parses the daemon's own verdict —
+the high-fidelity measurement, when a key is set. The fixtures are fully
+synthetic (a test asserts they carry no secrets or private paths); point
+`--fixtures-dir` at your own labeled set to score real decisions. See
+[docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for how the harness couples to the
+daemon prompts.
+
+---
+
 ## Tests
 
 ```bash
@@ -826,6 +873,7 @@ threadkeeper/
 ├── identity.py           # session, self-cid, daemon launchers
 ├── ingest.py             # adapter-driven transcript ingest
 ├── verify_ingest.py      # cross-CLI production verification verdict
+├── eval/                 # offline learning-loop decision-quality harness (python -m threadkeeper.eval)
 ├── brief.py              # render_brief / render_context
 ├── shadow_review.py      # autonomous learning observer
 ├── i18n.py               # 10 locales of regex + prompt bundles

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -20,6 +20,7 @@ threadkeeper/
 ├── identity.py        per-process session + self-cid + daemon launchers
 ├── ingest.py          live ingest of jsonl transcripts + skill_usage backfill
 ├── verify_ingest.py   cross-CLI production verification — slot coverage + PASS/PARTIAL/FAIL verdict (issue #1)
+├── eval/              offline learning-loop decision-quality harness — precision/recall/F1 + judge↔human agreement (issue #72)
 ├── embeddings.py      pluggable backend (ONNX/fastembed default; ST fallback), cosine search
 ├── migrate_embeddings.py  CLI: recompute stored vectors after a backend switch
 ├── helpers.py         ID generators, fmt_age, q-quoting, alive-pid check
@@ -753,6 +754,57 @@ tests/
 Run: `.venv/bin/python -m pytest tests/ -q`. Currently 495 tests (1 skipped),
 all green. Smoke parametrization automatically picks up any new tools without
 having to add tests.
+
+## Evaluating the learning loop
+
+`verify_ingest.py` measures the *ingest plumbing* (did rows land, does shadow
+span >1 adapter). `threadkeeper/eval/` measures the orthogonal axis —
+**decision quality**: when `shadow_review` calls materialize-vs-skip and
+`candidate_reviewer` calls accept-vs-reject, are those calls right? There was
+no labeled set and no precision/recall before this harness (issue #72); the
+shadow rubric hard-codes a class-vs-incident decision but nothing scored how
+often it's correct.
+
+The harness (`python -m threadkeeper.eval`, pure verdict logic in
+`threadkeeper/eval/harness.py`) has three parts, surfaced with the same
+`PASS/PARTIAL/FAIL` verdict shape as `verify_ingest`:
+
+- **Fixtures** (`threadkeeper/eval/fixtures/*.json`) — small, hand-labeled,
+  fully-synthetic sets: `shadow.json` (dialog windows + expected
+  materialize/skip), `candidates.json` (candidate snippets + expected
+  accept/reject), and `skill_quality.json` (skill bodies + a human high/low
+  label). `test_eval_harness.py` asserts they carry no secrets/private paths.
+- **Two judges** (mirroring the `verify_ingest` / memory-recall split between an
+  offline CI-safe path and an LLM path):
+  - `rubric` (default, deterministic, offline) — a *signal-vote* classifier
+    **coupled to the live daemon prompt**. Each fixture item carries the human
+    rubric `signals` it contains (`stated_policy`, `false_positive`, …); each
+    signal maps to an `anchor` phrase, and a signal only votes if its anchor is
+    present **in its decision's section of the current prompt**
+    (`SHADOW_SECTIONS` / `CANDIDATE_SECTIONS`, with graceful fallback to
+    whole-prompt presence if a section header was reworded). So editing a rubric
+    — dropping a materialize/reject criterion — deactivates the signals anchored
+    to it and **moves the precision/recall**, deterministically and offline.
+    Calibrated so the golden fixtures classify cleanly, the offline judge is a
+    cheap regression guard: a rubric edit that silently drops a criterion shows
+    up as an F1 drop in CI.
+  - `llm` (opt-in, needs `ANTHROPIC_API_KEY`) — replays the *actual*
+    `SHADOW_REVIEW_PROMPT` / `CANDIDATE_REVIEW_PROMPT` (plus the same
+    `<observed_dialog>` data fence the daemons use) over each item via the
+    Anthropic Messages API over `urllib` (no SDK), and parses the daemon's own
+    verdict contract. This is the high-fidelity decision-quality measurement; a
+    prompt edit obviously moves it because the model reads the edited prompt.
+- **Calibration** — the skill-quality axis reports judge↔human **agreement**
+  (raw accuracy + Cohen's kappa). Per the evidently.ai LLM-as-a-judge guidance,
+  agreement against a fixed human-labeled set is what makes a drifting judge
+  (offline heuristic or LLM) visible before its scores are trusted.
+
+The CLI exits non-zero only when the harness itself is broken (no fixtures /
+nothing computable), never on model quality — quality is a number to track and
+optimize against (e.g. the ROADMAP's extract-precision and "do we need tiers"
+open questions), not a gate. `--fixtures-dir` scores a custom labeled set.
+Smoke-tested in `tests/test_eval_harness.py` (pure-function units +
+rubric-sensitivity + a subprocess end-to-end run).
 
 ## Env knobs (config.py)
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -421,7 +421,24 @@ verified at the cited file:line, deduplicated against the issues above):
 - Memory **recall/abstention** eval harness (LongMemEval-style QA + abstention
   + tokens-per-retrieval) to give the lessons-decay (#27) and bi-temporal
   (#28) work a number to optimize against — complementary to the learning-loop
-  **decision-quality** harness (#72) (#71).
+  **decision-quality** harness below (#71).
+- ✅ DONE (#72). Learning-loop **decision-quality** eval harness. The
+  quality-control daemons (`shadow_review`, `candidate_reviewer`, `curator`)
+  make accept/reject/materialize calls with decision telemetry but no labeled
+  set and no precision/recall — nothing scored how often the hard-coded
+  class-vs-incident rubric was right. New `threadkeeper/eval/`
+  (`python -m threadkeeper.eval`) replays the *current* daemon rubrics over a
+  small hand-labeled, anonymized fixture set and reports precision/recall/F1 for
+  the shadow-review and candidate decisions plus a calibrated judge↔human
+  agreement (accuracy + Cohen's kappa) on the open-ended "is this skill high
+  quality" question, with a `verify_ingest`-style PASS/PARTIAL/FAIL verdict on
+  harness readiness. Default **rubric** judge is offline/deterministic and
+  section-coupled to the live prompt, so editing a rubric *moves the metric*
+  (caught in CI against the golden baseline); `--judge llm` replays the actual
+  prompts for the high-fidelity number. This gives the ROADMAP's own open
+  questions — **extract precision re-measurement** and **"do we even need
+  tiers — metric not collected"** — a harness to measure against; point
+  `--fixtures-dir` at a production-derived labeled set to collect those numbers.
 - MCP **tool annotations** (`readOnly`/`destructive`/`idempotent` hints) +
   structured output across the tool registry (independently confirmed; canonical
   issue #67) — gives hosts a mechanical read-vs-write signal and composes with

--- a/tests/test_eval_harness.py
+++ b/tests/test_eval_harness.py
@@ -1,0 +1,219 @@
+"""Learning-loop decision-quality eval harness (threadkeeper/eval, issue #72).
+
+Three layers, mirroring test_memory_eval.py:
+  • pure-function units — metrics (precision/recall/F1), Cohen's kappa, the
+    deterministic rubric classifier, and the skill-quality heuristic. These
+    import nothing heavy, so they run in-process.
+  • rubric-sensitivity — the acceptance criterion "editing a daemon rubric and
+    re-running moves the metric", proven offline by perturbing the live prompt
+    and asserting the F1 drops (no API key needed).
+  • end-to-end smoke — runs `python -m threadkeeper.eval --json` as a
+    subprocess against the bundled golden fixtures and asserts it computes the
+    headline metrics (precision/recall/F1 + judge↔human agreement) and a PASS
+    verdict, NOT a fixed quality threshold.
+Plus a fixtures-have-no-secrets guard for the "fixtures contain no secrets/
+private paths" acceptance criterion.
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+from threadkeeper.eval import harness as h
+
+REPO = Path(__file__).resolve().parents[1]
+FIXTURES = REPO / "threadkeeper" / "eval" / "fixtures"
+
+
+# ── pure functions: metrics ────────────────────────────────────────────────
+def test_binary_metrics_precision_recall_f1():
+    # 2 TP, 1 FP, 1 FN, 1 TN
+    pairs = [("pos", "pos"), ("pos", "pos"), ("pos", "neg"),
+             ("neg", "pos"), ("neg", "neg")]
+    m = h.binary_metrics(pairs, "pos")
+    assert (m["tp"], m["fp"], m["fn"], m["tn"]) == (2, 1, 1, 1)
+    assert m["precision"] == round(2 / 3, 4)
+    assert m["recall"] == round(2 / 3, 4)
+    assert m["f1"] == round(2 / 3, 4)
+
+
+def test_binary_metrics_undefined_when_no_positives_predicted():
+    m = h.binary_metrics([("neg", "neg"), ("neg", "neg")], "pos")
+    assert m["precision"] is None and m["recall"] is None and m["f1"] is None
+
+
+def test_cohen_kappa_perfect_and_chance():
+    perfect = [("a", "a"), ("b", "b"), ("a", "a"), ("b", "b")]
+    assert h.cohen_kappa(perfect) == 1.0
+    # one disagreement out of four → kappa strictly below 1
+    mixed = [("a", "a"), ("b", "b"), ("a", "b"), ("b", "b")]
+    k = h.cohen_kappa(mixed)
+    assert k is not None and k < 1.0
+
+
+def test_agreement_shape():
+    agr = h.agreement([("high", "high"), ("low", "high")])
+    assert agr["n"] == 2
+    assert agr["accuracy"] == 0.5
+    assert agr["kappa"] is not None
+
+
+# ── pure functions: rubric classifier ───────────────────────────────────────
+def test_rubric_predict_votes_via_present_anchor():
+    prompt = "CLASS-LEVEL signals (materialize):\n- a workflow rule\nNOT class-level (skip):\n- one-off task\nPROCEDURE"
+    reg = {
+        "stated_policy": {"label": "materialize", "anchor": "workflow rule"},
+        "one_off_task": {"label": "skip", "anchor": "one-off task"},
+    }
+    sections = h.SHADOW_SECTIONS
+    pred, _ = h.rubric_predict(prompt, ["stated_policy"], reg, "skip", sections)
+    assert pred == "materialize"
+    pred, _ = h.rubric_predict(prompt, ["one_off_task"], reg, "skip", sections)
+    assert pred == "skip"
+
+
+def test_rubric_predict_deactivates_when_section_loses_anchor():
+    """A signal stops voting once its anchor leaves its rubric section."""
+    reg = {"stated_policy": {"label": "materialize", "anchor": "workflow rule"}}
+    with_anchor = "CLASS-LEVEL signals (materialize):\n- a workflow rule\nNOT class-level (skip):\n- x\nPROCEDURE"
+    without = "CLASS-LEVEL signals (materialize):\n- a debugging insight\nNOT class-level (skip):\n- x\nPROCEDURE"
+    assert h.rubric_predict(with_anchor, ["stated_policy"], reg, "skip",
+                            h.SHADOW_SECTIONS)[0] == "materialize"
+    # anchor gone from the materialize section → falls back to default
+    assert h.rubric_predict(without, ["stated_policy"], reg, "skip",
+                            h.SHADOW_SECTIONS)[0] == "skip"
+
+
+def test_rubric_predict_tie_falls_back_to_default():
+    prompt = "CLASS-LEVEL signals (materialize):\n- a workflow rule\nNOT class-level (skip):\n- one-off task\nPROCEDURE"
+    reg = {
+        "stated_policy": {"label": "materialize", "anchor": "workflow rule"},
+        "one_off_task": {"label": "skip", "anchor": "one-off task"},
+    }
+    pred, reason = h.rubric_predict(prompt, ["stated_policy", "one_off_task"],
+                                    reg, "skip", h.SHADOW_SECTIONS)
+    assert pred == "skip" and "tie" in reason
+
+
+# ── pure functions: quality heuristic ───────────────────────────────────────
+def test_quality_heuristic_high_and_low_cases():
+    high, _ = h.quality_heuristic(
+        "verify-state-transition",
+        "Use when asserting a result after navigating between screens.",
+        "Assert that the destination state actually changed, not merely that "
+        "a label exists on the screen.")
+    assert high == "high"
+    # negative-claim constraint
+    assert h.quality_heuristic("x", "notes", "the browser tools do not work")[0] == "low"
+    # incident-scoped name
+    assert h.quality_heuristic("fix-login-pr-1234", "how we fixed it",
+                               "edited the handler and it passed now")[0] == "low"
+    # missing description
+    assert h.quality_heuristic("x", "", "a body with several words here ok")[0] == "low"
+    # too thin
+    assert h.quality_heuristic("x", "use it", "too short")[0] == "low"
+    # bloated
+    assert h.quality_heuristic("x", "use it", "word " * 700)[0] == "low"
+
+
+# ── rubric sensitivity: editing the rubric moves the metric ─────────────────
+def test_editing_shadow_rubric_moves_the_metric():
+    """Acceptance criterion: a daemon-rubric edit changes the offline F1."""
+    fx = h.load_fixtures(FIXTURES)["shadow"]
+    prompt = h.get_shadow_prompt()
+
+    def f1(p):
+        pairs = [(h.rubric_predict(p, it.get("signals", []), h.SHADOW_SIGNALS,
+                                   "skip", h.SHADOW_SECTIONS)[0], it["label"])
+                 for it in fx]
+        return h.binary_metrics(pairs, "materialize")["f1"]
+
+    base = f1(prompt)
+    assert base == 1.0, "golden fixtures should classify cleanly on the live rubric"
+    # remove the stated-policy materialize criterion from the rubric section
+    edited = prompt.replace("a workflow rule the user stated as policy", "")
+    assert f1(edited) < base
+
+
+def test_editing_candidate_rubric_moves_the_metric():
+    fx = h.load_fixtures(FIXTURES)["candidate"]
+    prompt = h.get_candidate_prompt()
+
+    def f1(p):
+        pairs = [(h.rubric_predict(p, it.get("signals", []),
+                                   h.CANDIDATE_SIGNALS, "reject",
+                                   h.CANDIDATE_SECTIONS)[0], it["label"])
+                 for it in fx]
+        return h.binary_metrics(pairs, "accept")["f1"]
+
+    base = f1(prompt)
+    assert base == 1.0
+    edited = prompt.replace("class-level rule worth a durable SKILL.md",
+                            "worth a durable SKILL.md")
+    assert f1(edited) < base
+
+
+# ── end-to-end smoke ────────────────────────────────────────────────────────
+def _run_cli(*args, env=None):
+    return subprocess.run(
+        [sys.executable, "-m", "threadkeeper.eval", *args],
+        cwd=str(REPO), capture_output=True, text=True, timeout=180, env=env)
+
+
+def test_cli_computes_metrics_and_passes():
+    proc = _run_cli("--json")
+    assert proc.returncode == 0, f"runner failed: {proc.stderr}\n{proc.stdout}"
+    r = json.loads(proc.stdout)
+    # the metrics the acceptance criteria require, all present and computed
+    assert r["shadow"]["precision"] is not None
+    assert r["shadow"]["recall"] is not None
+    assert r["shadow"]["f1"] is not None
+    assert r["candidate"]["f1"] is not None
+    assert r["quality"]["accuracy"] is not None  # judge↔human agreement
+    assert r["quality"]["kappa"] is not None
+    assert r["judge"] == "rubric"
+
+
+def test_cli_golden_baseline_is_clean():
+    """The bundled fixtures are a golden set: the offline rubric judge agrees
+    with the human labels, so any future rubric edit that drops a criterion
+    shows up as a metric regression here."""
+    r = json.loads(_run_cli("--json").stdout)
+    assert r["shadow"]["f1"] == 1.0, r["shadow"]["rows"]
+    assert r["candidate"]["f1"] == 1.0, r["candidate"]["rows"]
+    assert r["quality"]["accuracy"] == 1.0, r["quality"]["rows"]
+    assert r["verdict"] == "PASS"
+    # both decision axes carry enough labels with both classes present
+    assert r["shadow"]["ready"] and r["candidate"]["ready"] and r["quality"]["ready"]
+
+
+def test_cli_llm_judge_without_key_exits_cleanly():
+    env = {k: v for k, v in os.environ.items() if k != "ANTHROPIC_API_KEY"}
+    proc = _run_cli("--judge", "llm", env=env)
+    assert proc.returncode == 3
+    assert "ANTHROPIC_API_KEY" in proc.stderr
+
+
+# ── fixtures contain no secrets / private paths ─────────────────────────────
+_SECRET_PATTERNS = [
+    re.compile(r"/Users/[A-Za-z0-9]"),       # macOS home paths
+    re.compile(r"/home/[A-Za-z0-9]"),        # linux home paths
+    re.compile(r"\bsk-[A-Za-z0-9]{16,}"),    # API-key-ish tokens
+    re.compile(r"AKIA[0-9A-Z]{12,}"),        # AWS access key id
+    re.compile(r"BEGIN [A-Z ]*PRIVATE KEY"),  # PEM private keys
+    re.compile(r"xox[baprs]-[A-Za-z0-9-]{8,}"),  # slack tokens
+    re.compile(r"password\s*[=:]\s*\S", re.I),
+]
+
+
+def test_fixtures_have_no_secrets_or_private_paths():
+    for name in ("shadow.json", "candidates.json", "skill_quality.json"):
+        text = (FIXTURES / name).read_text()
+        # valid JSON
+        json.loads(text)
+        for pat in _SECRET_PATTERNS:
+            assert not pat.search(text), f"{name} matched secret pattern {pat.pattern!r}"

--- a/threadkeeper/eval/__init__.py
+++ b/threadkeeper/eval/__init__.py
@@ -1,0 +1,24 @@
+"""Offline eval harness for learning-loop decision quality (issue #72).
+
+Where ``threadkeeper/verify_ingest.py`` (issue #1) and the memory-recall
+harness (issue #71) measure *plumbing* and *retrieval*, this package measures
+**decision quality**: when the shadow-review / candidate-reviewer daemons make
+a materialize/skip or accept/reject call, are those calls *right*?
+
+It does so over a small, hand-labeled, **anonymized** fixture set checked into
+``threadkeeper/eval/fixtures/`` and reports precision / recall / F1 for the two
+binary decision loops plus a calibrated judge-vs-human agreement number for the
+open-ended "is this a high-quality skill?" question. See
+``harness.py`` for the design and :mod:`threadkeeper.eval.__main__` for the CLI
+(``python -m threadkeeper.eval``).
+"""
+from .harness import (  # noqa: F401
+    run_eval,
+    format_report,
+    main,
+    binary_metrics,
+    cohen_kappa,
+    agreement,
+    rubric_predict,
+    quality_heuristic,
+)

--- a/threadkeeper/eval/__main__.py
+++ b/threadkeeper/eval/__main__.py
@@ -1,0 +1,5 @@
+"""``python -m threadkeeper.eval`` entry point (issue #72)."""
+from .harness import main
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/threadkeeper/eval/fixtures/candidates.json
+++ b/threadkeeper/eval/fixtures/candidates.json
@@ -1,0 +1,75 @@
+{
+  "_doc": "Hand-labeled, anonymized fixtures for the candidate-reviewer decision (issue #72). Each item is a harvested candidate snippet with a human ACCEPT/REJECT label and the rubric signal classes a human reader saw. Fully synthetic — no real paths, secrets, or private content. ACCEPT = a genuine note/verbatim/skill; REJECT = a false positive that slipped past extract's noise filters.",
+  "items": [
+    {
+      "id": "cand-classrule-1",
+      "kind": "skill",
+      "content": "When a UI selector matches a text label but the tap doesn't advance the screen, re-target the underlying interactive control by its automation id — the visible label node is often not hit-testable.",
+      "signals": ["class_level_rule"],
+      "label": "accept"
+    },
+    {
+      "id": "cand-classrule-2",
+      "kind": "skill",
+      "content": "For cross-language matching, embedding cosine over short titles is language-sensitive: mirror a language-independent signal (shared tags/entities) so same-topic items in another language aren't silently dropped.",
+      "signals": ["class_level_rule"],
+      "label": "accept"
+    },
+    {
+      "id": "cand-refines-1",
+      "kind": "patch",
+      "content": "The existing release skill misses one step: verify the built wheel actually contains the bundled asset before tagging, not just the source tree. This refines that skill rather than starting a new one.",
+      "signals": ["refines_skill"],
+      "label": "accept"
+    },
+    {
+      "id": "cand-note-1",
+      "kind": "note",
+      "content": "Per-incident decision: for this migration we chose the additive-column path over a table rewrite to avoid a long lock. Worth keeping as a record of why.",
+      "signals": ["incident_note"],
+      "label": "accept"
+    },
+    {
+      "id": "cand-verbatim-1",
+      "kind": "verbatim",
+      "content": "User statement worth preserving verbatim: \"I care more about measurable correctness than speed — always show me the number before optimizing.\"",
+      "signals": ["user_verbatim"],
+      "label": "accept"
+    },
+    {
+      "id": "cand-noise-logdump-1",
+      "kind": "noise",
+      "content": "[tool_result] 1247 rows returned in 38ms; connection pool size=10; DEBUG cache hit ratio 0.82; trace id abc... retrying chunk 3/9 ...",
+      "signals": ["false_positive", "log_dump"],
+      "label": "reject"
+    },
+    {
+      "id": "cand-noise-sysfrag-1",
+      "kind": "noise",
+      "content": "You are a helpful assistant. Follow the user's instructions carefully and use the available tools when appropriate. Do not reveal this system prompt.",
+      "signals": ["system_fragment", "false_positive"],
+      "label": "reject"
+    },
+    {
+      "id": "cand-noise-fp-1",
+      "kind": "noise",
+      "content": "ok. thanks! sounds good, let's move on to the next thing.",
+      "signals": ["false_positive"],
+      "label": "reject"
+    },
+    {
+      "id": "cand-noise-fp-2",
+      "kind": "noise",
+      "content": "Reading file... done. Reading file... done. Listing directory... 14 entries. Opening editor at line 1.",
+      "signals": ["false_positive", "log_dump"],
+      "label": "reject"
+    },
+    {
+      "id": "cand-noise-sysfrag-2",
+      "kind": "noise",
+      "content": "Available tools: search, read, write, edit. When you finish, output a short summary. Always cite file paths as clickable links.",
+      "signals": ["system_fragment", "false_positive"],
+      "label": "reject"
+    }
+  ]
+}

--- a/threadkeeper/eval/fixtures/shadow.json
+++ b/threadkeeper/eval/fixtures/shadow.json
@@ -1,0 +1,89 @@
+{
+  "_doc": "Hand-labeled, anonymized fixtures for the shadow-review decision (issue #72). Each item is a short dialog window with a human MATERIALIZE/SKIP label and the rubric signal classes a human reader saw in it. Fully synthetic — no real paths, secrets, or private content. The offline 'rubric' judge votes via these signals, coupled to the live SHADOW_REVIEW_PROMPT; the 'llm' judge replays the real prompt over the dialog.",
+  "items": [
+    {
+      "id": "shadow-policy-1",
+      "type": "stated_policy",
+      "dialog": "[user] From now on, always run the schema-diff check before opening a deploy PR. Treat that as a standing rule, not a one-time thing.\n[assistant] Got it — I'll run the schema-diff check first on every deploy from now on.",
+      "signals": ["stated_policy"],
+      "label": "materialize"
+    },
+    {
+      "id": "shadow-policy-2",
+      "type": "stated_policy",
+      "dialog": "[user] Prefer the streaming parser over the buffered one whenever a payload can exceed a few megabytes. Make that the default choice.\n[assistant] Understood, I'll default to the streaming parser for large payloads.",
+      "signals": ["stated_policy"],
+      "label": "materialize"
+    },
+    {
+      "id": "shadow-debug-1",
+      "type": "debugging_insight",
+      "dialog": "[assistant] The flaky test wasn't a timing issue. The pattern is: a stale element handle is cached after the list re-renders, so any later tap targets the old node. The general fix is to re-query the handle after any list mutation, not to add sleeps.\n[user] yes that's the real root cause, good.",
+      "signals": ["debugging_insight"],
+      "label": "materialize"
+    },
+    {
+      "id": "shadow-debug-2",
+      "type": "debugging_insight",
+      "dialog": "[assistant] Three bugs were compounding: a cache that wasn't invalidated, an overlay stealing z-order, and a fixture mismatch. The generalizable rule is to bisect compounding failures one layer at a time before assuming a single cause.\n[user] exactly, that's worth remembering.",
+      "signals": ["debugging_insight"],
+      "label": "materialize"
+    },
+    {
+      "id": "shadow-correct-1",
+      "type": "corrected_skill",
+      "dialog": "[user] No — the existing note about that API is wrong. The retry header is honored on the second call, not the first. Update what we have.\n[assistant] Thanks for the correction; the prior guidance was incomplete, I'll fix it.",
+      "signals": ["corrected_skill"],
+      "label": "materialize"
+    },
+    {
+      "id": "shadow-recovery-1",
+      "type": "recovery_procedure",
+      "dialog": "[assistant] To get the local emulator unstuck reliably: reset the proxy state, kill any zombie helper process, then wait for the port to free before relaunching. That sequence recovers it every time.\n[user] good, that procedure has worked for me too.",
+      "signals": ["recovery_procedure"],
+      "label": "materialize"
+    },
+    {
+      "id": "shadow-oneoff-1",
+      "type": "one_off_task",
+      "dialog": "[user] Summarize the changes in this one pull request for me.\n[assistant] Sure — it renames two functions and adds a test. Done.",
+      "signals": ["one_off_task"],
+      "label": "skip"
+    },
+    {
+      "id": "shadow-oneoff-2",
+      "type": "one_off_task",
+      "dialog": "[user] Can you analyze this CSV and tell me the row count by category?\n[assistant] There are 412 rows across 6 categories; here's the breakdown.",
+      "signals": ["one_off_task"],
+      "label": "skip"
+    },
+    {
+      "id": "shadow-confusion-1",
+      "type": "transient_confusion",
+      "dialog": "[assistant] Hm, the import looks broken... wait, I was in the wrong directory. It resolves fine from the project root. Never mind.",
+      "signals": ["transient_confusion"],
+      "label": "skip"
+    },
+    {
+      "id": "shadow-whatis-1",
+      "type": "what_is_question",
+      "dialog": "[user] What does the term 'idempotent' mean again?\n[assistant] It means applying the operation multiple times has the same effect as applying it once.",
+      "signals": ["what_is_question"],
+      "label": "skip"
+    },
+    {
+      "id": "shadow-summary-1",
+      "type": "self_summary",
+      "dialog": "[assistant] Great work by me — to recap what just happened, I read three files, made an edit, and the test passed. Nice and clean.",
+      "signals": ["self_summary"],
+      "label": "skip"
+    },
+    {
+      "id": "shadow-transient-env-1",
+      "type": "transient_env_error",
+      "dialog": "[assistant] The command failed with 'package not found'. After a quick reinstall it worked. Nothing else changed.\n[user] ok cool.",
+      "signals": ["transient_env_error"],
+      "label": "skip"
+    }
+  ]
+}

--- a/threadkeeper/eval/fixtures/skill_quality.json
+++ b/threadkeeper/eval/fixtures/skill_quality.json
@@ -1,0 +1,75 @@
+{
+  "_doc": "Hand-labeled, anonymized fixtures for the open-ended 'is this a high-quality skill?' judgment (issue #72). Each item is a synthetic SKILL.md (name + frontmatter description + body) with a human HIGH/LOW quality label. The harness reports judge-vs-human AGREEMENT (accuracy + Cohen's kappa) so a drifting judge is visible — the offline judge is a deterministic heuristic, the 'llm' judge grades quality with a model. Fully synthetic — no real paths, secrets, or private content.",
+  "items": [
+    {
+      "id": "q-good-state-transition",
+      "name": "verify-state-transition-not-existence",
+      "description": "Use when asserting a result after navigating between screens, to avoid false positives where the asserted label exists on both the source and destination screen.",
+      "body": "## Rule\nAssert that the destination state actually changed, not merely that a label exists. When a flow moves between screens, the success label is often present on the source screen too, so an existence check passes even when the action never happened. Assert on a destination-only marker, or verify the source marker is gone.",
+      "label": "high"
+    },
+    {
+      "id": "q-good-cross-language",
+      "name": "cross-language-matching-cosine-is-sensitive",
+      "description": "Use when a matching, dedup, or clustering pipeline silently misses same-topic items in another language.",
+      "body": "## Rule\nEmbedding cosine over short titles is language-sensitive: same-topic items in different languages score below typical thresholds, so a cosine-only prefilter drops cross-language matches. Mirror a language-independent signal such as shared tags or entities alongside the embedding score.",
+      "label": "high"
+    },
+    {
+      "id": "q-good-recovery",
+      "name": "flaky-emulator-recovery-procedure",
+      "description": "Use before starting a test runner against a local emulator that intermittently hangs.",
+      "body": "## Procedure\nReset the proxy state, kill any zombie helper process, then wait for the port to free before relaunching. Make the reset the default and opt out for speed, so leftover state can never produce a false pass or fail.",
+      "label": "high"
+    },
+    {
+      "id": "q-good-verify-wheel",
+      "name": "release-wheel-asset-verification",
+      "description": "Use when releasing a packaged CLI that depends on bundled non-Python assets, to avoid shipping a wheel that omits them.",
+      "body": "## Rule\nVerify the built wheel and a clean installed artifact actually contain and resolve the bundled assets, instead of trusting the git tag or the source tree. A polluted local environment can mask a missing asset that breaks a fresh install.",
+      "label": "high"
+    },
+    {
+      "id": "q-good-fixture-policy",
+      "name": "make-ad-hoc-fixture-steps-explicit",
+      "description": "Use when an E2E fixture has optional or environment-dependent setup steps.",
+      "body": "## Rule\nMake optional and ad-hoc fixture steps explicit in the scenario rather than relying on ambient state. Implicit setup is the most common source of runs that pass on one machine and fail on another.",
+      "label": "high"
+    },
+    {
+      "id": "q-bad-negclaim",
+      "name": "browser-tools-status",
+      "description": "Notes about the browser tools.",
+      "body": "The browser tools do not work and cannot be used. Do not attempt to call them in any session.",
+      "label": "low"
+    },
+    {
+      "id": "q-bad-incident-pr",
+      "name": "fix-login-redirect-pr-1234",
+      "description": "How we fixed the login redirect in that one change set.",
+      "body": "We edited the redirect handler and the test, and it passed. This documents that specific change for later reference if anyone asks about it.",
+      "label": "low"
+    },
+    {
+      "id": "q-bad-nodesc",
+      "name": "misc-helper",
+      "description": "",
+      "body": "Some assorted helper guidance with no trigger description, so nothing will ever auto-load this skill when it would actually be relevant.",
+      "label": "low"
+    },
+    {
+      "id": "q-bad-thin",
+      "name": "remember-this",
+      "description": "Use sometimes.",
+      "body": "Just remember it.",
+      "label": "low"
+    },
+    {
+      "id": "q-bad-incident-today",
+      "name": "todays-deploy-notes",
+      "description": "Notes about the deploy we ran today and the hiccup we saw.",
+      "body": "The deploy needed a manual retry once and then succeeded; capturing the play-by-play here in case it comes up again.",
+      "label": "low"
+    }
+  ]
+}

--- a/threadkeeper/eval/harness.py
+++ b/threadkeeper/eval/harness.py
@@ -1,0 +1,667 @@
+"""Decision-quality eval harness for the learning loop (issue #72).
+
+The quality-control daemons each make a binary call on every item they see:
+
+  * ``shadow_review``      — MATERIALIZE (write a durable skill) vs SKIP, over a
+                            window of recent dialog.
+  * ``candidate_reviewer`` — ACCEPT (genuine note/skill/verbatim) vs REJECT
+                            (false-positive noise), over a harvested candidate.
+  * ``curator``            — KEEP vs PRUNE, i.e. the open-ended judgment "is this
+                            an entry worth keeping in the library?".
+
+There was no way to tell whether those calls were *good*: the codebase has
+decision telemetry but no labeled set and no precision/recall (issue #72). This
+harness closes that gap with three pieces, modeled on the
+``verify_ingest.py`` PASS/PARTIAL/FAIL surface and the evidently.ai
+LLM-as-a-judge guidance (build a labeled set; measure judge↔human agreement;
+calibrate before trusting a judge's scores):
+
+(a) Fixtures — ``fixtures/shadow.json`` (dialog windows + expected
+    materialize/skip), ``fixtures/candidates.json`` (candidate snippets +
+    expected accept/reject), and ``fixtures/skill_quality.json`` (candidate
+    skill bodies + a human high/low quality label). All hand-written and
+    anonymized; ``test_eval_harness.py`` asserts they carry no secrets/paths.
+
+(b) Two judges, mirroring the memory-recall harness (#71):
+
+    * ``rubric`` (default, offline, deterministic, no API key) — a *signal-vote*
+      classifier that is coupled to the LIVE daemon prompt. Each fixture item
+      carries human ``signals`` (e.g. ``stated_policy``, ``false_positive``);
+      each signal maps to an ``anchor`` phrase that the daemon's rubric ships.
+      A signal only votes for its decision if its anchor is **still present in
+      the current prompt** — so editing the rubric (dropping a signal class)
+      deactivates those signals and *moves the metric* (acceptance criterion
+      #2), deterministically and offline. This is a faithful but cheap stand-in
+      for the LLM; on the bundled golden fixtures it agrees with the human
+      labels, so a rubric edit that drops a criterion shows up as a metric
+      regression in CI.
+
+    * ``llm`` (opt-in, needs ``ANTHROPIC_API_KEY``) — replays the *actual*
+      daemon prompt (``SHADOW_REVIEW_PROMPT`` / ``CANDIDATE_REVIEW_PROMPT``)
+      over each item and parses the daemon's own verdict contract. This is the
+      high-fidelity decision-quality measurement; a prompt edit obviously moves
+      it because the model reads the edited prompt.
+
+(c) Calibration — the skill-quality axis reports judge↔human **agreement**
+    (raw accuracy + Cohen's kappa). A drifting judge (the offline heuristic or
+    the LLM) shows up as falling agreement against the fixed human labels.
+
+The pure functions (metrics, kappa, the rubric classifier, the quality
+heuristic) take their inputs as plain data and import nothing from
+``threadkeeper`` at module load, so they are unit-testable in-process; only the
+live-prompt getters and the LLM backend touch the rest of the package, and they
+defer those imports.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import urllib.request
+from pathlib import Path
+from typing import Iterable, Optional
+
+HERE = Path(__file__).resolve().parent
+FIXTURES_DIR = HERE / "fixtures"
+
+# A decision axis is "ready" (its precision/recall are meaningfully defined)
+# only with enough labels AND both classes present. Below this the harness
+# reports the axis as thin, not as a quality failure.
+MIN_LABELS = 6
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Signal registries — couple a fixture's human signal tags to the LIVE rubric.
+#
+# Each entry: signal_key -> {"label": <decision>, "anchor": <phrase the daemon
+# prompt ships>}. The rubric classifier honors a signal's vote only when its
+# anchor is still present in the current prompt text, so a rubric edit that
+# removes a criterion deactivates the signals that depend on it.
+# ──────────────────────────────────────────────────────────────────────────
+
+# Phrases below are exact substrings of SHADOW_REVIEW_PROMPT's
+# "CLASS-LEVEL signals (materialize)" / "NOT class-level (skip)" sections.
+SHADOW_SIGNALS: dict[str, dict] = {
+    "debugging_insight":   {"label": "materialize", "anchor": "debugging insight"},
+    "stated_policy":       {"label": "materialize", "anchor": "workflow rule"},
+    "corrected_skill":     {"label": "materialize", "anchor": "corrected misunderstanding"},
+    "recovery_procedure":  {"label": "materialize", "anchor": "recovery / cleanup procedure"},
+    "one_off_task":        {"label": "skip", "anchor": "one-off task"},
+    "transient_confusion": {"label": "skip", "anchor": "session-transient confusion"},
+    "what_is_question":    {"label": "skip", "anchor": "asking what something is"},
+    "self_summary":        {"label": "skip", "anchor": "summarizing what just happened"},
+    "transient_env_error": {"label": "skip", "anchor": "transient env errors"},
+}
+
+# The rubric SECTIONS each decision's anchors must live in. A signal votes only
+# if its anchor is present in its decision's section (so an edit to the
+# materialize/skip rubric block moves the metric even when the same phrase
+# happens to appear elsewhere in the prompt, e.g. in POSITIVE_EXAMPLES). When a
+# section marker isn't found (e.g. someone reworded a header), coupling degrades
+# gracefully to whole-prompt presence rather than cratering every signal.
+SHADOW_SECTIONS: dict[str, tuple[str, str]] = {
+    "materialize": ("CLASS-LEVEL signals (materialize)", "NOT class-level (skip)"),
+    "skip": ("NOT class-level (skip)", "PROCEDURE"),
+}
+
+# Phrases below are exact substrings of CANDIDATE_REVIEW_PROMPT's action menu.
+CANDIDATE_SIGNALS: dict[str, dict] = {
+    "class_level_rule": {"label": "accept", "anchor": "class-level rule"},
+    "refines_skill":    {"label": "accept", "anchor": "refines a skill"},
+    "incident_note":    {"label": "accept", "anchor": "per-incident decision"},
+    "user_verbatim":    {"label": "accept", "anchor": "worth preserving verbatim"},
+    "false_positive":   {"label": "reject", "anchor": "false positive"},
+    "system_fragment":  {"label": "reject", "anchor": "system prompt fragment"},
+    "log_dump":         {"label": "reject", "anchor": "log dump"},
+}
+
+CANDIDATE_SECTIONS: dict[str, tuple[str, str]] = {
+    "accept": ("PROCEDURE", "6. REJECT"),
+    "reject": ("6. REJECT", "DECISION RULES"),
+}
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Pure functions: metrics
+# ──────────────────────────────────────────────────────────────────────────
+
+def binary_metrics(pairs: Iterable[tuple[str, str]], positive: str) -> dict:
+    """Precision / recall / F1 for a binary decision.
+
+    ``pairs`` is an iterable of ``(predicted, gold)`` labels; ``positive`` is
+    the class precision/recall are computed against. Returns a dict with the
+    confusion counts and the three metrics (``None`` when undefined — e.g. no
+    predicted/actual positives — so a thin fixture never fakes a 0.0).
+    """
+    tp = fp = fn = tn = 0
+    for pred, gold in pairs:
+        if gold == positive and pred == positive:
+            tp += 1
+        elif gold != positive and pred == positive:
+            fp += 1
+        elif gold == positive and pred != positive:
+            fn += 1
+        else:
+            tn += 1
+    precision = tp / (tp + fp) if (tp + fp) else None
+    recall = tp / (tp + fn) if (tp + fn) else None
+    if precision is None or recall is None:
+        f1 = None
+    elif precision == 0 and recall == 0:
+        f1 = 0.0
+    else:
+        f1 = 2 * precision * recall / (precision + recall)
+    return {
+        "positive": positive,
+        "n": tp + fp + fn + tn,
+        "tp": tp, "fp": fp, "fn": fn, "tn": tn,
+        "precision": round(precision, 4) if precision is not None else None,
+        "recall": round(recall, 4) if recall is not None else None,
+        "f1": round(f1, 4) if f1 is not None else None,
+        "accuracy": round((tp + tn) / (tp + fp + fn + tn), 4)
+        if (tp + fp + fn + tn) else None,
+    }
+
+
+def cohen_kappa(pairs: Iterable[tuple[str, str]]) -> Optional[float]:
+    """Cohen's kappa between two labelers over ``(a, b)`` label pairs.
+
+    1.0 = perfect agreement, 0.0 = chance-level, <0 = worse than chance.
+    Returns ``None`` for an empty set. When both labelers are perfectly
+    constant and identical (no variance), agreement is trivially perfect → 1.0.
+    """
+    pairs = list(pairs)
+    n = len(pairs)
+    if not n:
+        return None
+    po = sum(1 for a, b in pairs if a == b) / n
+    labels = {a for a, _ in pairs} | {b for _, b in pairs}
+    pe = 0.0
+    for lab in labels:
+        pa = sum(1 for a, _ in pairs if a == lab) / n
+        pb = sum(1 for _, b in pairs if b == lab) / n
+        pe += pa * pb
+    if pe >= 1.0:
+        return 1.0
+    return (po - pe) / (1 - pe)
+
+
+def agreement(pairs: Iterable[tuple[str, str]]) -> dict:
+    """Judge↔human agreement: raw accuracy + Cohen's kappa over ``(judge,
+    human)`` pairs."""
+    pairs = list(pairs)
+    n = len(pairs)
+    acc = sum(1 for a, b in pairs if a == b) / n if n else None
+    kappa = cohen_kappa(pairs)
+    return {
+        "n": n,
+        "accuracy": round(acc, 4) if acc is not None else None,
+        "kappa": round(kappa, 4) if kappa is not None else None,
+    }
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Pure functions: the deterministic rubric classifier + quality heuristic
+# ──────────────────────────────────────────────────────────────────────────
+
+def _section_text(prompt: str, start: str, end: str) -> Optional[str]:
+    """Return the slice of ``prompt`` between markers ``start`` and ``end``
+    (start inclusive, end exclusive), or ``None`` if ``start`` is absent."""
+    lo = prompt.find(start)
+    if lo < 0:
+        return None
+    hi = prompt.find(end, lo + len(start))
+    return prompt[lo: hi if hi >= 0 else len(prompt)]
+
+
+def rubric_predict(prompt: str, signals: Iterable[str], registry: dict,
+                   default: str,
+                   sections: Optional[dict] = None) -> tuple[str, str]:
+    """Predict a decision from a fixture item's human ``signals``, coupled to
+    the live ``prompt``.
+
+    Each signal votes for its registry label ONLY if its anchor phrase is still
+    present in the rubric. With ``sections`` (label → (start, end) markers) the
+    anchor must appear inside that decision's section, so editing the rubric
+    block moves the metric even when the same phrase recurs elsewhere; if the
+    markers aren't found, coupling falls back to whole-prompt presence. The
+    majority label wins; a tie or no active votes falls back to ``default`` (the
+    conservative call). Returns ``(label, reason)``. Because votes depend on the
+    live prompt, removing a rubric criterion drops the signals anchored to it
+    and changes the prediction — which is how a rubric edit moves the metric.
+    """
+    low = prompt.lower()
+    region_cache: dict[str, Optional[str]] = {}
+
+    def haystack_for(label: str) -> str:
+        if not sections or label not in sections:
+            return low
+        if label not in region_cache:
+            seg = _section_text(prompt, *sections[label])
+            region_cache[label] = seg.lower() if seg is not None else None
+        region = region_cache[label]
+        return region if region is not None else low
+
+    tally: dict[str, int] = {}
+    active: list[str] = []
+    dropped: list[str] = []
+    for sig in signals:
+        spec = registry.get(sig)
+        if not spec:
+            continue
+        if spec["anchor"].lower() in haystack_for(spec["label"]):
+            tally[spec["label"]] = tally.get(spec["label"], 0) + 1
+            active.append(sig)
+        else:
+            dropped.append(sig)
+    if not tally:
+        reason = "no active rubric signal"
+        if dropped:
+            reason += f" (dropped: {', '.join(dropped)})"
+        return default, reason
+    best = max(tally.values())
+    winners = sorted(k for k, v in tally.items() if v == best)
+    if len(winners) > 1:
+        return default, f"tie {winners} → default {default}"
+    return winners[0], f"{winners[0]} via {', '.join(active)}"
+
+
+# Negative-claim constraints ANTI_CAPTURE warns against ("this tool is broken")
+# — a hallmark of a low-quality, self-limiting skill.
+_NEG_CLAIM = (
+    "do not work", "does not work", "doesn't work", "do not function",
+    "is broken", "are broken", "cannot use", "can't use", "not working",
+    "never works",
+)
+# Incident-scoped naming: a skill keyed to one PR/issue/day is not class-level.
+_INCIDENT_RE = re.compile(r"\b(pr[-\s]?\d+|#\d+|issue\s+\d+|today|yesterday)\b")
+
+
+def quality_heuristic(name: str, description: str, body: str) -> tuple[str, str]:
+    """Deterministic stand-in for the "is this a high-quality skill?" judge.
+
+    Returns ``("high"|"low", reason)``. Encodes the same shape the curator /
+    skill rubric optimizes for: a class-level trigger description plus a
+    durable, rule-shaped body, and NOT a negative-claim constraint or an
+    incident-scoped one-off. Calibrated to the human labels on the bundled
+    fixtures; the LLM judge is the higher-fidelity alternative.
+    """
+    desc = (description or "").strip()
+    text = f"{desc} {body or ''}".lower()
+    if any(n in text for n in _NEG_CLAIM):
+        return "low", "negative-claim constraint (ANTI_CAPTURE)"
+    if _INCIDENT_RE.search(f"{name} {desc}".lower()):
+        return "low", "incident-scoped name, not class-level"
+    if not desc:
+        return "low", "missing frontmatter trigger description"
+    words = len((body or "").split())
+    if words < 8:
+        return "low", "body too thin to be durable"
+    if words > 600:
+        return "low", "body bloated beyond a focused rule"
+    return "high", "class-level trigger + durable rule body"
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Live daemon prompts (deferred imports — keep pure functions import-light)
+# ──────────────────────────────────────────────────────────────────────────
+
+def get_shadow_prompt() -> str:
+    from ..shadow_review import SHADOW_REVIEW_PROMPT
+    return SHADOW_REVIEW_PROMPT
+
+
+def get_candidate_prompt() -> str:
+    from ..candidate_reviewer import CANDIDATE_REVIEW_PROMPT
+    return CANDIDATE_REVIEW_PROMPT
+
+
+def _fence(content: str, label: str) -> str:
+    """Wrap an item as observed data for the LLM judge (same fence the daemons
+    use, so the replay matches production framing)."""
+    from ..review_prompts import fence_observed
+    return fence_observed(content, label)
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# LLM judge — replay the real prompt, parse the daemon's own verdict contract
+# ──────────────────────────────────────────────────────────────────────────
+
+class LLMJudgeUnavailable(RuntimeError):
+    pass
+
+
+def _anthropic_text(prompt: str, *, model: str, api_key: str,
+                    timeout: float = 60.0) -> str:
+    """POST a single-turn Messages request over urllib (no SDK). Raises
+    :class:`LLMJudgeUnavailable` on any transport/API error."""
+    body = json.dumps({
+        "model": model,
+        "max_tokens": 128,
+        "messages": [{"role": "user", "content": prompt}],
+    }).encode()
+    req = urllib.request.Request(
+        "https://api.anthropic.com/v1/messages",
+        data=body,
+        headers={
+            "content-type": "application/json",
+            "x-api-key": api_key,
+            "anthropic-version": "2023-06-01",
+        },
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            payload = json.loads(resp.read())
+    except Exception as e:  # noqa: BLE001 — surface any transport/API error
+        raise LLMJudgeUnavailable(f"anthropic request failed: {e}") from e
+    return "".join(
+        b.get("text", "") for b in payload.get("content", [])
+        if b.get("type") == "text"
+    )
+
+
+_SHADOW_EVAL_TAIL = (
+    "\n\nEVAL MODE — do NOT call any tools and do NOT write anything. Using "
+    "ONLY the rubric above, classify the single dialog window below. Output "
+    "exactly one line, either `MATERIALIZED: <would-be-slug>` (class-level "
+    "learning worth a durable skill) or `SKIP: <reason>` (nothing "
+    "class-level).\n\n"
+)
+_CANDIDATE_EVAL_TAIL = (
+    "\n\nEVAL MODE — do NOT call any tools. Using ONLY the rubric above, "
+    "classify the single candidate below. Output exactly one line, either "
+    "`DECISION: ACCEPT` (a genuine note/verbatim/skill) or `DECISION: REJECT` "
+    "(a false-positive that slipped past extract's noise filters).\n\n"
+)
+_QUALITY_PROMPT = (
+    "You grade thread-keeper SKILL.md quality. A HIGH-quality skill is "
+    "class-level (applies to a whole class of tasks, not one incident), has a "
+    "trigger description, and a durable rule-shaped body. A LOW-quality skill "
+    "is an incident-scoped one-off, a negative claim that a tool 'does not "
+    "work', or too thin/bloated to be durable. Reply with ONLY a JSON object "
+    '{"quality": "high"|"low", "reason": "<=12 words"}.\n\n'
+    "SKILL name: {name}\nSKILL description: {description}\n\nSKILL body:\n{body}\n"
+)
+
+
+def _parse_shadow_verdict(text: str) -> str:
+    """Last MATERIALIZED/SKIP line wins (tool prose can precede it)."""
+    verdict = "skip"
+    for line in text.splitlines():
+        st = line.lstrip().upper()
+        if st.startswith("MATERIALIZED:"):
+            verdict = "materialize"
+        elif st.startswith("SKIP:"):
+            verdict = "skip"
+    return verdict
+
+
+def _parse_candidate_verdict(text: str) -> str:
+    verdict = "reject"
+    for line in text.splitlines():
+        st = line.lstrip().upper()
+        if st.startswith("DECISION: ACCEPT") or st.startswith("ACCEPT"):
+            verdict = "accept"
+        elif st.startswith("DECISION: REJECT") or st.startswith("REJECT"):
+            verdict = "reject"
+    return verdict
+
+
+def _llm_shadow(item: dict, *, model: str, api_key: str) -> tuple[str, str]:
+    prompt = (get_shadow_prompt() + _SHADOW_EVAL_TAIL
+              + _fence(item.get("dialog", ""), "recent dialog"))
+    text = _anthropic_text(prompt, model=model, api_key=api_key)
+    return _parse_shadow_verdict(text), text.strip().replace("\n", " ")[:80]
+
+
+def _llm_candidate(item: dict, *, model: str, api_key: str) -> tuple[str, str]:
+    prompt = (get_candidate_prompt() + _CANDIDATE_EVAL_TAIL
+              + _fence(item.get("content", ""), "pending candidate"))
+    text = _anthropic_text(prompt, model=model, api_key=api_key)
+    return _parse_candidate_verdict(text), text.strip().replace("\n", " ")[:80]
+
+
+def _llm_quality(item: dict, *, model: str, api_key: str) -> tuple[str, str]:
+    prompt = _QUALITY_PROMPT.format(
+        name=item.get("name", ""),
+        description=item.get("description", ""),
+        body=(item.get("body", ""))[:4000],
+    )
+    text = _anthropic_text(prompt, model=model, api_key=api_key)
+    m = re.search(r"\{.*\}", text, re.S)
+    if not m:
+        return "low", f"unparseable: {text[:50]!r}"
+    try:
+        verdict = json.loads(m.group(0))
+    except json.JSONDecodeError:
+        return "low", f"unparseable: {text[:50]!r}"
+    q = str(verdict.get("quality", "low")).lower()
+    q = "high" if q == "high" else "low"
+    return q, str(verdict.get("reason", ""))[:60]
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Fixture loading + axis evaluation
+# ──────────────────────────────────────────────────────────────────────────
+
+def load_fixtures(fixtures_dir: Path) -> dict:
+    """Load the three fixture files. Missing files yield empty lists so the
+    verdict can report FAIL rather than crash."""
+    out: dict[str, list] = {}
+    for key, fname in (("shadow", "shadow.json"),
+                       ("candidate", "candidates.json"),
+                       ("quality", "skill_quality.json")):
+        path = fixtures_dir / fname
+        try:
+            data = json.loads(path.read_text())
+        except (OSError, ValueError):
+            out[key] = []
+            continue
+        out[key] = data.get("items", data) if isinstance(data, dict) else data
+    return out
+
+
+def _eval_decision_axis(items: list[dict], positive: str, default: str,
+                        signals_registry: dict, sections: dict, get_prompt,
+                        llm_fn, *, judge: str, model: str, api_key: str) -> dict:
+    """Score one binary decision axis (shadow or candidate)."""
+    rows: list[dict] = []
+    prompt = get_prompt() if (judge == "rubric" and items) else ""
+    for it in items:
+        gold = it["label"]
+        if judge == "llm":
+            pred, reason = llm_fn(it, model=model, api_key=api_key)
+        else:
+            pred, reason = rubric_predict(
+                prompt, it.get("signals", []), signals_registry, default,
+                sections)
+        rows.append({"id": it.get("id", "?"), "gold": gold, "pred": pred,
+                     "correct": pred == gold, "reason": reason})
+    metrics = binary_metrics(((r["pred"], r["gold"]) for r in rows), positive)
+    classes = {r["gold"] for r in rows}
+    metrics["ready"] = len(rows) >= MIN_LABELS and len(classes) >= 2
+    metrics["rows"] = rows
+    return metrics
+
+
+def _eval_quality_axis(items: list[dict], *, judge: str, model: str,
+                       api_key: str) -> dict:
+    """Score the open-ended skill-quality axis as judge↔human agreement."""
+    rows: list[dict] = []
+    for it in items:
+        human = it["label"]
+        if judge == "llm":
+            pred, reason = _llm_quality(it, model=model, api_key=api_key)
+        else:
+            pred, reason = quality_heuristic(
+                it.get("name", ""), it.get("description", ""),
+                it.get("body", ""))
+        rows.append({"id": it.get("id", "?"), "human": human, "judge": pred,
+                     "agree": pred == human, "reason": reason})
+    agr = agreement((r["judge"], r["human"]) for r in rows)
+    classes = {r["human"] for r in rows}
+    agr["ready"] = len(rows) >= MIN_LABELS and len(classes) >= 2
+    agr["rows"] = rows
+    return agr
+
+
+def run_eval(fixtures_dir: Path = FIXTURES_DIR, *, judge: str = "rubric",
+             llm_model: str = "claude-haiku-4-5-20251001") -> dict:
+    """Run all three axes and assemble the report with a PASS/PARTIAL/FAIL
+    verdict on harness readiness (NOT a fixed quality threshold)."""
+    api_key = os.environ.get("ANTHROPIC_API_KEY", "")
+    if judge == "llm" and not api_key:
+        raise LLMJudgeUnavailable(
+            "ANTHROPIC_API_KEY not set; rerun with --judge rubric (default).")
+
+    fx = load_fixtures(fixtures_dir)
+    shadow = _eval_decision_axis(
+        fx["shadow"], "materialize", "skip", SHADOW_SIGNALS, SHADOW_SECTIONS,
+        get_shadow_prompt, _llm_shadow,
+        judge=judge, model=llm_model, api_key=api_key)
+    candidate = _eval_decision_axis(
+        fx["candidate"], "accept", "reject", CANDIDATE_SIGNALS,
+        CANDIDATE_SECTIONS, get_candidate_prompt, _llm_candidate,
+        judge=judge, model=llm_model, api_key=api_key)
+    quality = _eval_quality_axis(
+        fx["quality"], judge=judge, model=llm_model, api_key=api_key)
+
+    ready = [shadow["ready"], candidate["ready"], quality["ready"]]
+    if all(ready):
+        verdict = "PASS"
+    elif not any(ready):
+        verdict = "FAIL"
+    else:
+        verdict = "PARTIAL"
+
+    return {
+        "judge": judge,
+        "shadow": shadow,
+        "candidate": candidate,
+        "quality": quality,
+        "verdict": verdict,
+        "summary": _summarize(verdict, shadow, candidate, quality),
+    }
+
+
+def _summarize(verdict: str, shadow: dict, candidate: dict,
+               quality: dict) -> str:
+    def f1(m):
+        return f"{m['f1']:.2f}" if m.get("f1") is not None else "n/a"
+
+    def agr(m):
+        return f"{m['accuracy']:.2f}" if m.get("accuracy") is not None else "n/a"
+
+    return (
+        f"{verdict}: shadow_F1={f1(shadow)} candidate_F1={f1(candidate)} "
+        f"quality_agreement={agr(quality)} (n={quality.get('n', 0)})"
+    )
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Reporting
+# ──────────────────────────────────────────────────────────────────────────
+
+def _fmt_pct(x) -> str:
+    return f"{x:.1%}" if isinstance(x, (int, float)) else "n/a"
+
+
+def _decision_block(title: str, m: dict) -> list[str]:
+    out = [f"  {title}  (positive='{m['positive']}', n={m['n']}"
+           f"{'' if m['ready'] else ', THIN'})"]
+    out.append(
+        f"    precision={_fmt_pct(m['precision'])}  "
+        f"recall={_fmt_pct(m['recall'])}  f1={_fmt_pct(m['f1'])}  "
+        f"acc={_fmt_pct(m['accuracy'])}"
+    )
+    out.append(
+        f"    confusion: tp={m['tp']} fp={m['fp']} fn={m['fn']} tn={m['tn']}")
+    wrong = [r for r in m["rows"] if not r["correct"]]
+    if wrong:
+        out.append(f"    misclassified ({len(wrong)}):")
+        for r in wrong:
+            out.append(
+                f"      ✗ {r['id']:<22} gold={r['gold']} pred={r['pred']}"
+                f"  {r['reason']}")
+    return out
+
+
+def format_report(report: dict) -> str:
+    out: list[str] = []
+    out.append("── learning-loop decision-quality eval ───────────────────")
+    out.append(f"judge={report['judge']}")
+    out.append("")
+    out.append("shadow-review decisions (materialize vs skip):")
+    out.extend(_decision_block("shadow", report["shadow"]))
+    out.append("")
+    out.append("candidate-reviewer decisions (accept vs reject):")
+    out.extend(_decision_block("candidate", report["candidate"]))
+    out.append("")
+    q = report["quality"]
+    out.append("skill-quality judge ↔ human agreement (calibration):")
+    out.append(
+        f"  agreement={_fmt_pct(q['accuracy'])}  kappa="
+        f"{q['kappa'] if q['kappa'] is not None else 'n/a'}  n={q['n']}"
+        f"{'' if q['ready'] else '  (THIN)'}")
+    disagree = [r for r in q["rows"] if not r["agree"]]
+    if disagree:
+        out.append(f"  disagreements ({len(disagree)}):")
+        for r in disagree:
+            out.append(
+                f"    ✗ {r['id']:<22} human={r['human']} judge={r['judge']}"
+                f"  {r['reason']}")
+    out.append("")
+    out.append(f"  VERDICT: {report['verdict']}")
+    out.append(f"  {report['summary']}")
+    out.append("──────────────────────────────────────────────────────────")
+    return "\n".join(out)
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# CLI
+# ──────────────────────────────────────────────────────────────────────────
+
+def main(argv: Optional[list[str]] = None) -> int:
+    # Defensive: this is a read-only offline measurement, never a live session.
+    # Setting the kill-switch before any threadkeeper import means importing the
+    # daemon prompt modules can never start background work.
+    os.environ.setdefault("THREADKEEPER_DISABLE_BG_DAEMONS", "1")
+
+    ap = argparse.ArgumentParser(
+        prog="python -m threadkeeper.eval",
+        description="Offline eval harness for learning-loop decision quality "
+                    "(issue #72): precision/recall/F1 for shadow-review and "
+                    "candidate decisions, plus calibrated judge↔human "
+                    "agreement on skill quality.")
+    ap.add_argument("--judge", choices=("rubric", "llm"), default="rubric",
+                    help="rubric (default, offline, deterministic) or llm "
+                         "(replays the real prompt; needs ANTHROPIC_API_KEY).")
+    ap.add_argument("--llm-model", default="claude-haiku-4-5-20251001",
+                    help="model id for --judge llm.")
+    ap.add_argument("--fixtures-dir", type=Path, default=FIXTURES_DIR,
+                    help="fixture directory (default: bundled golden set).")
+    ap.add_argument("--json", action="store_true",
+                    help="emit the full report as JSON instead of a table.")
+    args = ap.parse_args(argv)
+
+    try:
+        report = run_eval(args.fixtures_dir, judge=args.judge,
+                          llm_model=args.llm_model)
+    except LLMJudgeUnavailable as e:
+        print(f"ERR: {e}", file=sys.stderr)
+        return 3
+
+    if args.json:
+        print(json.dumps(report, indent=2))
+    else:
+        print(format_report(report))
+    # Exit non-zero only when the harness itself is broken (no fixtures /
+    # nothing computable), never on model quality — quality is a number to
+    # track, not a gate.
+    return 0 if report["verdict"] in ("PASS", "PARTIAL") else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What

Adds `threadkeeper/eval/` — an offline harness that measures **decision quality** of the learning-loop daemons (the orthogonal axis to `verify_ingest.py`, which checks ingest plumbing). The quality-control daemons (`shadow_review`, `candidate_reviewer`, `curator`) make accept/reject/materialize calls with decision telemetry but, until now, no labeled set and no precision/recall — nothing scored how often the hard-coded class-vs-incident rubric was right.

```bash
python -m threadkeeper.eval                 # bundled golden fixtures, offline rubric judge
python -m threadkeeper.eval --json          # machine-readable
python -m threadkeeper.eval --judge llm     # replay the real prompts (needs ANTHROPIC_API_KEY)
python -m threadkeeper.eval --fixtures-dir my_labels/
```

## How

- **Fixtures** (`threadkeeper/eval/fixtures/*.json`) — small, hand-labeled, fully-synthetic sets: dialog windows + expected materialize/skip, candidate snippets + expected accept/reject, skill bodies + a human high/low quality label.
- **Two judges** (mirroring the `verify_ingest` offline/LLM split):
  - `rubric` (default, deterministic, offline, no API key) — a signal-vote classifier **section-coupled to the live daemon prompt**. Each fixture's human-tagged rubric signals only count when their anchor phrase is still present in the relevant section of the current `SHADOW_REVIEW_PROMPT` / `CANDIDATE_REVIEW_PROMPT` — so editing a rubric (dropping a criterion) deactivates those signals and **moves the metric**, caught in CI against the golden baseline.
  - `llm` (opt-in) — replays the *actual* daemon prompts (with the same `<observed_dialog>` data fence) over the Anthropic Messages API (urllib, no SDK) and parses the daemon's own verdict.
- **Calibration** — the skill-quality axis reports judge↔human **agreement** (accuracy + Cohen's kappa), per the evidently.ai LLM-as-a-judge guidance, so a drifting judge is visible.
- Output uses the same **PASS/PARTIAL/FAIL** verdict shape as `verify_ingest` (on harness readiness, **not** a fixed quality threshold).

## Acceptance criteria

- ✅ `python -m threadkeeper.eval` prints precision/recall/F1 for shadow-review and candidate decisions plus judge-vs-human agreement.
- ✅ Editing a daemon rubric and re-running moves the metric (section-coupled offline; LLM path reads the edited prompt). Demonstrated by `test_editing_{shadow,candidate}_rubric_moves_the_metric`.
- ✅ Fixtures contain no secrets/private paths (`test_fixtures_have_no_secrets_or_private_paths`).

## Tests / docs

- New `tests/test_eval_harness.py` (pure-function units + rubric-sensitivity + subprocess end-to-end; asserts the harness runs and computes metrics, not a fixed threshold). Full suite green.
- `docs/ARCHITECTURE.md` gets an "Evaluating the learning loop" section; README gets a usage section; CHANGELOG + ROADMAP updated.

Closes #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)