### PR TITLE
feat(mcp): adopt tool annotations + structured outputs across the registry (#67)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ version bumps follow semver per the policy in
 
 ## [Unreleased]
 
+### Added
+
+- **MCP tool annotations + structured outputs (#67).** Every thread-keeper tool
+  was a bare `@mcp.tool()` with no machine-readable read/write signal. Now each
+  of the 113 tools registers through one of two wrappers in
+  `threadkeeper/_mcp.py` — `@read_tool()` (sets `readOnlyHint=True`) for pure
+  queries, `@write_tool(destructive=…, idempotent=…)` for mutations — so
+  `tools/list` exposes MCP 2025-06-18 `ToolAnnotations` for every tool. The ten
+  delete/overwrite/kill tools (`compost` is **not** one — it only reads) carry
+  `destructiveHint=True`: `agent_memory_cleanup`, `concept_manage`,
+  `consolidate`, `core_remove`, `curator_run`, `lesson_remove`,
+  `memory_guard_check`, `mp_cleanup`, `skill_manage`, `unlink`. This is the
+  static metadata a confirmation/elicitation host reads to decide which calls
+  warrant a prompt (substrate for #26). The five status tools — `context`,
+  `spawn_budget_status`, `spawn_status`, `mp_health`, `agent_status` — now also
+  advertise an `outputSchema` (typed models in `threadkeeper/tool_schemas.py`)
+  and return `structuredContent`, while preserving the legacy human-readable
+  text block (per the spec's structured-content backward-compat rule). New
+  `tests/test_tool_annotations.py` fails if any tool is unclassified, a mutating
+  tool is marked read-only, or a delete-class tool drops `destructiveHint`.
+  Requires the MCP **2025-06-18** tool vocabulary (`mcp>=1.10.0`).
+
 ### Security
 
 - **Lock down spawn artifacts + minimize embedded env (#68).** The per-task

--- a/README.md
+++ b/README.md
@@ -911,6 +911,8 @@ the suite on every push and PR.
 ```
 threadkeeper/
 ├── server.py             # MCP entry: python -m threadkeeper.server
+├── _mcp.py               # FastMCP singleton + read_tool()/write_tool() annotation wrappers
+├── tool_schemas.py       # typed outputSchema models for the structured status tools
 ├── _setup.py             # `thread-keeper-setup` installer
 ├── config.py             # env-driven defaults
 ├── db.py                 # SQLite schema + sqlite-vec loader
@@ -929,7 +931,7 @@ threadkeeper/
 │   ├── gemini.py
 │   ├── copilot.py
 │   └── vscode.py
-└── tools/                # @mcp.tool entries — 89 of them
+└── tools/                # @read_tool()/@write_tool() entries — 113 of them
     ├── threads.py
     ├── peers.py
     ├── spawn.py
@@ -938,6 +940,19 @@ threadkeeper/
     ├── validate.py
     └── ...
 ```
+
+**Tool annotation contract (#67).** Every tool registers through
+`@read_tool()` or `@write_tool(destructive=…, idempotent=…)` (in `_mcp.py`),
+so `tools/list` carries MCP 2025-06-18 `ToolAnnotations` for all 113 tools:
+`readOnlyHint=True` for pure reads (`brief`, `context`, `search`,
+`dialog_search`, `lesson_list`, the status tools, …) and `readOnlyHint=False`
+for mutations, with `destructiveHint=True` on the ten delete/overwrite/kill
+tools (`compost` is read-only — it only surfaces idle threads). A
+confirmation/elicitation host reads this to decide which calls warrant a
+prompt. The five status tools (`context`, `spawn_budget_status`,
+`spawn_status`, `mp_health`, `agent_status`) additionally advertise an
+`outputSchema` and return `structuredContent` alongside the legacy text
+block. The contract is enforced by `tests/test_tool_annotations.py`.
 
 Detailed map in [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md).
 Open work in [docs/ROADMAP.md](docs/ROADMAP.md) and the

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -694,7 +694,9 @@ numerically identical, so after a switch run `tk-migrate-embeddings --all`
 ## MCP tools (107 total)
 
 Compact grouping by module. Full signatures are in the code; `_mcp.py`
-auto-generates JSON-Schema from annotations.
+auto-generates JSON-Schema from annotations. Every tool also carries an
+explicit read/write **`ToolAnnotations`** hint (see the annotation contract
+below).
 
 | Module | N | Tools |
 |---|---|---|
@@ -728,9 +730,32 @@ auto-generates JSON-Schema from annotations.
 | missed_spawns | 1 | find_missed_spawns |
 | session | 1 | session_end |
 
-Each @mcp.tool() is a synchronous Python function; FastMCP wraps it in
-JSON-Schema automatically from type annotations. One process — one mcp
-instance (`threadkeeper._mcp.mcp`).
+Each tool is a synchronous Python function; FastMCP wraps it in JSON-Schema
+automatically from type annotations. One process — one mcp instance
+(`threadkeeper._mcp.mcp`).
+
+### Tool annotation contract (#67)
+
+Tools register through two thin wrappers in `_mcp.py` instead of bare
+`@mcp.tool()`, so `tools/list` exposes MCP 2025-06-18 `ToolAnnotations` for
+every tool:
+
+- `@read_tool()` → `readOnlyHint=True` — pure queries (`brief`, `context`,
+  `search`, `dialog_search`, `lesson_list`, the status tools, `compost`, …).
+- `@write_tool(destructive=…, idempotent=…)` → `readOnlyHint=False` —
+  mutations. The ten delete/overwrite/kill tools carry `destructiveHint=True`:
+  `agent_memory_cleanup`, `concept_manage`, `consolidate`, `core_remove`,
+  `curator_run`, `lesson_remove`, `memory_guard_check`, `mp_cleanup`,
+  `skill_manage`, `unlink`. `idempotentHint=True` marks no-op-on-repeat tools
+  (`close_thread`, `mark_skill_materialized`, `core_set`, deletes-by-key, …).
+
+This is the static metadata a confirmation/elicitation host reads to decide
+which calls warrant a prompt (substrate for #26). The five status tools
+(`context`, `spawn_budget_status`, `spawn_status`, `mp_health`,
+`agent_status`) additionally return an `outputSchema` + `structuredContent`
+(typed models in `tool_schemas.py`, built via `structured_result()`), keeping
+the legacy human-readable text block for backward compatibility. The contract
+is enforced by `tests/test_tool_annotations.py`.
 
 ## Tests
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -450,10 +450,18 @@ verified at the cited file:line, deduplicated against the issues above):
   questions — **extract precision re-measurement** and **"do we even need
   tiers — metric not collected"** — a harness to measure against; point
   `--fixtures-dir` at a production-derived labeled set to collect those numbers.
-- MCP **tool annotations** (`readOnly`/`destructive`/`idempotent` hints) +
-  structured output across the tool registry (independently confirmed; canonical
-  issue #67) — gives hosts a mechanical read-vs-write signal and composes with
-  #22 and the elicitation work in #26.
+- ✅ DONE (#67). MCP **tool annotations** (`readOnlyHint`/`destructiveHint`/
+  `idempotentHint`) across the whole tool registry, plus structured
+  **`outputSchema` + `structuredContent`** on the five status tools (`context`,
+  `spawn_budget_status`, `spawn_status`, `mp_health`, `agent_status`). Every
+  tool now registers through `read_tool()` / `write_tool()` wrappers
+  (`threadkeeper/_mcp.py`) so `tools/list` carries an explicit read-vs-write
+  signal and delete-class tools carry `destructiveHint=True`. A registry test
+  (`tests/test_tool_annotations.py`) fails if any tool is unclassified, marks a
+  mutator read-only, or drops the destructive hint; the status tools keep their
+  legacy human-readable text block alongside the typed JSON. Gives hosts a
+  mechanical confirmation signal and composes with #22 and the elicitation work
+  in #26.
 - **Learning-loop memory poisoning** — the synthesis children (`shadow_review`,
   `candidate_reviewer`, close-thread auto-review, `dialectic_validator`) turn the
   **raw observed-dialog stream** into **auto-loaded** `SKILL.md` / `lessons.md` /

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,9 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
 dependencies = [
-    "mcp>=1.0.0",
+    # >=1.10.0 for the MCP 2025-06-18 tool vocabulary: ToolAnnotations
+    # (readOnly/destructive/idempotent hints) + structured outputSchema (#67).
+    "mcp>=1.10.0",
     "pydantic>=2",
     "pydantic-settings>=2",
     "pyyaml>=6.0",

--- a/tests/test_agent_status.py
+++ b/tests/test_agent_status.py
@@ -12,6 +12,15 @@ def _tool(pkg, name):
     return pkg["mcp"]._tool_manager._tools[name].fn
 
 
+def _txt(res):
+    """Text payload from a tool result (str or CallToolResult, #67)."""
+    if isinstance(res, str):
+        return res
+    return "\n".join(
+        c.text for c in res.content if getattr(c, "type", None) == "text"
+    )
+
+
 def _insert_task(pkg, task_id: str, prompt: str, rss_mb: int = 0):
     conn = pkg["db"].get_db()
     now = int(time.time())
@@ -317,7 +326,7 @@ def test_agent_status_mcp_json_output(mp_with_cid):
     pkg = mp_with_cid(_FAKE_CID)
     _insert_task(pkg, "tk_status", "Build a compact menu-bar status app.", rss_mb=100)
 
-    raw = _tool(pkg, "agent_status")(json_output=True, refresh=False)
+    raw = _txt(_tool(pkg, "agent_status")(json_output=True, refresh=False))
     data = json.loads(raw)
     assert data["running_count"] == 1
     assert "loops" in data
@@ -468,7 +477,7 @@ def test_agent_status_text_output(mp_with_cid):
     pkg = mp_with_cid(_FAKE_CID)
     _insert_task(pkg, "tk_status", "Build a compact menu-bar status app.", rss_mb=100)
 
-    txt = _tool(pkg, "agent_status")(json_output=False, refresh=False)
+    txt = _txt(_tool(pkg, "agent_status")(json_output=False, refresh=False))
     assert "loops enabled=" in txt
     assert "Candidate reviewer" in txt
     assert "agents=1" in txt

--- a/tests/test_identity.py
+++ b/tests/test_identity.py
@@ -31,7 +31,11 @@ def test_context_sees_live_session_id(fresh_mp):
     `sess=-` in production briefs.
     """
     mcp = fresh_mp["mcp"]
-    out = mcp._tool_manager._tools["context"].fn()
+    res = mcp._tool_manager._tools["context"].fn()
+    # context() now returns a CallToolResult (structuredContent + legacy text, #67)
+    out = "\n".join(
+        c.text for c in res.content if getattr(c, "type", None) == "text"
+    )
     # Whatever happens, must be a non-empty string with sess= prefix populated
     assert isinstance(out, str)
     assert "sess=s_" in out, f"context didn't see live session: {out!r}"

--- a/tests/test_process_health.py
+++ b/tests/test_process_health.py
@@ -18,6 +18,15 @@ def _tool(pkg, name):
     return pkg["mcp"]._tool_manager._tools[name].fn
 
 
+def _txt(res):
+    """Text payload from a tool result (str or CallToolResult, #67)."""
+    if isinstance(res, str):
+        return res
+    return "\n".join(
+        c.text for c in res.content if getattr(c, "type", None) == "text"
+    )
+
+
 # ─────────────────────────────────────────────────────────────────────
 # classify() — the heart of the logic
 # ─────────────────────────────────────────────────────────────────────
@@ -219,7 +228,7 @@ def test_mp_health_tool_shows_table(mp_with_cid, monkeypatch):
          "heartbeat_age_s": 10, "is_self": False, "is_orphaned": False,
          "orphan_reason": "parent_alive"},
     ])
-    txt = _tool(pkg, "mp_health")()
+    txt = _txt(_tool(pkg, "mp_health")())
     assert "total=2" in txt
     assert "orphans=1" in txt
     assert "ORPHAN" in txt

--- a/tests/test_spawn_budget.py
+++ b/tests/test_spawn_budget.py
@@ -18,6 +18,15 @@ def _tool(pkg, name):
     return pkg["mcp"]._tool_manager._tools[name].fn
 
 
+def _txt(res):
+    """Text payload from a tool result (str or CallToolResult, #67)."""
+    if isinstance(res, str):
+        return res
+    return "\n".join(
+        c.text for c in res.content if getattr(c, "type", None) == "text"
+    )
+
+
 def _insert_task(pkg, task_id, rss_kb=None, ended=False):
     """Insert a fake task. Uses the test process's own pid so
     _refresh_tasks (alive() check) doesn't mark it ended on a brief()
@@ -133,7 +142,7 @@ def test_spawn_budget_status_reports_running_children(mp_with_cid, monkeypatch):
     _insert_task(pkg, "tk_y", rss_kb=500 * 1024)
     _insert_task(pkg, "tk_done", rss_kb=999 * 1024, ended=True)
 
-    txt = _tool(pkg, "spawn_budget_status")()
+    txt = _txt(_tool(pkg, "spawn_budget_status")())
     assert "budget=3072MB" in txt
     # used = 400 + 500 = 900 (ended task excluded)
     assert "used=900MB" in txt
@@ -145,7 +154,7 @@ def test_spawn_budget_status_reports_running_children(mp_with_cid, monkeypatch):
 def test_spawn_budget_status_when_disabled(mp_with_cid, monkeypatch):
     monkeypatch.setenv("THREADKEEPER_SPAWN_BUDGET_MB", "0")
     pkg = mp_with_cid(_FAKE_CID)
-    txt = _tool(pkg, "spawn_budget_status")()
+    txt = _txt(_tool(pkg, "spawn_budget_status")())
     assert "budget=disabled" in txt
 
 
@@ -161,7 +170,7 @@ def test_spawn_budget_set_lowers_cap_at_runtime(mp_with_cid, monkeypatch):
     from threadkeeper import config
     assert config.SPAWN_BUDGET_MB == 1000
 
-    txt = _tool(pkg, "spawn_budget_status")()
+    txt = _txt(_tool(pkg, "spawn_budget_status")())
     assert "budget=1000MB" in txt
 
 

--- a/tests/test_tool_annotations.py
+++ b/tests/test_tool_annotations.py
@@ -1,0 +1,162 @@
+"""MCP tool-annotation contract (roadmap #67).
+
+Every thread-keeper tool must carry an explicit read/write annotation so a
+confirmation/elicitation client (issue #26) can tell pure reads from
+mutations without calling them. This test pins that contract:
+
+  * every registered tool sets ``readOnlyHint`` explicitly (never None);
+  * the curated read / write / delete-class sets match their annotations;
+  * no mutating tool is marked ``readOnlyHint=True``;
+  * every delete-class tool carries ``destructiveHint=True``;
+  * a tool added without being classified here fails the name-set check;
+  * the five status tools advertise an ``outputSchema`` and return
+    ``structuredContent`` that validates against it, with the legacy text
+    block preserved.
+
+The classification mirrors :mod:`threadkeeper._mcp` (``read_tool`` /
+``write_tool``); it is intentionally duplicated here so a miscategorised or
+unannotated tool is caught in CI.
+"""
+from __future__ import annotations
+
+import jsonschema
+import pytest
+
+# --- read-only tools: pure queries, no state mutation ------------------------
+READ_TOOLS = {
+    "agent_status", "brief", "candidate_review_status", "compost",
+    "config_watch_status", "context", "core_get", "core_list",
+    "curator_review_status", "dialectic_mine_status", "dialectic_review",
+    "dialectic_synthesis", "dialectic_validate_status", "dialog_search",
+    "evolve_apply_status", "evolve_review", "expand_concept", "find_invariants",
+    "find_missed_spawns", "lesson_get", "lesson_list", "list_concepts",
+    "memory_guard_status", "mp_dashboard", "mp_health", "neighbors", "peers",
+    "pending_distillates", "pickup_candidates", "reliability_for",
+    "review_candidates", "run_probe", "search", "shadow_review_status",
+    "skill_list", "spawn_budget_status", "spawn_status", "task_logs",
+    "task_thread", "tasks", "weak_spots", "whoami",
+}
+
+# --- delete/overwrite/kill tools: destructiveHint=True -----------------------
+DELETE_CLASS_TOOLS = {
+    "agent_memory_cleanup", "concept_manage", "consolidate", "core_remove",
+    "curator_run", "lesson_remove", "memory_guard_check", "mp_cleanup",
+    "skill_manage", "unlink",
+}
+
+# --- non-destructive mutating tools ------------------------------------------
+WRITE_TOOLS = {
+    "accept_candidate", "ask", "auto_review_trigger", "broadcast",
+    "candidate_review_run", "claim_pickup", "close_thread", "config_reload",
+    "convene_panel", "core_set", "curator_review", "dialectic_claim",
+    "dialectic_evidence", "dialectic_mine_run", "dialectic_observation_resolve",
+    "dialectic_supersede", "dialectic_validate_run", "distill", "evolve_apply",
+    "evolve_apply_curator_report", "evolve_apply_roadmap_issue", "evolve_decide",
+    "evolve_format", "evolve_mark_applied", "evolve_mark_curator_report_applied",
+    "evolve_mark_roadmap_issue_applied", "export_distillates", "extract_recent",
+    "idle_thread", "inbox", "ingest", "lesson_append", "link", "live_status",
+    "mark_skill_materialized", "memory_guard_reclaim", "note",
+    "open_dialog_window", "open_thread", "presence", "record_attempt",
+    "register_concept", "register_probe", "reject_candidate", "release_pickup",
+    "respond", "review_thread", "search_via_parent", "session_end",
+    "shadow_review_run", "skill_record", "spawn", "spawn_budget_set",
+    "style_set", "tag_signal", "tournament", "validate_threads",
+    "verbatim_user", "vote_distill", "wait", "whisper",
+}
+
+# status tools that must expose outputSchema + structuredContent
+STATUS_TOOLS = {
+    "context", "spawn_budget_status", "spawn_status", "mp_health",
+    "agent_status",
+}
+
+ALL_CLASSIFIED = READ_TOOLS | DELETE_CLASS_TOOLS | WRITE_TOOLS
+
+
+def _tools(pkg):
+    return {t.name: t for t in pkg["mcp"]._tool_manager.list_tools()}
+
+
+def test_every_tool_is_classified(fresh_mp):
+    """A new tool that is not added to one of the curated sets fails here,
+    forcing an explicit read/write decision."""
+    registered = set(_tools(fresh_mp))
+    assert registered == ALL_CLASSIFIED, {
+        "unclassified": sorted(registered - ALL_CLASSIFIED),
+        "stale_in_test": sorted(ALL_CLASSIFIED - registered),
+    }
+
+
+def test_every_tool_has_explicit_read_write_hint(fresh_mp):
+    tools = _tools(fresh_mp)
+    missing = [
+        n for n, t in tools.items()
+        if t.annotations is None or t.annotations.readOnlyHint is None
+    ]
+    assert not missing, f"tools missing explicit readOnlyHint: {sorted(missing)}"
+
+
+def test_read_tools_are_read_only(fresh_mp):
+    tools = _tools(fresh_mp)
+    for n in READ_TOOLS:
+        a = tools[n].annotations
+        assert a.readOnlyHint is True, f"{n} should be readOnlyHint=True"
+        assert a.destructiveHint in (None, False), f"{n} read tool is destructive?"
+
+
+def test_no_mutating_tool_marked_read_only(fresh_mp):
+    tools = _tools(fresh_mp)
+    bad = [
+        n for n in (WRITE_TOOLS | DELETE_CLASS_TOOLS)
+        if tools[n].annotations.readOnlyHint is not False
+    ]
+    assert not bad, f"mutating tools wrongly marked read-only: {sorted(bad)}"
+
+
+def test_delete_class_tools_are_destructive(fresh_mp):
+    tools = _tools(fresh_mp)
+    for n in DELETE_CLASS_TOOLS:
+        a = tools[n].annotations
+        assert a.readOnlyHint is False, f"{n} delete-class must not be read-only"
+        assert a.destructiveHint is True, f"{n} must carry destructiveHint=True"
+
+
+def test_non_destructive_writes_not_flagged_destructive(fresh_mp):
+    tools = _tools(fresh_mp)
+    bad = [n for n in WRITE_TOOLS if tools[n].annotations.destructiveHint is True]
+    assert not bad, f"non-destructive writes flagged destructive: {sorted(bad)}"
+
+
+def test_annotation_consistency(fresh_mp):
+    """destructive/idempotent hints are only meaningful when not read-only."""
+    tools = _tools(fresh_mp)
+    for n, t in tools.items():
+        a = t.annotations
+        if a.readOnlyHint:
+            assert a.destructiveHint in (None, False), n
+            assert a.idempotentHint in (None, False), n
+        if a.destructiveHint:
+            assert a.readOnlyHint is False, n
+
+
+@pytest.mark.parametrize("name", sorted(STATUS_TOOLS))
+def test_status_tools_emit_validating_structured_content(fresh_mp, name):
+    pkg = fresh_mp
+    tools = _tools(pkg)
+    tool = tools[name]
+    assert tool.output_schema is not None, f"{name} must advertise outputSchema"
+
+    fn = pkg["mcp"]._tool_manager._tools[name].fn
+    kwargs = {"refresh": False} if name == "agent_status" else {}
+    result = fn(**kwargs)
+
+    # legacy human-readable text block preserved
+    text_blocks = [
+        c for c in result.content
+        if getattr(c, "type", None) == "text" and c.text
+    ]
+    assert text_blocks, f"{name} dropped its legacy text block"
+
+    # structured content present and validates against the advertised schema
+    assert result.structuredContent is not None, f"{name} returned no structuredContent"
+    jsonschema.validate(result.structuredContent, tool.output_schema)

--- a/threadkeeper/_mcp.py
+++ b/threadkeeper/_mcp.py
@@ -1,6 +1,64 @@
 """Singleton FastMCP instance shared by every tool module. All
 @mcp.tool() definitions across the package register on this same instance,
-so server.py can simply import every tool module and call mcp.run()."""
+so server.py can simply import every tool module and call mcp.run().
+
+Tools are registered through two thin wrappers around ``mcp.tool`` that
+attach MCP 2025-06-18 ``ToolAnnotations`` so clients can tell reads from
+writes without calling them:
+
+  * ``@read_tool()``  — pure query, no state mutation (``readOnlyHint=True``).
+  * ``@write_tool()`` — mutates state (``readOnlyHint=False``); pass
+    ``destructive=True`` for delete/overwrite/kill tools and
+    ``idempotent=True`` where a repeat call is a no-op.
+
+This static metadata layer is what a confirmation/elicitation client reads
+to decide which calls warrant a prompt (roadmap #67; substrate for #26).
+"""
 from mcp.server.fastmcp import FastMCP
+from mcp.types import CallToolResult, TextContent, ToolAnnotations
+from pydantic import BaseModel
 
 mcp = FastMCP("thread-keeper")
+
+
+def read_tool(**kwargs):
+    """Register a read-only MCP tool (``readOnlyHint=True``).
+
+    Use for pure queries that do not modify thread-keeper state — briefs,
+    searches, status snapshots, listings. Extra kwargs pass through to
+    ``mcp.tool`` (e.g. ``name=``)."""
+    return mcp.tool(
+        annotations=ToolAnnotations(readOnlyHint=True),
+        **kwargs,
+    )
+
+
+def write_tool(*, destructive: bool = False, idempotent: bool = False, **kwargs):
+    """Register a state-mutating MCP tool (``readOnlyHint=False``).
+
+    ``destructive=True`` sets ``destructiveHint=True`` for tools that delete,
+    overwrite, archive, or kill (``compost`` excluded — it only reads).
+    ``idempotent=True`` sets ``idempotentHint=True`` where repeating the call
+    is a no-op (closing an already-closed thread, deleting a missing key)."""
+    return mcp.tool(
+        annotations=ToolAnnotations(
+            readOnlyHint=False,
+            destructiveHint=destructive,
+            idempotentHint=idempotent,
+        ),
+        **kwargs,
+    )
+
+
+def structured_result(text: str, model: BaseModel) -> CallToolResult:
+    """Build a CallToolResult that carries BOTH the legacy human-readable
+    ``text`` block AND ``model`` as machine-readable ``structuredContent``.
+
+    The tool's return annotation (a pydantic model) supplies the advertised
+    ``outputSchema`` in ``tools/list``; this helper keeps the serialized text
+    block for backward compatibility, as the MCP 2025-06-18 spec recommends
+    for tools that emit structured content."""
+    return CallToolResult(
+        content=[TextContent(type="text", text=text)],
+        structuredContent=model.model_dump(mode="json", by_alias=True),
+    )

--- a/threadkeeper/tool_schemas.py
+++ b/threadkeeper/tool_schemas.py
@@ -1,0 +1,111 @@
+"""Typed output schemas for the status tools that advertise an MCP
+``outputSchema`` and return ``structuredContent`` (roadmap #67).
+
+Each model is used as the return annotation of its tool so FastMCP derives
+the ``outputSchema`` exposed in ``tools/list``; the tool body builds the
+model and hands it to :func:`threadkeeper._mcp.structured_result`, which
+keeps the legacy human-readable text block alongside the structured JSON.
+
+Nested/list members allow extra keys so the snapshot producers can grow
+new fields without breaking validation.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class _Lenient(BaseModel):
+    """Base for nested rows that may gain fields over time."""
+
+    model_config = ConfigDict(extra="allow")
+
+
+# --- context -----------------------------------------------------------------
+class ContextStatus(BaseModel):
+    """Runtime context: session, semantic flag, db path, thread counts."""
+
+    session_id: str | None = None
+    started_age_s: int = 0
+    semantic: bool = False
+    db_path: str = ""
+    thread_counts: dict[str, int] = Field(default_factory=dict)
+    now: str = ""
+
+
+# --- spawn_budget_status -----------------------------------------------------
+class SpawnTaskRss(_Lenient):
+    id: str
+    pid: int = 0
+    cid: str = "-"
+    rss_mb: int = 0
+    age_s: int = 0
+    prompt: str = ""
+
+
+class SpawnBudgetStatus(BaseModel):
+    """Spawn-budget usage: cap, used, free, plus per-running-task RSS."""
+
+    enabled: bool = True
+    cap_mb: int | None = None
+    used_mb: int = 0
+    free_mb: int | None = None
+    running: int = 0
+    poll_s: int | None = None
+    tasks: list[SpawnTaskRss] = Field(default_factory=list)
+
+
+# --- spawn_status ------------------------------------------------------------
+class CliCapability(_Lenient):
+    cli: str
+    available: bool = False
+    bin: str | None = None
+    note: str | None = None
+
+
+class SpawnStatus(BaseModel):
+    """Detected host CLI plus per-role spawn resolution and capabilities."""
+
+    active_cli: str | None = None
+    role_resolution: str = ""
+    capabilities: list[CliCapability] = Field(default_factory=list)
+
+
+# --- mp_health ---------------------------------------------------------------
+class MpProcess(_Lenient):
+    pid: int
+    ppid: int = 0
+    parent_alive: bool = False
+    rss_kb: int = 0
+    heartbeat_age_s: int | None = None
+    etime: str = ""
+    is_self: bool = False
+    is_orphaned: bool = False
+    orphan_reason: str | None = None
+
+
+class MpHealth(BaseModel):
+    """Snapshot of every running thread-keeper server process on the host."""
+
+    total: int = 0
+    live: int = 0
+    orphans: int = 0
+    rss_total_mb: int = 0
+    processes: list[MpProcess] = Field(default_factory=list)
+
+
+# --- agent_status ------------------------------------------------------------
+class AgentStatusSnapshot(_Lenient):
+    """Autonomous learning loops + running children (JSON-ready snapshot)."""
+
+    generated_at: int = 0
+    running_count: int = 0
+    total_rss_kb: int = 0
+    total_rss_mb: int = 0
+    enabled_loop_count: int = 0
+    running_loop_count: int = 0
+    ready_loop_count: int = 0
+    loops: list[dict[str, Any]] = Field(default_factory=list)
+    recent_results: list[dict[str, Any]] = Field(default_factory=list)
+    agents: list[dict[str, Any]] = Field(default_factory=list)

--- a/threadkeeper/tools/agent_status.py
+++ b/threadkeeper/tools/agent_status.py
@@ -3,28 +3,33 @@ from __future__ import annotations
 
 import json
 
-from .._mcp import mcp
+from .._mcp import read_tool, write_tool, structured_result
 from ..agent_status import (
     agent_status_snapshot,
     format_agent_status,
     format_memory_cleanup,
     memory_cleanup,
 )
+from ..tool_schemas import AgentStatusSnapshot
 
 
-@mcp.tool()
-def agent_status(json_output: bool = False, refresh: bool = True) -> str:
+@read_tool()
+def agent_status(json_output: bool = False, refresh: bool = True) -> AgentStatusSnapshot:
     """Show autonomous learning loops with state, backlog, last pass, and RSS.
 
     Set json_output=True for the same stable shape used by the menu-bar app.
+    Always returns structuredContent (AgentStatusSnapshot); the text block is
+    the JSON dump when json_output else the formatted summary.
     """
     snapshot = agent_status_snapshot(refresh=refresh)
     if json_output:
-        return json.dumps(snapshot, ensure_ascii=False, sort_keys=True)
-    return format_agent_status(snapshot)
+        text = json.dumps(snapshot, ensure_ascii=False, sort_keys=True)
+    else:
+        text = format_agent_status(snapshot)
+    return structured_result(text, AgentStatusSnapshot(**snapshot))
 
 
-@mcp.tool()
+@write_tool(destructive=True)
 def agent_memory_cleanup(
     json_output: bool = False,
     dry_run: bool = False,

--- a/threadkeeper/tools/candidate_reviewer.py
+++ b/threadkeeper/tools/candidate_reviewer.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 import time
 
-from .._mcp import mcp
+from .._mcp import read_tool, write_tool
 from ..db import get_db
 from ..identity import _ensure_session
 from ..candidate_reviewer import (
@@ -26,7 +26,7 @@ from ..config import (
 )
 
 
-@mcp.tool()
+@write_tool()
 def candidate_review_run(force: bool = False, dry_run: bool = False) -> str:
     """Fire one candidate-review pass.
 
@@ -53,7 +53,7 @@ def candidate_review_run(force: bool = False, dry_run: bool = False) -> str:
     return run_review_pass(force=force)
 
 
-@mcp.tool()
+@read_tool()
 def candidate_review_status() -> str:
     """Show candidate-reviewer configuration + last 5 passes +
     current pending queue size."""

--- a/threadkeeper/tools/concepts.py
+++ b/threadkeeper/tools/concepts.py
@@ -8,7 +8,7 @@ import sqlite3
 import time
 from typing import Optional
 
-from .._mcp import mcp
+from .._mcp import read_tool, write_tool
 from ..config import SEMANTIC_AVAILABLE
 from ..db import get_db
 from ..embeddings import _embed, embed_tag
@@ -122,7 +122,7 @@ def _bump_concept_evidence(conn: sqlite3.Connection,
     return new_conf
 
 
-@mcp.tool()
+@write_tool()
 def register_concept(description: str,
                      triangulation_notes: str = "",
                      confidence: str = "medium",
@@ -174,7 +174,7 @@ def register_concept(description: str,
     return f"ok id={pid} conf={confidence}"
 
 
-@mcp.tool()
+@read_tool()
 def list_concepts(min_confidence: str = "low", k: int = 10) -> str:
     """List registered concepts, filtered by minimum confidence."""
     rank = {"low": 0, "medium": 1, "high": 2}
@@ -211,7 +211,7 @@ def list_concepts(min_confidence: str = "low", k: int = 10) -> str:
     return "\n".join(lines)
 
 
-@mcp.tool()
+@read_tool()
 def expand_concept(concept_id: str) -> str:
     """Full description + triangulation_notes for one concept."""
     conn = get_db()
@@ -233,7 +233,7 @@ def expand_concept(concept_id: str) -> str:
     return "\n".join(parts)
 
 
-@mcp.tool()
+@write_tool(destructive=True)
 def concept_manage(action: str,
                    concept_id: str,
                    merge_ids: str = "",

--- a/threadkeeper/tools/config_watch.py
+++ b/threadkeeper/tools/config_watch.py
@@ -14,14 +14,14 @@ from __future__ import annotations
 
 import time
 
-from .._mcp import mcp
+from .._mcp import read_tool, write_tool
 from ..db import get_db
 from ..identity import _ensure_session
 from .. import config
 from .. import config_watcher
 
 
-@mcp.tool()
+@write_tool(idempotent=True)
 def config_reload(force: bool = True) -> str:
     """Re-read the watched settings file and hot-apply changed env knobs.
 
@@ -36,7 +36,7 @@ def config_reload(force: bool = True) -> str:
     return config_watcher.run_config_watch_pass(force=force)
 
 
-@mcp.tool()
+@read_tool()
 def config_watch_status() -> str:
     """Show hot-config-reload state + the last 5 reload passes."""
     conn = get_db()

--- a/threadkeeper/tools/consolidate.py
+++ b/threadkeeper/tools/consolidate.py
@@ -12,7 +12,7 @@ reports (and optionally applies) four kinds of cleanup:
 import sqlite3
 import time
 
-from .._mcp import mcp
+from .._mcp import read_tool, write_tool
 from ..db import get_db
 from ..config import SEMANTIC_AVAILABLE
 from ..helpers import fmt_age, q, normalize_text
@@ -26,7 +26,7 @@ CONSOLIDATE_STALE_THREAD_DAYS = 30
 CONSOLIDATE_ORPHAN_CLAIM_DAYS = 7
 
 
-@mcp.tool()
+@write_tool(destructive=True)
 def consolidate(dry_run: bool = True,
                 stale_days: int = CONSOLIDATE_STALE_THREAD_DAYS,
                 orphan_days: int = CONSOLIDATE_ORPHAN_CLAIM_DAYS,

--- a/threadkeeper/tools/core_memory.py
+++ b/threadkeeper/tools/core_memory.py
@@ -8,7 +8,7 @@ store. Entries are capped at 1KB and a soft hint at 20 entries total.
 import sqlite3
 import time
 
-from .._mcp import mcp
+from .._mcp import read_tool, write_tool
 from ..db import get_db
 from ..helpers import fmt_age, q
 from ..identity import _ensure_session, _emit
@@ -20,7 +20,7 @@ CORE_PRIORITY_MIN = 0
 CORE_PRIORITY_MAX = 100
 
 
-@mcp.tool()
+@write_tool(idempotent=True)
 def core_set(key: str, content: str, priority: int = 50) -> str:
     """Upsert a core-memory entry. ALWAYS shown in brief, sorted by priority DESC.
 
@@ -55,7 +55,7 @@ def core_set(key: str, content: str, priority: int = 50) -> str:
     return f"ok n={n}{warn}"
 
 
-@mcp.tool()
+@write_tool(destructive=True, idempotent=True)
 def core_remove(key: str) -> str:
     """Delete a core-memory entry by key."""
     conn = get_db()
@@ -68,7 +68,7 @@ def core_remove(key: str) -> str:
     return "ok"
 
 
-@mcp.tool()
+@read_tool()
 def core_list() -> str:
     """List all core-memory entries, ordered by priority DESC then key."""
     conn = get_db()
@@ -91,7 +91,7 @@ def core_list() -> str:
     return "\n".join(lines)
 
 
-@mcp.tool()
+@read_tool()
 def core_get(key: str) -> str:
     """Return the full content of a single core-memory entry."""
     conn = get_db()

--- a/threadkeeper/tools/correlation.py
+++ b/threadkeeper/tools/correlation.py
@@ -8,13 +8,13 @@ spawned task as a chronological thread of signals plus relevant notes.
 import sqlite3
 import time
 
-from .._mcp import mcp
+from .._mcp import read_tool, write_tool
 from ..db import get_db
 from ..helpers import fmt_age, q
 from ..identity import _ensure_session
 
 
-@mcp.tool()
+@write_tool()
 def tag_signal(signal_id: int, task_id: str) -> str:
     """Manually attach a signal to a task. Useful when retroactively building
     a task-thread (auto-tagging happens at signal-emit time when the cid
@@ -37,7 +37,7 @@ def tag_signal(signal_id: int, task_id: str) -> str:
     return f"ok signal={signal_id} → task={task_id}"
 
 
-@mcp.tool()
+@read_tool()
 def task_thread(task_id: str, include_notes: bool = True,
                 k: int = 50) -> str:
     """Replay a spawned task as a chronological thread: every signal tagged

--- a/threadkeeper/tools/curator.py
+++ b/threadkeeper/tools/curator.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 import time
 
-from .._mcp import mcp
+from .._mcp import read_tool, write_tool
 from ..db import get_db
 from ..identity import _ensure_session
 from ..curator import (
@@ -35,7 +35,7 @@ from ..config import (
 )
 
 
-@mcp.tool()
+@write_tool()
 def curator_review(force: bool = False, dry_run: bool = False) -> str:
     """Fire one curator pass.
 
@@ -65,7 +65,7 @@ def curator_review(force: bool = False, dry_run: bool = False) -> str:
     return run_curator_pass(force=force)
 
 
-@mcp.tool()
+@read_tool()
 def curator_review_status() -> str:
     """Show curator configuration + last 5 passes + latest REPORT path.
 

--- a/threadkeeper/tools/dashboard.py
+++ b/threadkeeper/tools/dashboard.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 import sqlite3
 import time
 
-from .._mcp import mcp
+from .._mcp import read_tool, write_tool
 from ..db import get_db
 from ..helpers import fmt_age
 from ..identity import _ensure_session
@@ -86,7 +86,7 @@ _OUTCOME_KINDS = (
 )
 
 
-@mcp.tool()
+@read_tool()
 def mp_dashboard(window_days: int = 7) -> str:
     """One-call rollup of the whole thread-keeper system: store sizes, how
     often each autonomous loop fired (in the last `window_days` and 30d),

--- a/threadkeeper/tools/dialectic.py
+++ b/threadkeeper/tools/dialectic.py
@@ -59,7 +59,7 @@ import sqlite3
 import time
 from typing import Optional
 
-from .._mcp import mcp
+from .._mcp import read_tool, write_tool
 from ..config import WRITE_ORIGIN
 from ..db import get_db
 from ..helpers import fmt_age, q, gen_dialectic_id
@@ -321,7 +321,7 @@ def _insert_evidence(conn: sqlite3.Connection, claim_id: str, kind: str,
     return cur.lastrowid
 
 
-@mcp.tool()
+@write_tool()
 def dialectic_claim(claim: str, domain: str = "", evidence: str = "",
                     evidence_kind: str = "support") -> str:
     """Register a new claim about the user. Optionally seed with first
@@ -366,7 +366,7 @@ def dialectic_claim(claim: str, domain: str = "", evidence: str = "",
     return f"ok id={pid} conf={new_conf} tier={new_tier}"
 
 
-@mcp.tool()
+@write_tool()
 def dialectic_evidence(claim_id: str, kind: str = "support",
                        quote: str = "", source: str = "",
                        weight: float = 1.0) -> str:
@@ -414,7 +414,7 @@ def dialectic_evidence(claim_id: str, kind: str = "support",
     )
 
 
-@mcp.tool()
+@read_tool()
 def dialectic_review(min_confidence: str = "low",
                      domain: str = "",
                      k: int = 20) -> str:
@@ -478,7 +478,7 @@ def dialectic_review(min_confidence: str = "low",
     return "\n".join([f"claims n={len(out)}"] + out)
 
 
-@mcp.tool()
+@read_tool()
 def dialectic_synthesis(domain: str = "") -> str:
     """Terse rendering of accumulated beliefs about the user, grouped by
     domain. Used as brief() input. Excludes low/disputed claims and
@@ -560,7 +560,7 @@ def dialectic_synthesis(domain: str = "") -> str:
     return "\n".join(lines)
 
 
-@mcp.tool()
+@write_tool()
 def dialectic_supersede(old_claim_id: str, new_claim: str,
                         domain: str = "", quote: str = "") -> str:
     """Retire `old_claim_id` and register `new_claim` that refines or
@@ -616,7 +616,7 @@ def dialectic_supersede(old_claim_id: str, new_claim: str,
     return f"ok new={pid} old={old_id} conf={new_conf} tier={new_tier}"
 
 
-@mcp.tool()
+@write_tool(idempotent=True)
 def dialectic_observation_resolve(id: int, note: str = "") -> str:
     """Mark a dialectic_observations buffer row 'processed' so the validator
     never re-interprets it. Called by the validator child after it has written

--- a/threadkeeper/tools/dialectic_feed.py
+++ b/threadkeeper/tools/dialectic_feed.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import time
 
-from .._mcp import mcp
+from .._mcp import read_tool, write_tool
 from ..db import get_db
 from ..identity import _ensure_session
 from ..dialectic_miner import run_mine_pass, _last_mine_ts
@@ -24,7 +24,7 @@ from ..config import (
 )
 
 
-@mcp.tool()
+@write_tool()
 def dialectic_mine_run(force: bool = True) -> str:
     """Fire one mechanical capture pass now (force=True runs even when the
     miner daemon interval is 0)."""
@@ -33,7 +33,7 @@ def dialectic_mine_run(force: bool = True) -> str:
     return run_mine_pass(force=force)
 
 
-@mcp.tool()
+@write_tool()
 def dialectic_validate_run(force: bool = True, dry_run: bool = False) -> str:
     """Fire one validator pass. dry_run shows pending count + would_spawn
     without spawning or advancing the cursor."""
@@ -51,7 +51,7 @@ def dialectic_validate_run(force: bool = True, dry_run: bool = False) -> str:
     return run_validate_pass(force=force)
 
 
-@mcp.tool()
+@read_tool()
 def dialectic_mine_status() -> str:
     """Miner config + buffer sizes + last 5 capture passes."""
     conn = get_db()
@@ -83,7 +83,7 @@ def dialectic_mine_status() -> str:
     return "\n".join(lines)
 
 
-@mcp.tool()
+@read_tool()
 def dialectic_validate_status() -> str:
     """Validator config + pending observation count + last 5 passes."""
     conn = get_db()

--- a/threadkeeper/tools/dialog.py
+++ b/threadkeeper/tools/dialog.py
@@ -11,7 +11,7 @@ import subprocess
 import time
 from pathlib import Path
 
-from .._mcp import mcp
+from .._mcp import read_tool, write_tool
 from ..config import TASK_LOG_DIR, DIALOG_LOG, SEMANTIC_AVAILABLE
 from ..db import get_db
 from ..helpers import fmt_age, q
@@ -20,7 +20,7 @@ from ..embeddings import _dialog_cosine_search, _fts_search, _rrf_combine
 from ..ingest import _ingest_all
 
 
-@mcp.tool()
+@write_tool()
 def open_dialog_window() -> str:
     """Open a Terminal window that tails the live cross-session signal log.
 
@@ -50,7 +50,7 @@ def open_dialog_window() -> str:
     return f"opened tailing {DIALOG_LOG}"
 
 
-@mcp.tool()
+@read_tool()
 def dialog_search(query: str, k: int = 5, role: str = "",
                   mode: str = "hybrid") -> str:
     """Search ingested Claude Code transcripts.
@@ -118,7 +118,7 @@ def _legacy_like_fallback(conn: sqlite3.Connection, query: str,
     )
 
 
-@mcp.tool()
+@write_tool()
 def ingest(max_msgs: int = 5000) -> str:
     """Ingest new Claude Code transcripts. Auto-runs on session start; call
     manually for backfill or after long absence."""

--- a/threadkeeper/tools/distill.py
+++ b/threadkeeper/tools/distill.py
@@ -12,7 +12,7 @@ import time
 from pathlib import Path
 from typing import Optional
 
-from .._mcp import mcp
+from .._mcp import read_tool, write_tool
 from ..db import get_db
 from ..config import TASK_LOG_DIR
 from ..helpers import fmt_age, q, gen_distill_id
@@ -23,7 +23,7 @@ DISTILL_KINDS = ("insight", "pattern", "anti-pattern", "fix",
                  "terminology", "concept")
 
 
-@mcp.tool()
+@write_tool()
 def distill(content: str, kind: str = "insight",
             confidence: str = "medium", source_thread: str = "") -> str:
     """Mark content as worth carrying forward (distillation channel).
@@ -69,7 +69,7 @@ def distill(content: str, kind: str = "insight",
     return f"ok id={pid} kind={kind} conf={confidence} vote=1.0"
 
 
-@mcp.tool()
+@write_tool()
 def vote_distill(distill_id: str, weight: float) -> str:
     """Vote on a distillate, weight ∈ [-1, +1]. One vote per cid; re-voting
     overwrites your previous vote. Updates aggregate vote_sum/vote_count."""
@@ -109,7 +109,7 @@ def vote_distill(distill_id: str, weight: float) -> str:
     return f"ok id={did} vote_sum={agg['s']:.2f} count={agg['c']}"
 
 
-@mcp.tool()
+@read_tool()
 def pending_distillates(min_vote: float = 1.0, k: int = 10) -> str:
     """List distillates with vote_sum >= min_vote, not yet exported."""
     conn = get_db()
@@ -138,7 +138,7 @@ def pending_distillates(min_vote: float = 1.0, k: int = 10) -> str:
     return "\n".join(lines)
 
 
-@mcp.tool()
+@write_tool()
 def export_distillates(min_vote: float = 1.0,
                        output_path: str = "") -> str:
     """Write distillates with vote_sum >= min_vote to a jsonl bucket.

--- a/threadkeeper/tools/evolve_applier.py
+++ b/threadkeeper/tools/evolve_applier.py
@@ -31,7 +31,7 @@ from __future__ import annotations
 
 import time
 
-from .._mcp import mcp
+from .._mcp import read_tool, write_tool
 from ..db import get_db
 from ..identity import _ensure_session
 from ..config import EVOLVE_APPLY_INTERVAL_S
@@ -50,7 +50,7 @@ from ..evolve_applier import (
 )
 
 
-@mcp.tool()
+@write_tool()
 def evolve_apply(evolve_id: int) -> str:
     """Implement a PROMOTED + not-yet-applied format-evolution suggestion.
 
@@ -72,7 +72,7 @@ def evolve_apply(evolve_id: int) -> str:
     return apply_evolve(int(evolve_id))
 
 
-@mcp.tool()
+@write_tool()
 def evolve_apply_curator_report(report_path: str = "") -> str:
     """Apply a Curator advisory report using the existing evolve_applier role.
 
@@ -86,7 +86,7 @@ def evolve_apply_curator_report(report_path: str = "") -> str:
     return apply_curator_report(report_path)
 
 
-@mcp.tool()
+@write_tool()
 def evolve_apply_roadmap_issue(issue_number: int = 0) -> str:
     """Implement one open GitHub issue through the evolve_applier role.
 
@@ -99,7 +99,7 @@ def evolve_apply_roadmap_issue(issue_number: int = 0) -> str:
     return apply_roadmap_issue(int(issue_number or 0))
 
 
-@mcp.tool()
+@write_tool(idempotent=True)
 def evolve_mark_applied(evolve_id: int, pr_url: str) -> str:
     """Mark a format-evolution suggestion as APPLIED — called by the
     evolve_applier child after it has opened the PR.
@@ -116,7 +116,7 @@ def evolve_mark_applied(evolve_id: int, pr_url: str) -> str:
     return mark_applied(conn, int(evolve_id), pr_url.strip())
 
 
-@mcp.tool()
+@write_tool(idempotent=True)
 def evolve_mark_roadmap_issue_applied(issue_number: int, pr_url: str) -> str:
     """Mark a roadmap issue as handed off — called by evolve_applier only
     after it has opened a real pull request for that issue."""
@@ -130,7 +130,7 @@ def evolve_mark_roadmap_issue_applied(issue_number: int, pr_url: str) -> str:
     )
 
 
-@mcp.tool()
+@write_tool(idempotent=True)
 def evolve_mark_curator_report_applied(report_path: str, summary: str) -> str:
     """Mark a Curator report as processed by the evolve_applier child.
 
@@ -144,7 +144,7 @@ def evolve_mark_curator_report_applied(report_path: str, summary: str) -> str:
     return mark_curator_report_applied(conn, report_path.strip(), summary)
 
 
-@mcp.tool()
+@read_tool()
 def evolve_apply_status() -> str:
     """Show evolve-applier config + curator/evolve queues + running applier
     + the last 5 apply passes."""

--- a/threadkeeper/tools/extract.py
+++ b/threadkeeper/tools/extract.py
@@ -9,7 +9,7 @@ import sqlite3
 import time
 import re as _re_extract
 
-from .._mcp import mcp
+from .._mcp import read_tool, write_tool
 from ..db import get_db
 from ..config import SEMANTIC_AVAILABLE
 from ..helpers import fmt_age, q, gen_concept_id, gen_distill_id
@@ -127,7 +127,7 @@ def _enqueue(conn, kind, source_uuid, source_cid, content, rationale):
     return cur.lastrowid
 
 
-@mcp.tool()
+@write_tool()
 def extract_recent(window_min: int = 60, max_messages: int = 500) -> str:
     """Scan recent dialog_messages and enqueue heuristic candidates.
 
@@ -303,7 +303,7 @@ def extract_recent(window_min: int = 60, max_messages: int = 500) -> str:
     )
 
 
-@mcp.tool()
+@read_tool()
 def review_candidates(status: str = "pending", k: int = 20) -> str:
     """status ∈ {pending, accepted, rejected, all}. Newest first."""
     valid = ("pending", "accepted", "rejected", "all")
@@ -343,7 +343,7 @@ def review_candidates(status: str = "pending", k: int = 20) -> str:
 _VALID_TARGET_KINDS = ("note", "concept", "distill", "verbatim")
 
 
-@mcp.tool()
+@write_tool()
 def accept_candidate(id: int, target_kind: str = "",
                      thread_id: str = "") -> str:
     """Materialize candidate into its target table.
@@ -435,7 +435,7 @@ def accept_candidate(id: int, target_kind: str = "",
     return f"ok accepted #{id} → {placed}"
 
 
-@mcp.tool()
+@write_tool(idempotent=True)
 def reject_candidate(id: int, reason: str = "") -> str:
     """Mark rejected. Reason appended to rationale for heuristic tuning."""
     conn = get_db()

--- a/threadkeeper/tools/graph.py
+++ b/threadkeeper/tools/graph.py
@@ -9,7 +9,7 @@ import sqlite3
 import time
 from typing import Optional
 
-from .._mcp import mcp
+from .._mcp import read_tool, write_tool
 from ..db import get_db
 from ..helpers import fmt_age
 from ..identity import _ensure_session, _detect_self_cid, _emit
@@ -70,7 +70,7 @@ def _snippet_for(conn: sqlite3.Connection, kind: str, eid: str) -> str:
     return text
 
 
-@mcp.tool()
+@write_tool()
 def link(from_kind: str, from_id: str, to_kind: str, to_id: str,
          relation: str, weight: float = 1.0) -> str:
     """Create a typed edge between two entities.
@@ -124,7 +124,7 @@ def link(from_kind: str, from_id: str, to_kind: str, to_id: str,
     return f"ok edge={eid}"
 
 
-@mcp.tool()
+@write_tool(destructive=True, idempotent=True)
 def unlink(edge_id: int) -> str:
     """Remove an edge by id."""
     conn = get_db()
@@ -137,7 +137,7 @@ def unlink(edge_id: int) -> str:
     return "ok"
 
 
-@mcp.tool()
+@read_tool()
 def neighbors(kind: str, id: str, depth: int = 1, max_n: int = 12) -> str:
     """BFS the graph from a starting node up to `depth` hops away.
     Returns each visited node with its kind, id, and a short content snippet

--- a/threadkeeper/tools/invariants.py
+++ b/threadkeeper/tools/invariants.py
@@ -13,14 +13,14 @@ import sqlite3
 import time
 from typing import Optional
 
-from .._mcp import mcp
+from .._mcp import read_tool, write_tool
 from ..db import get_db
 from ..config import SEMANTIC_AVAILABLE
 from ..helpers import fmt_age, q
 from ..identity import _ensure_session
 
 
-@mcp.tool()
+@read_tool()
 def find_invariants(window_days: int = 14,
                     min_cluster_size: int = 3,
                     response_cohesion: float = 0.85,

--- a/threadkeeper/tools/lessons.py
+++ b/threadkeeper/tools/lessons.py
@@ -27,7 +27,7 @@ from datetime import datetime
 import re
 from typing import Optional
 
-from .._mcp import mcp
+from .._mcp import read_tool, write_tool
 from .. import identity
 from ..identity import _ensure_session
 from ..db import get_db
@@ -92,7 +92,7 @@ def _similar_lesson_slug(title: str) -> tuple[str, float] | None:
     return None
 
 
-@mcp.tool()
+@write_tool()
 def lesson_append(
     title: str,
     body: str,
@@ -152,7 +152,7 @@ def lesson_append(
     return f"ok slug={slug} path={get_path()}"
 
 
-@mcp.tool()
+@read_tool()
 def lesson_list(k: int = 20) -> str:
     """Compact listing of materialized lessons, newest first.
 
@@ -183,7 +183,7 @@ def lesson_list(k: int = 20) -> str:
     return "\n".join(out)
 
 
-@mcp.tool()
+@read_tool()
 def lesson_get(slug: str) -> str:
     """Return the full body of one lesson by slug. Useful when
     `lesson_list` surfaced something you want to read in full."""
@@ -195,7 +195,7 @@ def lesson_get(slug: str) -> str:
     return f"ERR not_found slug={slug}"
 
 
-@mcp.tool()
+@write_tool(destructive=True, idempotent=True)
 def lesson_remove(slug: str, force: bool = False) -> str:
     """Remove one materialized lesson section by slug.
 

--- a/threadkeeper/tools/memory_guard.py
+++ b/threadkeeper/tools/memory_guard.py
@@ -1,6 +1,6 @@
 """MCP tools for the thread-keeper server RSS guard."""
 
-from .._mcp import mcp
+from .._mcp import read_tool, write_tool
 from .. import memory_guard
 from ..db import get_db
 from ..identity import _ensure_session
@@ -13,7 +13,7 @@ def _fmt_proc(p: dict, prefix: str) -> str:
     )
 
 
-@mcp.tool()
+@read_tool()
 def memory_guard_status() -> str:
     """Show memory-guard thresholds and current thread-keeper RSS rows."""
     conn = get_db()
@@ -51,7 +51,7 @@ def memory_guard_status() -> str:
     return "\n".join(out)
 
 
-@mcp.tool()
+@write_tool(destructive=True)
 def memory_guard_check(dry_run: bool = True, notify: bool = False) -> str:
     """Run one memory-guard pass now.
 
@@ -102,7 +102,7 @@ def memory_guard_check(dry_run: bool = True, notify: bool = False) -> str:
     return "\n".join(out)
 
 
-@mcp.tool()
+@write_tool()
 def memory_guard_reclaim(scope: str = "self") -> str:
     """Unload thread-keeper model/caches now.
 

--- a/threadkeeper/tools/missed_spawns.py
+++ b/threadkeeper/tools/missed_spawns.py
@@ -17,7 +17,7 @@ import sqlite3
 import time
 from datetime import datetime, timezone
 
-from .._mcp import mcp
+from .._mcp import read_tool, write_tool
 from ..db import get_db
 from ..helpers import fmt_age, q
 from ..identity import _ensure_session
@@ -35,7 +35,7 @@ _HEADER_RE = re.compile(r"(?m)^#{2,3}\s+\S")
 _SPAWN_PROXIMITY_S = 600
 
 
-@mcp.tool()
+@read_tool()
 def find_missed_spawns(window_days: int = 14,
                        min_response_len: int = 400,
                        min_numbered: int = 2,

--- a/threadkeeper/tools/panel.py
+++ b/threadkeeper/tools/panel.py
@@ -29,7 +29,7 @@ import re
 import sqlite3
 from typing import Optional
 
-from .._mcp import mcp
+from .._mcp import read_tool, write_tool
 from ..config import (
     PANEL_SIZE, PANEL_ROLES, PANEL_REQUIRE_SKEPTIC,
     PANEL_MODEL, PANEL_EFFORT,
@@ -117,7 +117,7 @@ def _child_prompt(kind: str, target_id: str, content: str,
     )
 
 
-@mcp.tool()
+@write_tool()
 def convene_panel(target_kind: str, target_id: str,
                   size: int = 0, roles: str = "") -> str:
     """Spawn a panel of independent agents to vote on a distillate or claim,

--- a/threadkeeper/tools/peers.py
+++ b/threadkeeper/tools/peers.py
@@ -9,7 +9,7 @@ import sqlite3
 import time
 from typing import Optional
 
-from .._mcp import mcp
+from .._mcp import read_tool, write_tool
 from ..db import get_db
 from ..helpers import fmt_age, q
 from .. import identity
@@ -23,7 +23,7 @@ from ..identity import (
 from ..brief import _append_dialog_log
 
 
-@mcp.tool()
+@read_tool()
 def whoami() -> str:
     """Return this conversation's detected conversation_id + how we know.
 
@@ -45,7 +45,7 @@ def whoami() -> str:
     return f"cid={cid} ({note})"
 
 
-@mcp.tool()
+@read_tool()
 def peers(window_min: int = 5) -> str:
     """List concurrent claude conversations active in the last `window_min`.
 
@@ -109,7 +109,7 @@ def peers(window_min: int = 5) -> str:
     return "\n".join(lines)
 
 
-@mcp.tool()
+@write_tool()
 def broadcast(content: str) -> str:
     """Post a message visible to ALL concurrent claude conversations.
 
@@ -119,7 +119,7 @@ def broadcast(content: str) -> str:
     return _post_signal(to_cid="", content=content, kind="broadcast")
 
 
-@mcp.tool()
+@write_tool()
 def whisper(to_cid: str, content: str) -> str:
     """Post a message visible only to the specified conversation_id.
 
@@ -183,7 +183,7 @@ def _post_signal(to_cid: str, content: str, kind: str) -> str:
     return f"ok id={cur.lastrowid} broadcast{tail}"
 
 
-@mcp.tool()
+@write_tool()
 def wait(timeout_s: int = 30, kinds: str = "", mark_read: bool = True) -> str:
     """Block until a new signal arrives for me or `timeout_s` elapses.
 
@@ -240,7 +240,7 @@ def wait(timeout_s: int = 30, kinds: str = "", mark_read: bool = True) -> str:
         time.sleep(poll_interval)
 
 
-@mcp.tool()
+@write_tool()
 def ask(to_cid: str, question: str, timeout_s: int = 60) -> str:
     """Send a question to a peer and wait synchronously for their answer.
 
@@ -307,7 +307,7 @@ def ask(to_cid: str, question: str, timeout_s: int = 60) -> str:
         time.sleep(0.4)
 
 
-@mcp.tool()
+@write_tool()
 def respond(qid: int, content: str) -> str:
     """Answer a specific question (signals.id) with a directed whisper.
 
@@ -339,7 +339,7 @@ def respond(qid: int, content: str) -> str:
     return f"ok id={cur.lastrowid} -> {qrow['from_cid'][:8]}"
 
 
-@mcp.tool()
+@write_tool()
 def inbox(unread_only: bool = True, k: int = 20, mark_read: bool = True) -> str:
     """Read signals addressed to me (whispers + broadcasts).
 
@@ -382,7 +382,7 @@ def inbox(unread_only: bool = True, k: int = 20, mark_read: bool = True) -> str:
     return "\n".join(lines)
 
 
-@mcp.tool()
+@write_tool()
 def live_status(advance_cursor: bool = True, k: int = 30) -> str:
     """See what OTHER concurrent Claude sessions did since this session last
     polled. Call when brief() shows live=N where N>0, or proactively when you
@@ -429,7 +429,7 @@ def live_status(advance_cursor: bool = True, k: int = 30) -> str:
     return "\n".join(lines)
 
 
-@mcp.tool()
+@write_tool()
 def presence(idle_threshold_min: int = 5) -> str:
     """List concurrent Claude sessions with heartbeats within threshold
     (default 5 min). Excludes self. Useful for understanding who else is
@@ -474,7 +474,7 @@ def _resolve_parent_cid(conn) -> Optional[str]:
     return row["parent_cid"]
 
 
-@mcp.tool()
+@write_tool()
 def search_via_parent(query: str, k: int = 5,
                       scope: str = "notes",
                       mode: str = "hybrid",

--- a/threadkeeper/tools/pickup.py
+++ b/threadkeeper/tools/pickup.py
@@ -9,7 +9,7 @@ import sqlite3
 import time
 from typing import Optional
 
-from .._mcp import mcp
+from .._mcp import read_tool, write_tool
 from ..db import get_db
 from ..helpers import fmt_age, q
 from .. import identity
@@ -18,7 +18,7 @@ from ..embeddings import _embed, embed_tag
 from .spawn import spawn
 
 
-@mcp.tool()
+@read_tool()
 def pickup_candidates(min_idle_days: int = 3, max_n: int = 5) -> str:
     """Surface unresolved threads that are stale and unclaimed — candidates
     for self-initiated pickup when context is free.
@@ -50,7 +50,7 @@ def pickup_candidates(min_idle_days: int = 3, max_n: int = 5) -> str:
     return "\n".join(lines)
 
 
-@mcp.tool()
+@write_tool()
 def claim_pickup(thread_id: str, plan: str = "",
                  spawn_role: str = "", auto_spawn: bool = False) -> str:
     """Claim a thread for self-initiated work. Marks it claimed by my cid.
@@ -124,7 +124,7 @@ def claim_pickup(thread_id: str, plan: str = "",
     return f"ok claimed thread={tid}{spawn_info}"
 
 
-@mcp.tool()
+@write_tool(idempotent=True)
 def release_pickup(thread_id: str) -> str:
     """Release a claim. Only the claimant can release."""
     conn = get_db()

--- a/threadkeeper/tools/probes.py
+++ b/threadkeeper/tools/probes.py
@@ -9,7 +9,7 @@ import sqlite3
 import time
 from typing import Optional
 
-from .._mcp import mcp
+from .._mcp import read_tool, write_tool
 from ..db import get_db
 from ..helpers import fmt_age, q, gen_probe_id
 from .. import identity
@@ -76,7 +76,7 @@ def _recompute_reliability(conn: sqlite3.Connection, category: str) -> dict:
     }
 
 
-@mcp.tool()
+@write_tool()
 def register_probe(category: str, prompt: str,
                    expected_pattern: str = "",
                    grader: str = "regex") -> str:
@@ -110,7 +110,7 @@ def register_probe(category: str, prompt: str,
     return f"ok id={pid} cat={category}"
 
 
-@mcp.tool()
+@read_tool()
 def run_probe(probe_id: str) -> str:
     """Surface a registered probe for self-attempt. Returns the prompt and
     the grader hint. After attempting, call record_attempt(category,
@@ -136,7 +136,7 @@ def run_probe(probe_id: str) -> str:
     return "\n".join(parts)
 
 
-@mcp.tool()
+@write_tool()
 def record_attempt(category: str, success: bool, note: str = "",
                    probe_id: str = "", latency_ms: int = 0) -> str:
     """Record a self-test outcome. Updates reliability aggregates.
@@ -174,7 +174,7 @@ def record_attempt(category: str, success: bool, note: str = "",
     )
 
 
-@mcp.tool()
+@read_tool()
 def reliability_for(category: str, window_days: int = 30) -> str:
     """Reliability stats for one category over a window."""
     if not category.strip():
@@ -215,7 +215,7 @@ def reliability_for(category: str, window_days: int = 30) -> str:
     )
 
 
-@mcp.tool()
+@read_tool()
 def weak_spots(top_n: int = 5) -> str:
     """List categories ranked by recent failure rate (min 3 attempts in 30d),
     plus registered probe categories with no attempts yet (= unknown,

--- a/threadkeeper/tools/process_health.py
+++ b/threadkeeper/tools/process_health.py
@@ -5,26 +5,35 @@ leave orphan processes that hold RAM (especially with sentence-transformers
 loaded). These tools surface the situation and let you clean up.
 """
 
-from .._mcp import mcp
+from .._mcp import read_tool, write_tool, structured_result
 from .. import process_health
+from ..tool_schemas import MpHealth, MpProcess
 
 
-@mcp.tool()
-def mp_health() -> str:
+@read_tool()
+def mp_health() -> MpHealth:
     """Diagnostic snapshot of every running thread-keeper server process
     on this machine. Shows pid, parent status, RSS, heartbeat age, and
     whether each is classified as orphaned (parent gone + no fresh
     heartbeat from its session).
 
     Self (the process answering this call) is always marked is_self=true
-    and never flagged as orphan."""
+    and never flagged as orphan. Returns structuredContent (MpHealth) plus
+    the legacy text block."""
     procs = process_health.scan()
-    if not procs:
-        return "no_mp_processes_running"
-
     total_kb = sum(p["rss_kb"] for p in procs)
     orphans = [p for p in procs if p.get("is_orphaned")]
     live = [p for p in procs if not p.get("is_orphaned")]
+    model = MpHealth(
+        total=len(procs),
+        live=len(live),
+        orphans=len(orphans),
+        rss_total_mb=total_kb // 1024,
+        processes=[MpProcess(**p) for p in procs],
+    )
+    if not procs:
+        return structured_result("no_mp_processes_running", model)
+
     out = [
         f"total={len(procs)} live={len(live)} orphans={len(orphans)} "
         f"rss_total={total_kb // 1024}MB"
@@ -45,10 +54,10 @@ def mp_health() -> str:
             f"\nCleanup plan: mp_cleanup(dry_run=False) would SIGTERM "
             f"{len(orphans)} orphan(s); add force=True for SIGKILL."
         )
-    return "\n".join(out)
+    return structured_result("\n".join(out), model)
 
 
-@mcp.tool()
+@write_tool(destructive=True)
 def mp_cleanup(dry_run: bool = True, force: bool = False) -> str:
     """Kill orphaned thread-keeper processes (parent gone AND heartbeat
     stale for > 5 minutes). Defaults to dry-run — pass dry_run=False to

--- a/threadkeeper/tools/session.py
+++ b/threadkeeper/tools/session.py
@@ -4,14 +4,14 @@ record a terse summary note for future briefs."""
 import sqlite3
 import time
 
-from .._mcp import mcp
+from .._mcp import read_tool, write_tool
 from ..db import get_db
 from ..helpers import fmt_age
 from ..embeddings import _embed, embed_tag
 from .. import identity
 
 
-@mcp.tool()
+@write_tool(idempotent=True)
 def session_end(summary: str = "") -> str:
     """Mark current session ended with optional terse summary."""
     if identity._session_id is None:

--- a/threadkeeper/tools/shadow_review.py
+++ b/threadkeeper/tools/shadow_review.py
@@ -19,7 +19,7 @@ import time
 from pathlib import Path
 from typing import Optional
 
-from .._mcp import mcp
+from .._mcp import read_tool, write_tool
 from ..db import get_db
 from ..helpers import fmt_age
 from ..identity import _ensure_session
@@ -38,7 +38,7 @@ from ..config import (
 )
 
 
-@mcp.tool()
+@write_tool()
 def shadow_review_run(force: bool = False, dry_run: bool = False) -> str:
     """Fire one shadow-review pass.
 
@@ -141,7 +141,7 @@ def _telemetry_markdown(tel: dict, now: int) -> str:
     return "\n".join(out)
 
 
-@mcp.tool()
+@read_tool()
 def shadow_review_status(snapshot_path: str = "") -> str:
     """Show shadow-review config, recent passes, and production telemetry.
 

--- a/threadkeeper/tools/skills.py
+++ b/threadkeeper/tools/skills.py
@@ -35,7 +35,7 @@ from typing import Optional
 
 import yaml
 
-from .._mcp import mcp
+from .._mcp import read_tool, write_tool
 from ..config import CLAUDE_SKILLS_DIR, WRITE_ORIGIN
 from ..db import get_db
 from ..helpers import q
@@ -511,7 +511,7 @@ def _record_event(name: str, kind: str) -> None:
 _VALID_OUTCOMES: set[str] = {"helped", "partial", "wrong"}
 
 
-@mcp.tool()
+@write_tool()
 def skill_record(name: str, kind: str = "use", outcome: str = "") -> str:
     """Record usage telemetry for a mirrored skill.
 
@@ -571,7 +571,7 @@ def skill_record(name: str, kind: str = "use", outcome: str = "") -> str:
 # skill_manage
 # ──────────────────────────────────────────────────────────────────────────
 
-@mcp.tool()
+@write_tool(destructive=True)
 def skill_manage(action: str,
                  name: str = "",
                  content: str = "",
@@ -791,7 +791,7 @@ def _action_delete(name: str) -> str:
 # skill_list
 # ──────────────────────────────────────────────────────────────────────────
 
-@mcp.tool()
+@read_tool()
 def skill_list(include_archived: bool = False) -> str:
     """List skills with telemetry. Format:
         <name> tier=<hypothesis|observed|validated> origin=<...>
@@ -920,7 +920,7 @@ def _recent_active_skills_dump(
 # Curator
 # ──────────────────────────────────────────────────────────────────────────
 
-@mcp.tool()
+@write_tool(destructive=True)
 def curator_run(stale_after_days: int = 30,
                 archive_after_days: int = 90,
                 dry_run: bool = True) -> str:
@@ -1054,7 +1054,7 @@ def _thread_notes_dump(conn, thread_id: str) -> str:
     return "\n".join(lines)
 
 
-@mcp.tool()
+@write_tool()
 def review_thread(thread_id: str,
                   focus: str = "combined",
                   mode: str = "auto") -> str:

--- a/threadkeeper/tools/spawn.py
+++ b/threadkeeper/tools/spawn.py
@@ -19,9 +19,15 @@ import json as _json
 from pathlib import Path
 from typing import Optional
 
-from .._mcp import mcp
+from .._mcp import mcp, read_tool, write_tool, structured_result
 from ..db import get_db
 from ..config import TASK_LOG_DIR, CLAUDE_PROJECTS_DIR, DB_PATH
+from ..tool_schemas import (
+    SpawnBudgetStatus,
+    SpawnTaskRss,
+    SpawnStatus,
+    CliCapability,
+)
 from ..helpers import fmt_age, q, alive
 from .. import identity  # noqa: F401  (kept for future identity.* attr access)
 from ..identity import _ensure_session, _detect_self_cid, _emit
@@ -339,7 +345,7 @@ def _build_slim_mcp_config(
     return slim_path
 
 
-@mcp.tool()
+@write_tool()
 def spawn(prompt: str, cwd: str = "", append_system: str = "",
           model: str = "", effort: str = "",
           permission_mode: str = "auto",
@@ -782,7 +788,7 @@ exit $rc
     )
 
 
-@mcp.tool()
+@write_tool()
 def tournament(prompt: str,
                roles: str = "skeptic,generator,critic",
                cwd: str = "",
@@ -906,7 +912,7 @@ def tournament(prompt: str,
     return "\n".join(out)
 
 
-@mcp.tool()
+@read_tool()
 def tasks(include_ended: bool = True, k: int = 15) -> str:
     """List spawned tasks: id, pid, status, elapsed, spawned_cid (if linked),
     prompt prefix. Refreshes liveness and resolves spawned_cid lazily."""
@@ -951,7 +957,7 @@ def tasks(include_ended: bool = True, k: int = 15) -> str:
     return "\n".join(lines)
 
 
-@mcp.tool()
+@read_tool()
 def task_logs(task_id: str, tail_lines: int = 80) -> str:
     """Read tail of a spawned task's captured stdout/stderr log.
 
@@ -973,15 +979,17 @@ def task_logs(task_id: str, tail_lines: int = 80) -> str:
     return "\n".join(lines) if lines else "(empty)"
 
 
-@mcp.tool()
-def spawn_budget_status() -> str:
+@read_tool()
+def spawn_budget_status() -> SpawnBudgetStatus:
     """Report current spawn-budget usage: cap, used, free, plus per-running-task
     RSS. Used to decide whether another spawn() will be admitted.
 
     Values come from the budget daemon (refreshes every SPAWN_BUDGET_POLL_S
     seconds via `ps`). Just-spawned tasks show their initial estimate until
     the daemon catches up. Tasks with pid=0 (visible Terminal-launched
-    spawns) aren't tracked from here — their RSS column stays as estimate."""
+    spawns) aren't tracked from here — their RSS column stays as estimate.
+
+    Returns structuredContent (SpawnBudgetStatus) plus the legacy text block."""
     from ..config import SPAWN_BUDGET_MB, SPAWN_BUDGET_POLL_S
     conn = get_db()
     _ensure_session(conn)
@@ -995,38 +1003,52 @@ def spawn_budget_status() -> str:
     used_kb = sum(
         (r["rss_kb"] or 0) for r in rows
     )
-    if SPAWN_BUDGET_MB <= 0:
+    enabled = SPAWN_BUDGET_MB > 0
+    free_kb = max(0, SPAWN_BUDGET_MB * 1024 - used_kb) if enabled else None
+    if not enabled:
         header = (
             f"budget=disabled used={used_kb // 1024}MB "
             f"running={len(rows)}"
         )
     else:
-        free_kb = max(0, SPAWN_BUDGET_MB * 1024 - used_kb)
         header = (
             f"budget={SPAWN_BUDGET_MB}MB used={used_kb // 1024}MB "
             f"free={free_kb // 1024}MB running={len(rows)} "
             f"poll={SPAWN_BUDGET_POLL_S}s"
         )
-    if not rows:
-        return header
+    tasks: list[SpawnTaskRss] = []
     lines = [header]
     for r in rows:
         rss_mb = (r["rss_kb"] or 0) // 1024
         age_at = r["rss_updated_at"] or r["started_at"]
-        age = fmt_age(now_t - age_at)
+        age_s = now_t - age_at
         snip = r["prompt"][:50].replace("\n", " ")
         if len(r["prompt"]) > 50:
             snip += "…"
         cid = (r["spawned_cid"] or "-")[:8]
-        pid_disp = "vis" if not r["pid"] or r["pid"] <= 0 else str(r["pid"])
+        pid = r["pid"] or 0
+        pid_disp = "vis" if pid <= 0 else str(pid)
+        tasks.append(SpawnTaskRss(
+            id=r["id"], pid=pid, cid=cid, rss_mb=rss_mb,
+            age_s=age_s, prompt=snip,
+        ))
         lines.append(
             f"  {r['id']} pid={pid_disp} cid={cid} rss={rss_mb}MB "
-            f"age={age} {q(snip)}"
+            f"age={fmt_age(age_s)} {q(snip)}"
         )
-    return "\n".join(lines)
+    model = SpawnBudgetStatus(
+        enabled=enabled,
+        cap_mb=SPAWN_BUDGET_MB if enabled else None,
+        used_mb=used_kb // 1024,
+        free_mb=(free_kb // 1024) if free_kb is not None else None,
+        running=len(rows),
+        poll_s=SPAWN_BUDGET_POLL_S if enabled else None,
+        tasks=tasks,
+    )
+    return structured_result(header if not rows else "\n".join(lines), model)
 
 
-@mcp.tool()
+@write_tool(idempotent=True)
 def spawn_budget_set(limit_mb: int) -> str:
     """Override the spawn-budget cap for this process (in MB). Set 0 to
     disable enforcement. Does NOT persist across restarts — set
@@ -1043,8 +1065,8 @@ def spawn_budget_set(limit_mb: int) -> str:
     return f"ok: SPAWN_BUDGET_MB now {limit_mb}MB (was via env or previous override)"
 
 
-@mcp.tool()
-def spawn_status() -> str:
+@read_tool()
+def spawn_status() -> SpawnStatus:
     """Show which CLI thread-keeper detected as its host, and which CLI
     each spawn role resolves to (after env + file overrides). Use to
     sanity-check spawn config when you want loops to fire through a
@@ -1058,30 +1080,42 @@ def spawn_status() -> str:
 
     Manual model pinning:
       • THREADKEEPER_SPAWN__MODEL__<CLI-or-ROLE>=<model>
+
+    Returns structuredContent (SpawnStatus) plus the legacy text block.
     """
     from .. import spawn_config as _sc, identity as _id
     from ..adapters import get_adapter
     active = _id.active_cli()
+    role_resolution = _sc.summary_table(active)
     lines = [
         f"active_cli={active or '(none detected)'}",
         "",
         "per-role resolution:",
-        _sc.summary_table(active),
+        role_resolution,
         "",
         "spawn capability by CLI:",
     ]
+    capabilities: list[CliCapability] = []
     for cli in _sc.SUPPORTED_CLIS:
         adapter = get_adapter(cli)
         if not adapter:
+            capabilities.append(CliCapability(cli=cli, available=False, note="no adapter"))
             lines.append(f"  {cli:<8} no adapter")
             continue
         argv = adapter.spawn_argv("test", model="")
         if argv is None:
+            capabilities.append(CliCapability(cli=cli, available=False, note="not on PATH"))
             lines.append(f"  {cli:<8} not on PATH")
         else:
             bin_short = argv[0].split("/")[-1]
+            capabilities.append(CliCapability(cli=cli, available=True, bin=bin_short))
             lines.append(f"  {cli:<8} ok bin={bin_short}")
-    return "\n".join(lines)
+    model = SpawnStatus(
+        active_cli=active or None,
+        role_resolution=role_resolution,
+        capabilities=capabilities,
+    )
+    return structured_result("\n".join(lines), model)
 
 
 def task_kill(task_id: str, force: bool = False) -> str:

--- a/threadkeeper/tools/style.py
+++ b/threadkeeper/tools/style.py
@@ -4,13 +4,13 @@ import sqlite3
 import time
 from typing import Optional
 
-from .._mcp import mcp
+from .._mcp import read_tool, write_tool
 from ..db import get_db
 from .. import identity
 from ..identity import _ensure_session, _emit
 
 
-@mcp.tool()
+@write_tool()
 def verbatim_user(content: str, thread_id: str = "") -> str:
     """Capture a user quote worth surfacing in future briefs. Use when the user's
     exact phrasing matters (sharp reframes, decisions, pushback)."""
@@ -28,7 +28,7 @@ def verbatim_user(content: str, thread_id: str = "") -> str:
     return "ok"
 
 
-@mcp.tool()
+@write_tool(idempotent=True)
 def style_set(key: str, value: str) -> str:
     """Set a stylistic running rule. Examples:
        lang=ru | prose=lean | allow=half-baked,weird | deny=sycophancy,headers"""

--- a/threadkeeper/tools/threads.py
+++ b/threadkeeper/tools/threads.py
@@ -11,8 +11,9 @@ import time
 from datetime import datetime, timezone
 from typing import Optional
 
-from .._mcp import mcp
+from .._mcp import read_tool, write_tool, structured_result
 from ..config import SEMANTIC_AVAILABLE, DB_PATH
+from ..tool_schemas import ContextStatus
 from ..db import get_db
 from ..helpers import gen_thread_id, fmt_age, q, _fts_query
 from .. import identity
@@ -21,7 +22,7 @@ from ..embeddings import _embed, _cosine_search, _vec_upsert_note, embed_tag
 from ..brief import render_brief
 
 
-@mcp.tool()
+@read_tool()
 def brief(query: str = "", k: int = 6, scope: str = "full") -> str:
     """Compact Claude-native memory brief. CALL AT THE START OF EVERY CONVERSATION.
 
@@ -42,28 +43,40 @@ def brief(query: str = "", k: int = 6, scope: str = "full") -> str:
     return render_brief(conn, query=query, k=k, scope=scope)
 
 
-@mcp.tool()
-def context() -> str:
-    """Runtime context: session id, age, semantic on/off, db path, thread counts."""
+@read_tool()
+def context() -> ContextStatus:
+    """Runtime context: session id, age, semantic on/off, db path, thread counts.
+
+    Returns structuredContent (ContextStatus) plus the legacy text block."""
     conn = get_db()
     _ensure_session(conn)
     now = int(time.time())
     counts = conn.execute(
         "SELECT state, COUNT(*) c FROM threads GROUP BY state"
     ).fetchall()
-    cs = " ".join(f"{r['state']}={r['c']}" for r in counts) or "empty"
+    thread_counts = {r["state"]: r["c"] for r in counts}
+    cs = " ".join(f"{k}={v}" for k, v in thread_counts.items()) or "empty"
     started = identity._session_start or now
-    return (
+    now_iso = datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%MZ')
+    text = (
         f"sess={identity._session_id} "
         f"started={fmt_age(now - started)}_ago "
         f"sem={'on' if SEMANTIC_AVAILABLE else 'off'} "
         f"db={DB_PATH} "
         f"threads[{cs}] "
-        f"now={datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%MZ')}"
+        f"now={now_iso}"
     )
+    return structured_result(text, ContextStatus(
+        session_id=identity._session_id,
+        started_age_s=now - started,
+        semantic=bool(SEMANTIC_AVAILABLE),
+        db_path=str(DB_PATH),
+        thread_counts=thread_counts,
+        now=now_iso,
+    ))
 
 
-@mcp.tool()
+@write_tool()
 def open_thread(question: str, parent_id: str = "") -> str:
     """Open a thread. `question` should be terse (5-15 words, the open question).
     `parent_id` optional — pass an existing ID like 'T7f3' for a child. Returns new ID."""
@@ -88,7 +101,7 @@ def open_thread(question: str, parent_id: str = "") -> str:
     return tid
 
 
-@mcp.tool()
+@write_tool()
 def note(thread_id: str, content: str, kind: str = "move") -> str:
     """Add a note to a thread. Write terse, optimized for future-Claude.
 
@@ -124,7 +137,7 @@ def note(thread_id: str, content: str, kind: str = "move") -> str:
     return f"ok id={note_id}"
 
 
-@mcp.tool()
+@write_tool(idempotent=True)
 def close_thread(thread_id: str, outcome: str) -> str:
     """Close a thread with a 5-15 word outcome."""
     conn = get_db()
@@ -153,7 +166,7 @@ def close_thread(thread_id: str, outcome: str) -> str:
     return "ok"
 
 
-@mcp.tool()
+@write_tool(idempotent=True)
 def mark_skill_materialized(thread_id: str, skill_path: str = "") -> str:
     """Close the Learning loop: record that a closed thread's insights were
     written into a skill.
@@ -205,7 +218,7 @@ def mark_skill_materialized(thread_id: str, skill_path: str = "") -> str:
     return "ok"
 
 
-@mcp.tool()
+@write_tool(idempotent=True)
 def idle_thread(thread_id: str) -> str:
     """Mark thread idle (paused, may return). Auto-revives to active on next note()."""
     conn = get_db()
@@ -220,7 +233,7 @@ def idle_thread(thread_id: str) -> str:
     return "ok"
 
 
-@mcp.tool()
+@read_tool()
 def search(query: str, k: int = 5) -> str:
     """Semantic (or FTS) search over all notes."""
     conn = get_db()
@@ -252,7 +265,7 @@ def search(query: str, k: int = 5) -> str:
     )
 
 
-@mcp.tool()
+@read_tool()
 def compost(n: int = 2) -> str:
     """Surface N random idle threads. Call when current threads feel exhausted
     or you want to shake loose dormant ideas."""
@@ -270,7 +283,7 @@ def compost(n: int = 2) -> str:
     )
 
 
-@mcp.tool()
+@write_tool()
 def evolve_format(suggestion: str, rationale: str = "") -> str:
     """Propose a change to the brief format itself. The format is not fixed — this
     is how it adapts. Examples: 'field X unused this session, drop it';
@@ -286,7 +299,7 @@ def evolve_format(suggestion: str, rationale: str = "") -> str:
     return "ok"
 
 
-@mcp.tool()
+@read_tool()
 def evolve_review(include_applied: bool = False) -> str:
     """List pending (or all) format-evolution suggestions for review."""
     conn = get_db()
@@ -316,7 +329,7 @@ def evolve_review(include_applied: bool = False) -> str:
 _EVOLVE_DECISIONS = {"promote", "dismiss"}
 
 
-@mcp.tool()
+@write_tool()
 def evolve_decide(evolve_id: int, decision: str, reason: str = "") -> str:
     """Triage a pending format-evolution suggestion. Used by the autonomous
     evolve reviewer daemon (and available manually).
@@ -349,7 +362,7 @@ def evolve_decide(evolve_id: int, decision: str, reason: str = "") -> str:
     return f"ok id={evolve_id} status={status}"
 
 
-@mcp.tool()
+@write_tool()
 def auto_review_trigger(focus: str = "combined", force: bool = False) -> str:
     """Check current counters + close-thread state and, if conditions are
     met, fire review_thread(mode='auto') for the richest pending thread.

--- a/threadkeeper/tools/validate.py
+++ b/threadkeeper/tools/validate.py
@@ -29,7 +29,7 @@ import re
 import sqlite3
 import time
 
-from .._mcp import mcp
+from .._mcp import read_tool, write_tool
 from ..db import get_db
 from ..helpers import fmt_age, q
 from ..identity import _ensure_session, _emit
@@ -59,7 +59,7 @@ def _build_shipped_re(extra: str) -> "re.Pattern[str]":
     return re.compile(r"\b(" + "|".join(parts) + r")\b", re.IGNORECASE)
 
 
-@mcp.tool()
+@write_tool()
 def validate_threads(
     dry_run: bool = True,
     no_notes_days: int = VALIDATE_NO_NOTES_DAYS,


### PR DESCRIPTION
## What

Adopts the MCP **2025-06-18** tool vocabulary across the whole registry so clients can tell reads from writes without calling tools — the static metadata layer the elicitation work in #26 consumes.

### Annotations (every tool)
Every tool was a bare `@mcp.tool()`. Now each of the **113 tools** registers through one of two thin wrappers in `threadkeeper/_mcp.py`:

- `@read_tool()` → `readOnlyHint=True` — pure reads (`brief`, `context`, `search`, `dialog_search`, `lesson_list`, the status tools, `compost`, …).
- `@write_tool(destructive=…, idempotent=…)` → `readOnlyHint=False` — mutations. The **ten** delete/overwrite/kill tools carry `destructiveHint=True`: `agent_memory_cleanup`, `concept_manage`, `consolidate`, `core_remove`, `curator_run`, `lesson_remove`, `memory_guard_check`, `mp_cleanup`, `skill_manage`, `unlink`. `idempotentHint=True` marks no-op-on-repeat tools.

> Note: the issue listed `compost` as destructive, but it only runs a `SELECT` over idle threads — it is annotated **read-only**. Classification follows real behavior.

### Structured outputs (5 status tools)
`context`, `spawn_budget_status`, `spawn_status`, `mp_health`, `agent_status` now advertise an `outputSchema` (typed models in `threadkeeper/tool_schemas.py`) and return `structuredContent` via a new `structured_result()` helper — **keeping the legacy human-readable text block** alongside the typed JSON (the spec's structured-content backward-compat rule).

## Acceptance criteria
- ✅ `tools/list` exposes annotations for **every** tool.
- ✅ New `tests/test_tool_annotations.py`: fails if any tool is unclassified, if a mutating tool is `readOnlyHint=True`, or if a delete-class tool drops `destructiveHint=True`; also validates the 5 status tools' `structuredContent` against their `outputSchema` with the text block preserved.
- ✅ Advertised protocol bumped: `mcp>=1.10.0` (2025-06-18 tool vocabulary).

## Docs
README (tool annotation contract + project layout), `docs/ARCHITECTURE.md` (annotation-contract section), `docs/ROADMAP.md` (#67 marked DONE), CHANGELOG.

## Tests
Full suite green under the CI configuration: `pytest --forked` → **896 passed, 1 skipped, 0 failed**. Updated 4 existing tests (`test_agent_status`, `test_identity`, `test_process_health`, `test_spawn_budget`) to read the preserved text block from the status tools' `CallToolResult`.

Closes #67

🤖 Generated with [Claude Code](https://claude.com/claude-code)