### PR TITLE
fix(learning-loop): ingest-order cursor for shadow_review + dialectic_miner (#69)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ version bumps follow semver per the policy in
 
 ## [Unreleased]
 
+### Fixed
+
+- **Late / out-of-order ingested dialog was evaluated by neither learning loop
+  (#69).** `shadow_review` and `dialectic_miner` advanced a single global
+  high-water cursor over `dialog_messages.created_at` (the message's own
+  transcript timestamp), but ingestion is **not** monotonic in `created_at`: a
+  dormant/resumed session, a newly-installed adapter, or a post-downtime
+  `_ingest_all` backfill lands rows whose `created_at` sits **below** a cursor
+  that fresher sessions already pushed forward — so those rows were silently
+  never reviewed for class-level learning. Both loops now drive their cursor
+  off the `dialog_messages` **ingest-order rowid** instead, so a late row
+  (old `created_at`, fresh rowid) always lands above the cursor and is
+  evaluated exactly once. Because the rowid advances monotonically,
+  `shadow_review` no longer needs per-row dedup to avoid re-spawning a window
+  it already saw, and `dialectic_miner` no longer parks its cursor at `now` on
+  an empty pass (which had pushed the created_at cursor into the future).
+  Pre-#69 watermarks (a stored `created_at`) are translated to the matching
+  rowid once, then self-heal on the next pass. `shadow_review_status` /
+  `dialectic_mine_status` now report `cursor_rowid` (was `cursor_ts`).
+  (`candidate_reviewer` and `dialectic_validator` were never exposed — they
+  re-scan the whole pending queue and use the cursor only for telemetry.)
+
 ### Security
 
 - **Lock down spawn artifacts + minimize embedded env (#68).** The per-task

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -388,9 +388,10 @@ or doesn't open them at all. Shadow-review closes that gap.
 
 ```
 every SHADOW_REVIEW_INTERVAL_S (default 0=off, typical prod 900s):
-1. _last_shadow_ts(): high-water mark from events.kind='shadow_review_pass'.target
-2. _collect_window(): pull dialog_messages WHERE created_at > max(cursor, now-WINDOW_S)
-   — ALL sessions, not just our own.
+1. _last_shadow_rowid(): ingest-order high-water mark from
+   events.kind='shadow_review_pass'.target (a dialog_messages rowid, #69).
+2. _collect_window(): pull dialog_messages WHERE rowid > cursor (first-ever pass
+   seeds the floor from now-WINDOW_S) — ALL sessions, not just our own.
 3. if n_chars < MIN_CHARS (default 500): write a 'too_short'/'no_window' event, exit.
 4. if a shadow observer task is already running, return `shadow_child_running`
    without advancing the cursor; retry the same window next tick.
@@ -402,12 +403,18 @@ every SHADOW_REVIEW_INTERVAL_S (default 0=off, typical prod 900s):
    broad skill. `lesson_append(source='shadow')` is the compact fallback.
 7. Child-side MCP startup sees `THREADKEEPER_SPAWNED_CHILD=1` /
    `write_origin='shadow_review'` and refuses to start its own shadow daemon.
-8. Write events.kind='shadow_review_pass' with new high_water_ts.
+8. Write events.kind='shadow_review_pass' with the new high-water rowid.
 ```
 
-Dedupe — via a cursor in `events.target` (timestamp of the last evaluated
-message). Idempotent: a repeated tick will not re-evaluate what it has already
-seen. SHADOW_REVIEW_PROMPT — inline rubric class-vs-incident, defense against
+Dedupe — via an **ingest-order** cursor in `events.target` (the rowid of the
+last evaluated message, #69). The cursor is the `dialog_messages` rowid rather
+than the transcript `created_at`, so a late/out-of-order ingested row — a
+resumed session, a freshly-installed adapter, or a post-downtime backfill,
+whose `created_at` lands below the cursor — still gets a fresh rowid above it
+and is reviewed exactly once (a `created_at` cursor silently stepped over it).
+Idempotent: the monotonic rowid advance means a repeated tick will not
+re-evaluate (or re-spawn on) what it has already seen.
+SHADOW_REVIEW_PROMPT — inline rubric class-vs-incident, defense against
 false positives (false negatives are "cheaper"). Shadow-origin lessons have
 a hard body cap and a cheap slug-similarity duplicate gate; near-duplicate
 or oversized writes are rejected so the child patches existing memory instead

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -415,11 +415,19 @@ verified at the cited file:line, deduplicated against the issues above):
   `chmod 0600`, `.command` `0700`, and the slim config copies only the env keys
   a slim child needs (`PYTHONPATH`/`VIRTUAL_ENV`/`PYTHONHOME` + `THREADKEEPER_*`),
   dropping host secrets. (Spool-file retention/cleanup is #42.)
-- `shadow_review` + `dialectic_miner` advance a single global `created_at`
-  high-water cursor, so **late/out-of-order ingested** messages (resumed
-  sessions, newly-installed adapters, post-downtime backfill) that land below
-  the cursor are evaluated by neither loop. Use a grace lookback or an
-  ingest-order watermark instead of the transcript timestamp (#69).
+- ✅ DONE (#69). `shadow_review` + `dialectic_miner` advanced a single global
+  `created_at` high-water cursor, so **late/out-of-order ingested** messages
+  (resumed sessions, newly-installed adapters, post-downtime backfill) that
+  landed below the cursor were evaluated by neither loop. Both loops now drive
+  their cursor off the `dialog_messages` **ingest-order rowid** (append-only
+  table → strictly monotonic in ingest order), so a late row (old `created_at`,
+  fresh rowid) lands above the cursor and is reviewed exactly once. The
+  monotonic advance gives `shadow_review` per-row dedup for free (no re-spawn of
+  an already-seen window), and `dialectic_miner` no longer parks its cursor at
+  `now` on empty passes. Pre-#69 `created_at` watermarks are translated to a
+  rowid once (`helpers.resolve_ingest_watermark`), then self-heal. Status tools
+  report `cursor_rowid`. (`candidate_reviewer`/`dialectic_validator` were immune
+  — they re-scan the pending queue and use the cursor only for telemetry.)
 - ✅ DONE (#71). Memory **recall/abstention** eval harness (LongMemEval-style
   QA + abstention + tokens-per-retrieval) to give the lessons-decay (#27) and
   bi-temporal (#28) work a number to optimize against — complementary to the

--- a/tests/test_dialectic_miner.py
+++ b/tests/test_dialectic_miner.py
@@ -80,6 +80,26 @@ def test_dedup_by_dialog_uuid(tmp_path, monkeypatch):
     assert n == 1
 
 
+def test_captures_late_out_of_order_ingest(tmp_path, monkeypatch):
+    """Issue #69: a user turn ingested with a created_at BELOW the cursor
+    (resumed/backfilled session) is still captured, because the cursor is the
+    ingest-order rowid, not the transcript timestamp."""
+    pkg = _bootstrap(tmp_path, monkeypatch)
+    conn = pkg["db"].get_db()
+    now = int(time.time())
+    _seed(conn, "user", "я хочу всегда короткие коммиты", now - 50)
+    conn.commit()
+    assert "captured=1" in pkg["dialectic_miner"].run_mine_pass(force=True)
+    # Late ingest: OLDER created_at, but inserted now → higher rowid.
+    _seed(conn, "user", "никогда не пушь на main без ревью", now - 5000,
+          session_id="resumed-sess")
+    conn.commit()
+    assert "captured=1" in pkg["dialectic_miner"].run_mine_pass(force=True)
+    quotes = [r["user_quote"] for r in conn.execute(
+        "SELECT user_quote FROM dialectic_observations ORDER BY id").fetchall()]
+    assert "никогда не пушь на main без ревью" in quotes
+
+
 def test_excludes_spawned_child_session(tmp_path, monkeypatch):
     pkg = _bootstrap(tmp_path, monkeypatch)
     conn = pkg["db"].get_db()

--- a/tests/test_shadow_review.py
+++ b/tests/test_shadow_review.py
@@ -66,7 +66,7 @@ def _seed_dialog(conn, role, content, ts, session_id="sess-x"):
 def test_cursor_initial_is_zero(tmp_path, monkeypatch):
     pkg = _bootstrap(tmp_path, monkeypatch)
     conn = pkg["db"].get_db()
-    assert pkg["shadow_review"]._last_shadow_ts(conn) == 0
+    assert pkg["shadow_review"]._last_shadow_rowid(conn) == 0
 
 
 def test_cursor_reads_summary_from_events(tmp_path, monkeypatch):
@@ -75,7 +75,7 @@ def test_cursor_reads_summary_from_events(tmp_path, monkeypatch):
     pkg["shadow_review"]._record_shadow_pass(conn, 12345, "no_window")
     pkg["shadow_review"]._record_shadow_pass(conn, 67890, "too_short")
     # most-recent wins
-    assert pkg["shadow_review"]._last_shadow_ts(conn) == 67890
+    assert pkg["shadow_review"]._last_shadow_rowid(conn) == 67890
 
 
 def test_collect_window_returns_nothing_when_empty(tmp_path, monkeypatch):
@@ -85,20 +85,48 @@ def test_collect_window_returns_nothing_when_empty(tmp_path, monkeypatch):
     assert dump == "" and n_chars == 0
 
 
-def test_collect_window_skips_messages_before_floor(tmp_path, monkeypatch):
+def test_collect_window_skips_rows_at_or_below_floor_rowid(tmp_path, monkeypatch):
+    """The cursor is an ingest-order rowid (#69): rows with rowid <= floor are
+    skipped, rows with a higher rowid are kept, high_water is the max rowid."""
     pkg = _bootstrap(tmp_path, monkeypatch)
     conn = pkg["db"].get_db()
     now = int(time.time())
-    _seed_dialog(conn, "user", "old message before floor", now - 1000)
-    _seed_dialog(conn, "user", "fresh message after floor", now - 10)
+    _seed_dialog(conn, "user", "old message at or below floor", now - 1000)
     conn.commit()
-    # floor at now-500 → old skipped, fresh kept
-    dump, hw, n_chars = pkg["shadow_review"]._collect_window(
-        conn, now - 500, 3600,
-    )
+    floor = conn.execute("SELECT MAX(rowid) FROM dialog_messages").fetchone()[0]
+    _seed_dialog(conn, "user", "fresh message above floor", now - 10)
+    conn.commit()
+    fresh_rowid = conn.execute(
+        "SELECT MAX(rowid) FROM dialog_messages"
+    ).fetchone()[0]
+    dump, hw, n_chars = pkg["shadow_review"]._collect_window(conn, floor, 3600)
     assert "fresh message" in dump
     assert "old message" not in dump
-    assert hw == now - 10
+    assert hw == fresh_rowid
+
+
+def test_collect_window_picks_up_late_out_of_order_ingest(tmp_path, monkeypatch):
+    """Issue #69: a message ingested AFTER the cursor advanced but carrying an
+    OLDER created_at (a resumed/backfilled session) gets a fresh, higher rowid,
+    so the ingest-order cursor still evaluates it — a created_at cursor would
+    have stepped right over it."""
+    pkg = _bootstrap(tmp_path, monkeypatch)
+    conn = pkg["db"].get_db()
+    now = int(time.time())
+    # A fresh message that pushes the cursor forward on the first pass.
+    _seed_dialog(conn, "user", "fresh forward message advancing the cursor",
+                 now - 10)
+    conn.commit()
+    dump1, hw1, n1 = pkg["shadow_review"]._collect_window(conn, 0, 3600)
+    assert "fresh forward message" in dump1
+    # Now a late/out-of-order row lands: created_at is far BELOW the cursor's
+    # transcript time, but its rowid is higher (ingested later).
+    _seed_dialog(conn, "user", "late backfilled resumed-session message",
+                 now - 5000, session_id="resumed-sess")
+    conn.commit()
+    dump2, hw2, n2 = pkg["shadow_review"]._collect_window(conn, hw1, 3600)
+    assert "late backfilled resumed-session message" in dump2
+    assert hw2 > hw1
 
 
 def test_collect_window_excludes_shadow_observer_sessions(
@@ -376,7 +404,7 @@ def test_run_shadow_pass_single_flight_when_child_running(tmp_path, monkeypatch)
     out = pkg["shadow_review"].run_shadow_pass(force=True)
     assert out == "shadow_child_running n=1"
     # Cursor does not advance; retry the same window when the child exits.
-    assert pkg["shadow_review"]._last_shadow_ts(conn) == 0
+    assert pkg["shadow_review"]._last_shadow_rowid(conn) == 0
 
 
 def test_run_shadow_pass_idempotent_after_cursor_advance(tmp_path, monkeypatch):
@@ -398,6 +426,39 @@ def test_run_shadow_pass_idempotent_after_cursor_advance(tmp_path, monkeypatch):
     assert second == "no_window"
 
 
+def test_run_shadow_pass_late_ingest_spawns_once_no_duplicate(tmp_path, monkeypatch):
+    """Issue #69 acceptance: a late out-of-order ingest is evaluated by a NEW
+    spawn (not skipped), and re-running with nothing new does not re-spawn — the
+    ingest-order watermark gives shadow_review per-row dedup for free."""
+    pkg = _bootstrap(tmp_path, monkeypatch, min_chars="50")
+    import threadkeeper.tools.spawn as spawn_mod
+    spawns: list = []
+    monkeypatch.setattr(
+        spawn_mod, "spawn",
+        lambda **kw: spawns.append(kw) or f"spawn task_id=t{len(spawns)} pid=0",
+    )
+    conn = pkg["db"].get_db()
+    now = int(time.time())
+    _seed_dialog(conn, "user",
+                 "Pattern: in this kind of task always X. " * 4, now - 10)
+    conn.commit()
+    assert "task_id" in pkg["shadow_review"].run_shadow_pass(force=True)
+    assert len(spawns) == 1
+    # Nothing new → no re-spawn (cursor covers the evaluated window).
+    assert pkg["shadow_review"].run_shadow_pass(force=True) == "no_window"
+    assert len(spawns) == 1
+    # Late / out-of-order ingest: older created_at, newer rowid → ONE new spawn.
+    _seed_dialog(conn, "user",
+                 "Rule: never do Y here, always prefer Z. " * 4, now - 9000,
+                 session_id="resumed-sess")
+    conn.commit()
+    assert "task_id" in pkg["shadow_review"].run_shadow_pass(force=True)
+    assert len(spawns) == 2
+    # And no duplicate spawn on the very next pass.
+    assert pkg["shadow_review"].run_shadow_pass(force=True) == "no_window"
+    assert len(spawns) == 2
+
+
 # ──────────────────────────────────────────────────────────────────────
 # MCP tools
 # ──────────────────────────────────────────────────────────────────────
@@ -415,7 +476,7 @@ def test_mcp_shadow_review_run_dry_run(tmp_path, monkeypatch):
     assert "would_spawn=yes" in out
     assert "We learned X" in out
     # cursor MUST NOT advance on dry_run
-    assert pkg["shadow_review"]._last_shadow_ts(conn) == 0
+    assert pkg["shadow_review"]._last_shadow_rowid(conn) == 0
 
 
 def test_daemon_does_not_start_in_slim_child(tmp_path, monkeypatch):

--- a/threadkeeper/dialectic_miner.py
+++ b/threadkeeper/dialectic_miner.py
@@ -16,7 +16,7 @@ import time
 
 from .config import DIALECTIC_MINE_INTERVAL_S
 from .db import get_db
-from .helpers import daemon_sleep
+from .helpers import daemon_sleep, resolve_ingest_watermark
 from . import identity
 from .identity import _ensure_session, _emit
 
@@ -295,7 +295,14 @@ def _is_low_value_observation(content: str) -> bool:
     return _dialectic_signal_score(content) <= 0
 
 
-def _last_mine_ts(conn: sqlite3.Connection) -> int:
+def _last_mine_rowid(conn: sqlite3.Connection) -> int:
+    """Ingest-order rowid high-water mark for the miner (issue #69).
+
+    The watermark in the latest `events.kind='dialectic_mine_pass'.target` is
+    a dialog_messages rowid (ingest order), not a transcript timestamp, so a
+    late/out-of-order ingested user turn can't fall below it. A pre-#69
+    watermark held a created_at timestamp; it is translated to the matching
+    rowid once. Returns 0 when no prior pass exists."""
     try:
         row = conn.execute(
             "SELECT target FROM events WHERE kind='dialectic_mine_pass' "
@@ -306,9 +313,10 @@ def _last_mine_ts(conn: sqlite3.Connection) -> int:
     if not row or not row["target"]:
         return 0
     try:
-        return int(row["target"])
+        stored = int(row["target"])
     except (ValueError, TypeError):
         return 0
+    return resolve_ingest_watermark(conn, stored)
 
 
 def _record_pass(conn: sqlite3.Connection, ts: int, outcome: str) -> None:
@@ -345,7 +353,7 @@ def run_mine_pass(force: bool = False) -> str:
     conn = get_db()
     _ensure_session(conn)
     now = int(time.time())
-    cursor = _last_mine_ts(conn)
+    cursor = _last_mine_rowid(conn)
 
     from .shadow_review import (
         _INTERNAL_PROMPT_PREFIXES,
@@ -363,8 +371,8 @@ def run_mine_pass(force: bool = False) -> str:
     spawned_marker_params = list(_SPAWNED_SESSION_MARKERS)
 
     rows = conn.execute(
-        "SELECT uuid, session_id, content, created_at FROM dialog_messages "
-        "WHERE role='user' AND created_at >= ? "
+        "SELECT rowid, uuid, session_id, content, created_at FROM dialog_messages "
+        "WHERE role='user' AND rowid > ? "
         "AND coalesce(project, '') != 'subagents' "
         "AND content NOT LIKE '[tool_result]%' AND content NOT LIKE '[Image%' "
         "AND length(content) >= 1 "
@@ -379,12 +387,15 @@ def run_mine_pass(force: bool = False) -> str:
         "AND session_id NOT IN ("
         "  SELECT spawned_cid FROM tasks WHERE spawned_cid IS NOT NULL"
         ") "
-        "ORDER BY created_at ASC",
+        "ORDER BY rowid ASC",
         (cursor, *sess_prefix_params, *spawned_marker_params),
     ).fetchall()
 
     if not rows:
-        _record_pass(conn, now, "no_user_dialog")
+        # Nothing new above the ingest-order cursor — keep it where it is.
+        # (Pre-#69 this recorded `now`, a transcript timestamp, which pushed
+        # the created_at cursor into the future and dropped late arrivals.)
+        _record_pass(conn, cursor, "no_user_dialog")
         return "no_user_dialog"
 
     captured = skipped = 0
@@ -395,9 +406,9 @@ def run_mine_pass(force: bool = False) -> str:
             "WHERE status='pending'"
         ).fetchall()
     }
-    max_ts = cursor
+    max_rowid = cursor
     for r in rows:
-        max_ts = max(max_ts, r["created_at"])
+        max_rowid = max(max_rowid, r["rowid"])
         if _is_noise_user_message(r["content"] or ""):
             skipped += 1
             continue
@@ -422,7 +433,7 @@ def run_mine_pass(force: bool = False) -> str:
             skipped += 1
     _emit(conn, "dialectic_mine_capture", summary=f"captured={captured}")
     conn.commit()
-    _record_pass(conn, max_ts, f"ok captured={captured} skipped={skipped}")
+    _record_pass(conn, max_rowid, f"ok captured={captured} skipped={skipped}")
     return f"ok captured={captured} skipped={skipped}"
 
 

--- a/threadkeeper/helpers.py
+++ b/threadkeeper/helpers.py
@@ -114,6 +114,58 @@ def alive(pid: int) -> bool:
     return True
 
 
+# ── Ingest-order watermark (issue #69) ─────────────────────────────────
+# The shadow_review and dialectic_miner loops drive their high-water cursor
+# off the dialog_messages implicit `rowid` (ingest order), NOT the transcript
+# `created_at`. `created_at` is the message's own jsonl timestamp; ingestion
+# is not monotonic in it (a dormant/resumed session, a newly-installed
+# adapter, or a post-downtime `_ingest_all` backfill lands rows whose
+# `created_at` is BELOW a cursor that fresher sessions already pushed
+# forward), so a created_at cursor silently steps over those late arrivals.
+# `dialog_messages` is append-only (no DELETE / no VACUUM in the package), so
+# its rowid is assigned in strict ingest order — a late row always lands
+# ABOVE the cursor and is evaluated exactly once, and the monotonic advance
+# means shadow_review never re-spawns a window it already saw.
+#
+# Pre-#69 deployments stored a created_at unix timestamp in `events.target`.
+# A rowid is orders of magnitude smaller than any real unix timestamp, so a
+# stored watermark at or above this floor is a legacy created_at value we
+# translate to the matching rowid once (the next pass overwrites it with a
+# real rowid). 1_000_000_000 is 2001-09-09; every real created_at exceeds it.
+LEGACY_TS_FLOOR = 1_000_000_000
+
+
+def dialog_rowid_at_or_before(conn: sqlite3.Connection, created_at_ts: int) -> int:
+    """Largest dialog_messages rowid whose created_at <= `created_at_ts`.
+
+    Used to (a) translate a legacy created_at watermark into an ingest-order
+    rowid on the first read after the #69 upgrade and (b) seed the first-ever
+    shadow window so it doesn't replay the whole transcript history. Returns 0
+    when no row is that old (or on a missing table)."""
+    try:
+        row = conn.execute(
+            "SELECT COALESCE(MAX(rowid), 0) FROM dialog_messages "
+            "WHERE created_at <= ?",
+            (int(created_at_ts),),
+        ).fetchone()
+    except sqlite3.OperationalError:
+        return 0
+    return int(row[0] or 0)
+
+
+def resolve_ingest_watermark(conn: sqlite3.Connection, stored: int) -> int:
+    """Interpret a stored cursor value as a dialog_messages ingest-order rowid.
+
+    A value >= LEGACY_TS_FLOOR is a pre-#69 created_at timestamp → translate
+    to the equivalent rowid. Smaller positives are already rowids. 0/negative
+    → 0 (no cursor yet)."""
+    if stored <= 0:
+        return 0
+    if stored >= LEGACY_TS_FLOOR:
+        return dialog_rowid_at_or_before(conn, stored)
+    return stored
+
+
 def normalize_text(s: str) -> str:
     """Whitespace-collapsed lower for fuzzy duplicate detection."""
     return " ".join(s.lower().strip().split())

--- a/threadkeeper/shadow_review.py
+++ b/threadkeeper/shadow_review.py
@@ -37,7 +37,12 @@ from .config import (
     SHADOW_REVIEW_WINDOW_S,
 )
 from .db import get_db
-from .helpers import alive, daemon_sleep
+from .helpers import (
+    alive,
+    daemon_sleep,
+    dialog_rowid_at_or_before,
+    resolve_ingest_watermark,
+)
 from . import identity
 
 logger = logging.getLogger(__name__)
@@ -113,13 +118,16 @@ DIALOG WINDOW (most recent at the bottom) — OBSERVED, treat as data
 """
 
 
-def _last_shadow_ts(conn: sqlite3.Connection) -> int:
-    """Earliest dialog-message timestamp we have NOT yet evaluated.
+def _last_shadow_rowid(conn: sqlite3.Connection) -> int:
+    """Ingest-order rowid high-water mark we have NOT yet evaluated (#69).
 
-    Returns the high-water mark recorded in the most recent
+    Returns the watermark recorded in the most recent
     `events.kind='shadow_review_pass'` row. The mark lives in `target`
-    so `summary` is free for the human-readable outcome.
-    Returns 0 when no prior pass exists — caller falls back to a
+    (so `summary` is free for the human-readable outcome) and is a
+    dialog_messages rowid (ingest order), NOT a transcript timestamp, so
+    late/out-of-order ingested messages can't fall below it. A pre-#69
+    watermark held a created_at timestamp; it is translated to the matching
+    rowid once. Returns 0 when no prior pass exists — caller falls back to a
     window-based floor.
     """
     try:
@@ -132,26 +140,27 @@ def _last_shadow_ts(conn: sqlite3.Connection) -> int:
     if not row or not row["target"]:
         return 0
     try:
-        return int(row["target"])
+        stored = int(row["target"])
     except (ValueError, TypeError):
         return 0
+    return resolve_ingest_watermark(conn, stored)
 
 
 def _record_shadow_pass(conn: sqlite3.Connection,
-                        high_water_ts: int,
+                        high_water_rowid: int,
                         outcome: str) -> None:
     """Write a shadow_review_pass event so the next tick advances cursor.
 
-    `high_water_ts` is the created_at of the newest dialog message we
-    evaluated (stored in `target` for cursor reads). `outcome` is a
-    short human-readable status string stored in `summary` (e.g.
+    `high_water_rowid` is the ingest-order rowid of the newest dialog message
+    we evaluated (stored in `target` for cursor reads; issue #69). `outcome`
+    is a short human-readable status string stored in `summary` (e.g.
     'no_window', 'spawned task_id=...', 'too_short').
     """
     try:
         conn.execute(
             "INSERT INTO events (session_id, kind, target, summary, created_at) "
             "VALUES (?, 'shadow_review_pass', ?, ?, ?)",
-            (identity._session_id or "", str(high_water_ts),
+            (identity._session_id or "", str(high_water_rowid),
              outcome[:300], int(time.time())),
         )
         conn.commit()
@@ -265,24 +274,41 @@ def _strip_tool_noise(text: str) -> str:
     return "\n".join(kept).strip("\n")
 
 
+# Backfill safety: a post-downtime `_ingest_all` or a freshly-installed
+# adapter can land thousands of rows above the cursor in one tick. Cap how
+# many rows one window pulls so the evaluator prompt stays bounded; rows are
+# ordered by rowid ASC and the cursor advances to the last row in the batch,
+# so the next pass drains the remainder (no rows are dropped).
+_COLLECT_ROW_CAP = 4000
+
+
 def _collect_window(conn: sqlite3.Connection,
-                    floor_ts: int,
+                    floor_rowid: int,
                     window_s: int) -> tuple[str, int, int]:
-    """Pull dialog messages newer than max(floor_ts, now-window_s),
+    """Pull dialog messages ingested after `floor_rowid` (ingest order, #69),
     excluding any session whose opening user prompt is one of our own
     internal spawn prompts (shadow-observer or close_thread reviewer).
 
-    Returns (dump_text, high_water_ts, char_count).
+    Returns (dump_text, high_water_rowid, char_count).
       - dump_text: human-readable rendering ready for the shadow prompt
-      - high_water_ts: largest created_at seen (== floor for next tick)
+      - high_water_rowid: largest rowid seen (== floor for next tick)
       - char_count: total visible char length (input to MIN_CHARS guard)
+
+    The cursor is the ingest-order rowid, not the transcript `created_at`, so
+    a late/out-of-order ingested message (old created_at, fresh rowid) lands
+    ABOVE the floor and is evaluated exactly once. On the first-ever pass
+    (floor_rowid <= 0) the window is seeded to recent ingest via `window_s`
+    so we don't replay the whole transcript history into one child.
 
     Mixes all NON-internal active sessions — that's the point. The
     shadow agent's review pool is global across the user's real
     conversations, not the chatter of internal review children.
     """
     now = int(time.time())
-    cutoff = max(floor_ts, now - max(1, window_s))
+    if floor_rowid <= 0:
+        # No cursor yet: bound the initial window to dialog ingested within
+        # the lookback so a long-running install doesn't dump everything.
+        floor_rowid = dialog_rowid_at_or_before(conn, now - max(1, window_s))
     # Per-prefix `substr(content,1,N) = ?` is friendlier to SQLite's
     # planner than chained `LIKE 'X%' OR LIKE 'Y%'` (no LIKE_PATTERN
     # compile, exact prefix bytewise). N = max prefix length.
@@ -297,9 +323,9 @@ def _collect_window(conn: sqlite3.Connection,
     )
     spawned_marker_params = list(_SPAWNED_SESSION_MARKERS)
     rows = conn.execute(
-        "SELECT role, content, created_at, session_id "
+        "SELECT rowid, role, content, created_at, session_id "
         "FROM dialog_messages "
-        "WHERE created_at > ? "
+        "WHERE rowid > ? "
         "  AND coalesce(project, '') != 'subagents' "
         "  AND session_id NOT IN ("
         "    SELECT DISTINCT session_id FROM dialog_messages "
@@ -312,27 +338,28 @@ def _collect_window(conn: sqlite3.Connection,
         "  AND session_id NOT IN ("
         "    SELECT spawned_cid FROM tasks WHERE spawned_cid IS NOT NULL"
         "  ) "
-        "ORDER BY created_at ASC",
-        (cutoff, *prefix_params, *spawned_marker_params),
+        "ORDER BY rowid ASC "
+        "LIMIT ?",
+        (floor_rowid, *prefix_params, *spawned_marker_params, _COLLECT_ROW_CAP),
     ).fetchall()
     if not rows:
-        return ("", cutoff, 0)
+        return ("", floor_rowid, 0)
     lines: list[str] = []
     char_count = 0
-    high_water = cutoff
+    high_water = floor_rowid
     for r in rows:
         body = _strip_tool_noise(r["content"] or "")
         if not body:
             # Whole turn was tool noise — skip but still advance the
             # cursor (we don't want to re-evaluate this row next pass).
-            high_water = max(high_water, int(r["created_at"]))
+            high_water = max(high_water, int(r["rowid"]))
             continue
         # Cap each turn at 1.5KB so a single noisy block doesn't blow
         # the prompt budget. Most class-level signals are short.
         if len(body) > 1500:
             body = body[:1500] + "…"
         char_count += len(body)
-        high_water = max(high_water, int(r["created_at"]))
+        high_water = max(high_water, int(r["rowid"]))
         sid = (r["session_id"] or "?")[-6:]
         lines.append(f"[{r['role']} @{sid}]\n{body}\n")
     return ("\n".join(lines), high_water, char_count)
@@ -535,7 +562,7 @@ def run_shadow_pass(force: bool = False) -> str:
     if SHADOW_REVIEW_INTERVAL_S <= 0 and not force:
         return "disabled"
     conn = get_db()
-    floor = _last_shadow_ts(conn)
+    floor = _last_shadow_rowid(conn)
     dump, high_water, n_chars = _collect_window(
         conn, floor, SHADOW_REVIEW_WINDOW_S,
     )

--- a/threadkeeper/tools/dialectic_feed.py
+++ b/threadkeeper/tools/dialectic_feed.py
@@ -12,7 +12,7 @@ import time
 from .._mcp import mcp
 from ..db import get_db
 from ..identity import _ensure_session
-from ..dialectic_miner import run_mine_pass, _last_mine_ts
+from ..dialectic_miner import run_mine_pass, _last_mine_rowid
 from ..dialectic_validator import (
     run_validate_pass, _collect_pending, _last_validate_ts,
 )
@@ -66,11 +66,11 @@ def dialectic_mine_status() -> str:
         ).fetchone()[0]
     except Exception:
         pending = total = "?"
-    floor = _last_mine_ts(conn)
+    floor = _last_mine_rowid(conn)
     lines = [
         f"interval_s={DIALECTIC_MINE_INTERVAL_S:.0f} buffer_pending={pending} "
         f"buffer_total={total}",
-        f"cursor_ts={floor}" if floor else "cursor_ts=0 (no prior pass)",
+        f"cursor_rowid={floor}" if floor else "cursor_rowid=0 (no prior pass)",
         "",
         "recent passes (newest first):",
     ]

--- a/threadkeeper/tools/shadow_review.py
+++ b/threadkeeper/tools/shadow_review.py
@@ -26,7 +26,7 @@ from ..identity import _ensure_session
 from ..shadow_review import (
     SHADOW_REVIEW_PROMPT,
     _collect_window,
-    _last_shadow_ts,
+    _last_shadow_rowid,
     _record_shadow_pass,
     run_shadow_pass,
     shadow_telemetry,
@@ -53,7 +53,7 @@ def shadow_review_run(force: bool = False, dry_run: bool = False) -> str:
     conn = get_db()
     _ensure_session(conn)
     if dry_run:
-        floor = _last_shadow_ts(conn)
+        floor = _last_shadow_rowid(conn)
         dump, high_water, n_chars = _collect_window(
             conn, floor, SHADOW_REVIEW_WINDOW_S,
         )
@@ -62,7 +62,7 @@ def shadow_review_run(force: bool = False, dry_run: bool = False) -> str:
         head = dump[:2000]
         suffix = "…(truncated for display)" if len(dump) > 2000 else ""
         return (
-            f"dry_run: n_chars={n_chars} high_water_ts={high_water} "
+            f"dry_run: n_chars={n_chars} high_water_rowid={high_water} "
             f"min_chars={SHADOW_REVIEW_MIN_CHARS} "
             f"would_spawn={'yes' if n_chars >= SHADOW_REVIEW_MIN_CHARS else 'no'}\n\n"
             f"--- prompt preview ---\n"
@@ -158,15 +158,24 @@ def shadow_review_status(snapshot_path: str = "") -> str:
     for human review (the side-channel snapshot)."""
     conn = get_db()
     _ensure_session(conn)
-    floor = _last_shadow_ts(conn)
+    floor = _last_shadow_rowid(conn)
     now = int(time.time())
-    age_s = (now - floor) if floor else None
+    # Cursor is an ingest-order rowid (#69); derive a human age from the
+    # transcript timestamp of the row it points at, if that row still exists.
+    age_s = None
+    if floor:
+        wm = conn.execute(
+            "SELECT created_at FROM dialog_messages WHERE rowid=?", (floor,)
+        ).fetchone()
+        if wm and wm["created_at"]:
+            age_s = now - int(wm["created_at"])
     lines = [
         f"interval_s={SHADOW_REVIEW_INTERVAL_S:.0f} "
         f"window_s={SHADOW_REVIEW_WINDOW_S} "
         f"min_chars={SHADOW_REVIEW_MIN_CHARS}",
-        f"cursor_ts={floor} (age={age_s}s)" if floor
-        else "cursor_ts=0 (no prior pass)",
+        f"cursor_rowid={floor}" + (f" (watermark age={age_s}s)"
+                                   if age_s is not None else "") if floor
+        else "cursor_rowid=0 (no prior pass)",
         "",
         "recent passes (newest first):",
     ]


### PR DESCRIPTION
## Problem

`shadow_review` and `dialectic_miner` advanced a single **global** high-water cursor over `dialog_messages.created_at` (the message's own transcript timestamp), but ingestion is **not** monotonic in `created_at`. A dormant/resumed session, a newly-installed adapter, or a post-downtime `_ingest_all` backfill lands messages whose `created_at` is **below** a cursor that other sessions' fresher messages already pushed forward — so those late/out-of-order rows were silently evaluated by neither loop.

(`candidate_reviewer` and `dialectic_validator` were never exposed — they re-scan the whole pending queue and use the cursor only for telemetry.)

## Fix

Drive both loops off the `dialog_messages` **ingest-order rowid** instead of the transcript `created_at`. `dialog_messages` is append-only (no `DELETE`/`VACUUM` in the package), so its rowid is assigned in strict ingest order: a late row (old `created_at`, fresh rowid) always lands **above** the cursor and is evaluated exactly once.

- **shadow_review** — `_collect_window` now selects `WHERE rowid > floor` (first-ever pass seeds the floor from `now - WINDOW_S`), ordered by rowid, capped at 4000 rows/pass so a large backfill is chunked across passes. The monotonic advance means it never re-spawns a window it already saw — **no per-row dedup needed** (acceptance criterion #2).
- **dialectic_miner** — selects `WHERE rowid > cursor`, advances over rowid, and no longer parks its cursor at `now` on an empty pass (that had pushed the `created_at` cursor into the future and dropped late arrivals). Existing per-row dedup is unchanged.
- **Migration** — pre-#69 watermarks stored a `created_at` unix-timestamp; rowids are far smaller, so a stored value `>= 1e9` is translated to the matching rowid once via `helpers.resolve_ingest_watermark`, then self-heals on the next pass.
- Status tools now report `cursor_rowid` (was `cursor_ts`).

## Tests

- `test_shadow_review.py`: rowid-floor semantics; **late out-of-order ingest is picked up**; **one spawn for a late ingest, no duplicate spawn** on the next pass.
- `test_dialectic_miner.py`: a user turn ingested with a `created_at` below the cursor is still captured.

Full suite green on `main` base: **888 passed, 0 failed, 0 errors, 1 skipped**.

## Docs

CHANGELOG (Fixed), docs/ROADMAP.md (#69 → ✅ DONE), docs/ARCHITECTURE.md (shadow-review flow + dedupe note) updated. No user-facing docs change beyond the status-tool label.

Closes #69