### PR TITLE
fix(security): lock down spawn slim config/.command + minimize embedded env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ version bumps follow semver per the policy in
 
 ### Security
 
+- **Lock down spawn artifacts + minimize embedded env (#68).** The per-task
+  **slim MCP config** (`slim-mcp-<task_id>.json`) was written with the default
+  umask (typically `0644`, world-readable) and embedded the host
+  `thread-keeper` MCP `env` block **verbatim** — so any secret a user kept on
+  that entry travelled into the weakest-permission spawn artifact. The visible
+  `.command` script was `0755` (world-readable/executable) even though it
+  `export`s the child's env. Now: the slim config is `chmod 0600` and the
+  `.command` script `0700` on creation (parity with the already-locked-down
+  `0600` stdin spool file), and the slim config copies **only** the host env
+  keys a slim child actually needs to start its server (package/runtime
+  discovery — `PYTHONPATH`/`VIRTUAL_ENV`/`PYTHONHOME` — plus `THREADKEEPER_*`
+  knobs); every other host key (API keys, tokens) is dropped. Run-specific
+  values still arrive via the existing per-spawn env overrides.
+  (Spool-file retention/cleanup remains #42; broader `~/.threadkeeper` perms
+  are #21.)
 - **Injection fence + provenance gate for the learning loops (#76).** The
   learning loops synthesize **auto-loaded** skill / lesson / user-model
   artifacts from **raw observed dialog** — which routinely echoes content the

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -409,10 +409,12 @@ verified at the cited file:line, deduplicated against the issues above):
   never measured (the daemon skips `pid<=0`), and a visible row whose jsonl
   never resolves pins its full-estimate budget share forever. (The
   admission-time check-then-spawn TOCTOU is #58; kill-path safety is #66.) (#64).
-- Spawn **slim MCP config** is written world-readable with no `chmod` and
-  embeds the host server `env` block, while the stdin prompt file is correctly
-  `0600` and the `.command` script is `0755`. Restrict modes + minimize the
-  embedded env. (Spool-file retention/cleanup is #42.) (#68).
+- ✅ DONE (#68). Spawn **slim MCP config** was written world-readable with no
+  `chmod` and embedded the host server `env` block, while the stdin prompt file
+  is correctly `0600` and the `.command` script was `0755`. Now: slim config
+  `chmod 0600`, `.command` `0700`, and the slim config copies only the env keys
+  a slim child needs (`PYTHONPATH`/`VIRTUAL_ENV`/`PYTHONHOME` + `THREADKEEPER_*`),
+  dropping host secrets. (Spool-file retention/cleanup is #42.)
 - `shadow_review` + `dialectic_miner` advance a single global `created_at`
   high-water cursor, so **late/out-of-order ingested** messages (resumed
   sessions, newly-installed adapters, post-downtime backfill) that land below

--- a/tests/test_spawn_slim.py
+++ b/tests/test_spawn_slim.py
@@ -96,6 +96,90 @@ def test_build_slim_mcp_config_synthesizes_when_no_claude_json(tmp_path, monkeyp
     assert mp["env"]["THREADKEEPER_NO_EMBEDDINGS"] == "1"
 
 
+def test_slim_config_is_owner_only_and_minimizes_env(tmp_path, monkeypatch):
+    """#68: the slim config must be 0600 (not group/other readable) and must
+    NOT carry host env keys the child doesn't need — e.g. a secret a user
+    added to their ~/.claude.json thread-keeper entry."""
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    (home / ".claude.json").write_text(json.dumps({
+        "mcpServers": {
+            "thread-keeper": {
+                "type": "stdio",
+                "command": "/path/to/python",
+                "args": ["-m", "threadkeeper.server"],
+                "env": {
+                    "PYTHONPATH": "/path/to/repo",
+                    "THREADKEEPER_TZ": "Europe/Kyiv",
+                    # secrets a user may have on their host MCP entry — must
+                    # never travel into the slim config.
+                    "OPENAI_API_KEY": "sk-secret-should-be-dropped",
+                    "AWS_SECRET_ACCESS_KEY": "also-secret",
+                },
+            },
+        }
+    }))
+
+    log_dir = tmp_path / "logs"
+    monkeypatch.setenv("THREADKEEPER_TASK_LOG_DIR", str(log_dir))
+
+    import sys
+    for name in [m for m in list(sys.modules) if m.startswith("threadkeeper")]:
+        del sys.modules[name]
+    from threadkeeper.tools.spawn import _build_slim_mcp_config
+
+    slim_path = _build_slim_mcp_config("tk_perm01", {
+        "THREADKEEPER_FORCE_CID": _FAKE_CID,
+        "THREADKEEPER_NO_EMBEDDINGS": "1",
+    })
+    assert slim_path is not None
+
+    # File mode: owner-only, no group/other bits.
+    mode = slim_path.stat().st_mode & 0o777
+    assert mode == 0o600, f"expected 0600, got {oct(mode)}"
+
+    env = json.loads(slim_path.read_text())["mcpServers"]["thread-keeper"]["env"]
+    # Needed keys survive: package discovery + thread-keeper knobs + overrides.
+    assert env["PYTHONPATH"] == "/path/to/repo"
+    assert env["THREADKEEPER_TZ"] == "Europe/Kyiv"
+    assert env["THREADKEEPER_FORCE_CID"] == _FAKE_CID
+    assert env["THREADKEEPER_NO_EMBEDDINGS"] == "1"
+    # Secrets dropped.
+    assert "OPENAI_API_KEY" not in env
+    assert "AWS_SECRET_ACCESS_KEY" not in env
+
+
+def test_visible_command_script_is_owner_only(mp_with_cid, monkeypatch):
+    """#68: the visible-spawn `.command` script `export`s the child env and
+    must be 0700 (owner-only), not the world-readable/executable 0755."""
+    pkg = mp_with_cid(_FAKE_CID)
+
+    import threadkeeper.tools.spawn as spawn_mod
+
+    # Don't require a real claude binary, and never actually launch Terminal.
+    monkeypatch.setattr(spawn_mod, "_claude_bin", lambda: "/usr/bin/true")
+    # Pre-seed the active-CLI cache so spawn() resolves to the claude path
+    # without shelling out to `ps` (which would otherwise hit the patched
+    # Popen below). _detect_self_cid short-circuits on the pinned FORCE_CID.
+    monkeypatch.setattr(pkg["identity"], "_active_cli", "claude")
+
+    class _FakePopen:
+        def __init__(self, *a, **k):
+            self.pid = 4321
+
+    monkeypatch.setattr(spawn_mod.subprocess, "Popen", _FakePopen)
+
+    spawn_fn = pkg["mcp"]._tool_manager._tools["spawn"].fn
+    out = spawn_fn(prompt="do a thing", visible=True)
+    assert out.startswith("ok task="), out
+
+    cmd_files = list(spawn_mod.TASK_LOG_DIR.glob("*.command"))
+    assert len(cmd_files) == 1, cmd_files
+    mode = cmd_files[0].stat().st_mode & 0o777
+    assert mode == 0o700, f"expected 0700, got {oct(mode)}"
+
+
 def test_spawn_slim_falls_back_to_full_config_when_unable(tmp_path, monkeypatch):
     """If _build_slim_mcp_config returns None (e.g. write error), spawn()
     must NOT crash — it just runs without slim flags."""

--- a/threadkeeper/tools/spawn.py
+++ b/threadkeeper/tools/spawn.py
@@ -258,6 +258,16 @@ ROLE_PROMPTS: dict[str, str] = {
 }
 
 
+# Env keys from the host MCP `env` block that a slim child genuinely needs
+# to start its thread-keeper server. Everything else — arbitrary
+# secret-bearing keys a user may have added to their host `thread-keeper`
+# MCP entry — is dropped so it never lands in the slim config (#68). The
+# transient run values the child actually needs arrive via env_overrides;
+# these cover package/runtime discovery plus thread-keeper's own knobs.
+_SLIM_MCP_ENV_ALLOW = frozenset({"PYTHONPATH", "VIRTUAL_ENV", "PYTHONHOME"})
+_SLIM_MCP_ENV_ALLOW_PREFIXES = ("THREADKEEPER_",)
+
+
 def _build_slim_mcp_config(
     task_id: str,
     env_overrides: Optional[dict[str, str]] = None,
@@ -300,7 +310,17 @@ def _build_slim_mcp_config(
         }
     else:
         mp_entry = dict(mp_entry)
-    env = dict(mp_entry.get("env") or {})
+    # Minimize the embedded env (#68): the host `env` block is copied
+    # verbatim from ~/.claude.json and may carry secrets the slim child
+    # does NOT need. Keep only package/runtime-discovery keys plus
+    # thread-keeper's own config knobs; the run-specific values the child
+    # actually needs arrive via env_overrides. Everything else is dropped.
+    host_env = dict(mp_entry.get("env") or {})
+    env = {
+        k: v for k, v in host_env.items()
+        if k in _SLIM_MCP_ENV_ALLOW
+        or any(k.startswith(p) for p in _SLIM_MCP_ENV_ALLOW_PREFIXES)
+    }
     if env_overrides:
         env.update(env_overrides)
     mp_entry["env"] = env
@@ -310,6 +330,10 @@ def _build_slim_mcp_config(
                         indent=2),
             encoding="utf-8",
         )
+        # This file embeds the MCP server env — lock it down to owner-only,
+        # parity with the 0600 stdin spool file (#68). Not group/other
+        # readable.
+        slim_path.chmod(0o600)
     except OSError:
         return None
     return slim_path
@@ -680,7 +704,11 @@ OSA
 exit $rc
 """
             script_path.write_text(script)
-            script_path.chmod(0o755)
+            # The script `export`s the child's env (FORCE_CID, write-origin,
+            # etc.) and is run by Terminal.app as the current user, so it
+            # only needs owner rwx — not the world-readable/executable 0755
+            # it used to get. Parity with the 0600 stdin file (#68).
+            script_path.chmod(0o700)
             try:
                 subprocess.Popen(
                     ["open", "-a", "Terminal", str(script_path)],


### PR DESCRIPTION
## What

Fixes the inconsistent permission treatment + secret leakage across spawn artifacts (#68).

- **Slim MCP config** (`slim-mcp-<task_id>.json`) was written via `write_text` with **no `chmod`** (default umask, typically `0644` — world-readable) and embedded the host `thread-keeper` MCP `env` block **verbatim**. So the artifact most likely to carry secrets had the *weakest* permissions.
- The visible **`.command`** script was `chmod 0755` (world-readable/executable) even though it `export`s the child env (`THREADKEEPER_FORCE_CID`, write-origin, …).
- For contrast, the stdin prompt file was already correctly `0600`.

## Changes

- `_build_slim_mcp_config`: `chmod 0600` the slim config on creation (parity with the stdin spool file).
- `_build_slim_mcp_config`: **minimize the embedded env** — copy only the keys a slim child needs to start its server: package/runtime discovery (`PYTHONPATH`, `VIRTUAL_ENV`, `PYTHONHOME`) plus `THREADKEEPER_*` config knobs. Every other host key (API keys, tokens) is dropped. Run-specific values still arrive via the existing per-spawn env overrides.
- Visible-spawn `.command`: `chmod 0700` instead of `0755`. It's run by Terminal.app as the current user, so owner rwx is sufficient.

## Tests

`tests/test_spawn_slim.py`:
- `test_slim_config_is_owner_only_and_minimizes_env` — asserts mode `0600`, that host secrets (`OPENAI_API_KEY`, `AWS_SECRET_ACCESS_KEY`) are dropped, and that `PYTHONPATH` / `THREADKEEPER_*` / overrides survive.
- `test_visible_command_script_is_owner_only` — drives `spawn(visible=True)` with a faked launcher and asserts the `.command` mode is `0700`.

Full suite green (`pytest -q`, exit 0).

## Docs

CHANGELOG (Security) + ROADMAP (#68 marked done) updated. No user-facing docs change. Spool-file retention/cleanup remains #42; broader `~/.threadkeeper` perms are #21.

Closes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)