### PR TITLE
feat(security): scope cross-provider memory egress with an opt-out policy (#74)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,31 @@ version bumps follow semver per the policy in
 
 ### Security
 
+- **Cross-provider memory egress policy + opt-out (#74).** thread-keeper shares
+  one user-model across CLIs by design, but the most sensitive memory it holds —
+  `verbatim_user` quotes and the `dialectic` user-model (claims *about the
+  user*) — was rendered into **every** `brief()` with no provider scoping, and
+  `brief()` is consumed by whichever LLM vendor backs the active or spawned CLI.
+  So a quote said in confidence to Claude, or a trait inferred about the user,
+  could egress to **OpenAI** (Codex), **Google** (Gemini / Antigravity), or
+  **Microsoft-GitHub** (Copilot) on the next spawn or session-start — undocumented
+  and unrestricted. Added a static sensitivity-class map + CLI→vendor map
+  (`egress.py`) and the `THREADKEEPER_MEMORY_EGRESS` knob: `all` (default —
+  current behavior, brief byte-identical) | `same-vendor` (personal-class memory
+  renders only for Anthropic/Claude, omitted for third-party vendors) |
+  `work-only` (personal renders for no vendor). `render_brief` resolves the
+  consuming vendor (explicit `consumer_cli` arg → `THREADKEEPER_EGRESS_CONSUMER`
+  → `active_cli()`) and, under a restricted policy, drops the `verbatim`,
+  `user_model (dialectic)`, and `currently_testing` sections — leaving a one-line
+  `egress policy=…: personal memory … withheld from <vendor>` disclosure so the
+  consuming agent knows personal context was intentionally withheld. `spawn()`
+  injects `THREADKEEPER_EGRESS_CONSUMER=<target CLI>` into the child process env
+  and the slim MCP config, so a child spawned to a third-party CLI cannot pull
+  more personal memory than the policy allows for that vendor — deterministically,
+  without relying on the child's own ppid walk. `work`/`shared` classes
+  (threads/notes/skills/lessons/concepts) always egress. README + ARCHITECTURE
+  document the default and the opt-out. Distinct from the local-perms gap
+  (#21/#68) and the prompt-injection surface (#22/#76).
 - **Lock down spawn artifacts + minimize embedded env (#68).** The per-task
   **slim MCP config** (`slim-mcp-<task_id>.json`) was written with the default
   umask (typically `0644`, world-readable) and embedded the host

--- a/README.md
+++ b/README.md
@@ -151,6 +151,43 @@ Cline, … — so a single registration there reaches all of them at once.
 Adding a new CLI = one file under `threadkeeper/adapters/` implementing
 the `CLIAdapter` contract. See [CONTRIBUTING.md](CONTRIBUTING.md).
 
+### Memory egress (cross-provider privacy)
+
+thread-keeper is "one user model … shared across CLIs," and that sharing is by
+design. The flip side: the most sensitive memory it holds — `verbatim_user`
+quotes and the `dialectic` user-model (claims *about you*: style, values,
+workflow) — is rendered into every `brief()`, and `brief()` is consumed by
+**whichever LLM vendor backs the active or spawned CLI.** So by default, a quote
+you said to Claude, or a trait inferred about you, can be transmitted to OpenAI
+(Codex), Google (Gemini / Antigravity), or Microsoft-GitHub (Copilot) on the
+next session-start or spawn under that CLI. This is a deliberate default, not a
+leak — but it's worth stating plainly, and it's controllable.
+
+`THREADKEEPER_MEMORY_EGRESS` scopes the egress of **personal-class** memory
+(verbatim + dialectic user-model). `work`-class (threads/notes/tasks) and
+`shared`-class (skills/lessons/concepts) memory always egress.
+
+| Value | Personal-class memory egresses to… |
+|---|---|
+| `all` *(default)* | every vendor — current behavior, brief is byte-identical to pre-policy |
+| `same-vendor` | Claude / Anthropic only; omitted for OpenAI / Google / Microsoft CLIs |
+| `work-only` | no vendor — personal memory never leaves the machine |
+
+Under a restricted policy, the gated `brief()` drops the `verbatim` and
+`user_model (dialectic)` sections and leaves a one-line `egress policy=…:
+personal memory … withheld from <vendor>` disclosure so the consuming agent
+knows personal context exists but was intentionally not sent. The native vendor
+is Anthropic because the brief format and personal memory are authored in Claude
+sessions. The gate applies on every consumption path: the foreground brief and
+any spawned child — `spawn()` tells the child which vendor will consume its
+brief, so a child spawned to a third-party CLI cannot retrieve more than the
+policy allows for that vendor. Set it in `~/.threadkeeper/.env` (a real env
+override wins over `.env`):
+
+```bash
+THREADKEEPER_MEMORY_EGRESS=same-vendor
+```
+
 ---
 
 ## Core systems
@@ -572,6 +609,7 @@ The most-used env knobs (full list in `threadkeeper/config.py`):
 | Knob | Default | Purpose |
 |---|---|---|
 | `THREADKEEPER_DB` | `~/.threadkeeper/db.sqlite` | SQLite file |
+| `THREADKEEPER_MEMORY_EGRESS` | `all` | cross-provider scope for personal-class memory (verbatim quotes + dialectic user-model) in `brief()`. `all` = current behavior, egress to whichever vendor backs the consuming CLI. `same-vendor` = personal renders only for Claude/Anthropic, omitted for OpenAI/Google/Microsoft CLIs. `work-only` = personal never rendered, any vendor. See [Memory egress](#memory-egress-cross-provider-privacy) |
 | `THREADKEEPER_AUTO_REVIEW` | "" (off) | auto-review on `close_thread` |
 | `THREADKEEPER_AUTO_UPDATE_INTERVAL_S` | 86400 | MCP self-update check interval; 0 disables |
 | `THREADKEEPER_AUTO_UPDATE_RESTART` | "1" | exit MCP process after applying an update so the host restarts on new code |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -26,6 +26,7 @@ threadkeeper/
 ├── helpers.py         ID generators, fmt_age, q-quoting, alive-pid check
 ├── agent_status.py    structured loop/agent/recent-result status for UI clients
 ├── brief.py           render_brief() / render_context() — main digest
+├── egress.py          cross-provider memory egress policy (issue #74)
 ├── nudges.py          counter-driven memory_nudge / skill_hint / auto-review
 ├── review_prompts.py  MEMORY/SKILL/COMBINED/ANTI_CAPTURE for review-forks
 ├── process_health.py  orphan-detection (ppid + heartbeat)
@@ -327,6 +328,30 @@ so their direct Python/MCP calls hit the same store as the parent.
 
 `slim=False` is set explicitly when the child genuinely needs another MCP
 (e.g. `context7` for library documentation).
+
+### Cross-provider memory egress (issue #74)
+
+`spawn()` resolves the child's target CLI via `resolve_agent(role, active_cli)`
+and may route it to a third-party vendor (Codex→OpenAI, Gemini/Antigravity→
+Google, Copilot→Microsoft). A slim child still loads the thread-keeper MCP, so
+it can call `brief()` and pull the **personal-class** user-model into a prompt
+processed by that vendor. `egress.py` is the control layer:
+
+- `THREADKEEPER_MEMORY_EGRESS` (`all` default | `same-vendor` | `work-only`)
+  decides whether personal-class sections (`verbatim`, `user_model (dialectic)`,
+  `currently_testing`) render for a given consuming vendor. `all` skips the gate
+  entirely → brief stays byte-identical to pre-#74.
+- `render_brief(..., consumer_cli=…)` resolves the consumer from (1) the explicit
+  arg, (2) `THREADKEEPER_EGRESS_CONSUMER` (set by `spawn()` so the spawn path is
+  deterministic and doesn't depend on the child's own ppid walk), then (3)
+  `identity.active_cli()`. When the policy restricts a third-party vendor, the
+  personal sections are dropped and replaced by a one-line `withheld` disclosure.
+- `spawn()` injects `THREADKEEPER_EGRESS_CONSUMER=<chosen_cli>` into both the
+  child process env and the slim MCP config, so a child spawned to a third-party
+  CLI cannot retrieve more personal memory than the policy allows for that vendor.
+
+The native vendor is Anthropic — the brief format and personal memory are
+authored in Claude sessions. `work`/`shared` classes always egress.
 
 ### Search proxy (search_via_parent)
 
@@ -851,6 +876,7 @@ rubric-sensitivity + a subprocess end-to-end run).
 | Knob | Default | Purpose |
 |---|---|---|
 | `THREADKEEPER_DB` | `~/.threadkeeper/db.sqlite` | sqlite file |
+| `THREADKEEPER_MEMORY_EGRESS` | `all` | personal-class memory egress scope: `all` / `same-vendor` / `work-only` (see Spawn → Cross-provider memory egress) |
 | `THREADKEEPER_EMBED_MODEL` | paraphrase-multilingual-MiniLM-L12-v2 | 384-dim, RU+EN |
 | `THREADKEEPER_EMBED_BACKEND` | `onnx` | `onnx` (fastembed, no PyTorch) or `sentence-transformers` (fallback) |
 | `CLAUDE_PROJECTS_DIR` | `~/.claude/projects` | jsonl for ingest |

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -318,6 +318,21 @@ applier drains them. Listed here so the roadmap reflects the live backlog.
   elicitation; and a write-time screen refuses loop-origin bodies with
   imperative-override / remote-exec idioms. `SECURITY.md` documents the trust
   boundary. Scope was S–M.
+- ✅ DONE (#74). **Cross-provider memory egress.** `brief()` rendered the
+  personal-class user-model — `verbatim_user` quotes + the `dialectic` claims
+  *about the user* — unconditionally, and `brief()` is consumed by whatever LLM
+  vendor backs the active/spawned CLI, so a quote said to Claude could egress to
+  OpenAI / Google / Microsoft on the next spawn or session-start with no policy
+  or opt-out. Added a static sensitivity-class map + CLI→vendor map (`egress.py`)
+  and the `THREADKEEPER_MEMORY_EGRESS` knob (`all` default — byte-identical
+  behavior | `same-vendor` — personal only to Anthropic/Claude | `work-only` —
+  personal to no vendor). `render_brief` resolves the consuming vendor (explicit
+  arg → `THREADKEEPER_EGRESS_CONSUMER` set by `spawn()` → `active_cli()`) and
+  omits the personal sections for a restricted third-party consumer, leaving a
+  one-line `withheld` disclosure; `spawn()` propagates the target vendor so a
+  third-party child can't pull more than the policy allows. README + ARCHITECTURE
+  document the default and the opt-out. Distinct from the local-perms gap
+  (#21/#68) and the injection surface (#22/#76). Scope was S.
 
 **Evolve issue-flow reliability.** The applier posts a claim comment *before*
 spawning the implementer; a spawn failure or red-CI abort leaks the claim for a

--- a/tests/test_egress_policy.py
+++ b/tests/test_egress_policy.py
@@ -1,0 +1,218 @@
+"""Cross-provider memory egress policy (issue #74).
+
+thread-keeper renders the most sensitive memory it holds — verbatim user quotes
+and the dialectic user-model — into every brief(), and brief() is consumed by
+whatever LLM vendor backs the active/spawned CLI. These tests pin the control
+layer that scopes that egress:
+
+  * the static policy resolver (`egress`): class map, CLI→vendor map, and the
+    `personal_allowed(consumer, policy)` decision per policy × consumer;
+  * `render_brief`'s personal-section gating under each policy value × consumer,
+    including default-mode (`all`) byte-parity;
+  * spawn-target → policy resolution (a spawn to a third-party CLI gates the
+    same way that CLI's brief would);
+  * the env override being honored live (hot-reload).
+"""
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from threadkeeper import egress
+from threadkeeper.brief import render_brief
+
+
+@pytest.fixture(autouse=True)
+def _clean_egress_env():
+    """reload_settings() mutates os.environ in place, so a policy set by one
+    test leaks into the next (and into the pure resolver tests). Scrub the
+    egress knobs before and after every test in this module."""
+    keys = ("THREADKEEPER_MEMORY_EGRESS", "THREADKEEPER_EGRESS_CONSUMER")
+    for k in keys:
+        os.environ.pop(k, None)
+    yield
+    for k in keys:
+        os.environ.pop(k, None)
+
+
+# ── helpers ───────────────────────────────────────────────────────────────────
+
+def _tool(pkg, name):
+    return pkg["mcp"]._tool_manager._tools[name].fn
+
+
+def _seed_personal(pkg):
+    """Seed one verbatim quote + one validated dialectic claim so both
+    personal-class brief sections (`verbatim`, `user_model`) render."""
+    verbatim_user = _tool(pkg, "verbatim_user")
+    claim = _tool(pkg, "dialectic_claim")
+    evidence = _tool(pkg, "dialectic_evidence")
+
+    verbatim_user(content="this is a confidential quote to claude")
+    res = claim(claim="prefers terse, source-grounded answers", domain="style")
+    claim_id = next(p[3:] for p in res.split() if p.startswith("id="))
+    for _ in range(5):
+        evidence(claim_id=claim_id, kind="support", quote="terse")
+
+
+def _set_policy(pkg, value: str):
+    pkg["config"].reload_settings({"THREADKEEPER_MEMORY_EGRESS": value})
+
+
+# ── static resolver ───────────────────────────────────────────────────────────
+
+def test_vendor_map_covers_all_supported_clis():
+    assert egress.vendor_for("claude") == "anthropic"
+    assert egress.vendor_for("codex") == "openai"
+    assert egress.vendor_for("gemini") == "google"
+    assert egress.vendor_for("antigravity") == "google"
+    assert egress.vendor_for("agy") == "google"          # alias
+    assert egress.vendor_for("copilot") == "microsoft"
+    assert egress.vendor_for("unknown-cli") is None
+
+
+def test_normalize_policy_aliases_and_fallback():
+    assert egress.normalize_policy("same_vendor") == "same-vendor"
+    assert egress.normalize_policy("WORK-ONLY") == "work-only"
+    assert egress.normalize_policy("  all ") == "all"
+    # Unknown / empty → permissive default (fail-open, don't regress product).
+    assert egress.normalize_policy("nonsense") == "all"
+    assert egress.normalize_policy("") == "all"
+    assert egress.normalize_policy(None) == "all"
+
+
+def test_category_class_map():
+    assert egress.class_for("verbatim_user") == egress.PERSONAL
+    assert egress.class_for("dialectic") == egress.PERSONAL
+    assert egress.class_for("threads") == egress.WORK
+    assert egress.class_for("lessons") == egress.SHARED
+    # Unknown category → neutral WORK (never silently SHARED).
+    assert egress.class_for("something-new") == egress.WORK
+
+
+@pytest.mark.parametrize(
+    "policy,consumer,expected",
+    [
+        # all → everything egresses everywhere
+        ("all", "claude", True),
+        ("all", "codex", True),
+        ("all", "gemini", True),
+        ("all", "copilot", True),
+        # same-vendor → personal only to the native vendor (Anthropic/Claude)
+        ("same-vendor", "claude", True),
+        ("same-vendor", "codex", False),
+        ("same-vendor", "gemini", False),
+        ("same-vendor", "antigravity", False),
+        ("same-vendor", "copilot", False),
+        ("same-vendor", None, True),     # undetected consumer → fail-open
+        # work-only → personal never egresses, any vendor incl. Claude
+        ("work-only", "claude", False),
+        ("work-only", "codex", False),
+        ("work-only", None, False),
+    ],
+)
+def test_personal_allowed_matrix(policy, consumer, expected):
+    assert egress.personal_allowed(consumer, policy) is expected
+
+
+# ── render_brief gating ───────────────────────────────────────────────────────
+
+def test_default_all_renders_personal_for_every_consumer(mp_with_cid):
+    """Default policy = no gating: personal sections present regardless of the
+    consuming CLI, and output is identical across consumers (byte-parity)."""
+    pkg = mp_with_cid("aaaaaaaa-0000-0000-0000-000000000001")
+    _seed_personal(pkg)
+    conn = pkg["db"].get_db()
+
+    base = render_brief(conn)  # no consumer override
+    for consumer in ("claude", "codex", "gemini", "copilot"):
+        txt = render_brief(conn, consumer_cli=consumer)
+        assert "verbatim" in txt
+        assert "user_model" in txt
+        assert "withheld" not in txt
+        # default 'all' ignores the consumer entirely → byte-identical
+        assert txt == base
+
+
+def test_same_vendor_omits_personal_for_third_party(mp_with_cid):
+    pkg = mp_with_cid("aaaaaaaa-0000-0000-0000-000000000002")
+    _seed_personal(pkg)
+    conn = pkg["db"].get_db()
+    _set_policy(pkg, "same-vendor")
+
+    claude_txt = render_brief(conn, consumer_cli="claude")
+    assert "verbatim" in claude_txt
+    assert "user_model" in claude_txt
+
+    for third_party in ("codex", "gemini", "antigravity", "copilot"):
+        txt = render_brief(conn, consumer_cli=third_party)
+        assert "verbatim (reactivated first)" not in txt
+        assert "user_model (dialectic)" not in txt
+        # disclosure: tell the consumer personal memory exists but was withheld
+        assert "withheld" in txt
+        assert f"policy=same-vendor" in txt
+
+
+def test_work_only_omits_personal_for_every_consumer(mp_with_cid):
+    pkg = mp_with_cid("aaaaaaaa-0000-0000-0000-000000000003")
+    _seed_personal(pkg)
+    conn = pkg["db"].get_db()
+    _set_policy(pkg, "work-only")
+
+    for consumer in ("claude", "codex", "gemini", "copilot"):
+        txt = render_brief(conn, consumer_cli=consumer)
+        assert "verbatim (reactivated first)" not in txt
+        assert "user_model (dialectic)" not in txt
+        assert "withheld" in txt
+
+
+def test_consumer_resolved_from_env_when_unset(mp_with_cid, monkeypatch):
+    """When render_brief gets no explicit consumer, it resolves the spawn-set
+    THREADKEEPER_EGRESS_CONSUMER env (the deterministic spawn path)."""
+    pkg = mp_with_cid("aaaaaaaa-0000-0000-0000-000000000004")
+    _seed_personal(pkg)
+    conn = pkg["db"].get_db()
+    _set_policy(pkg, "same-vendor")
+
+    monkeypatch.setenv("THREADKEEPER_EGRESS_CONSUMER", "codex")
+    txt = render_brief(conn)  # consumer_cli=None → env
+    assert "user_model (dialectic)" not in txt
+    assert "withheld" in txt
+
+
+# ── spawn-target → policy resolution ──────────────────────────────────────────
+
+def test_spawn_target_resolution_matches_brief_gate(fresh_mp):
+    """A spawn to a third-party-CLI role resolves to that CLI; the egress gate
+    for that resolved target matches what its brief would render. Pinning a
+    role to codex under same-vendor must drop personal for that child."""
+    # Re-import against the fixture's fresh package so current_policy() reads
+    # the reloaded config (the top-level `egress` binding is stale post-wipe).
+    from threadkeeper import spawn_config
+    from threadkeeper import egress as egr
+
+    fresh_mp["config"].reload_settings({
+        "THREADKEEPER_SPAWN__LOOP__SHADOW_OBSERVER": "codex",
+        "THREADKEEPER_MEMORY_EGRESS": "same-vendor",
+    })
+    target = spawn_config.resolve_agent("shadow_observer", active_cli="claude")
+    assert target == "codex"
+    # The child consuming under this target gets personal withheld.
+    assert egr.personal_allowed(target, egr.current_policy()) is False
+
+    # A claude-resolved role keeps personal under same-vendor.
+    claude_target = spawn_config.resolve_agent("archivist", active_cli="claude")
+    assert claude_target == "claude"
+    assert egr.personal_allowed(claude_target, egr.current_policy()) is True
+
+
+def test_env_override_beats_dotenv_default(fresh_mp):
+    """A real THREADKEEPER_MEMORY_EGRESS override is honored over the default."""
+    from threadkeeper import egress as egr
+
+    assert egr.current_policy() == "all"
+    fresh_mp["config"].reload_settings({"THREADKEEPER_MEMORY_EGRESS": "work-only"})
+    assert egr.current_policy() == "work-only"
+    fresh_mp["config"].reload_settings(remove=["THREADKEEPER_MEMORY_EGRESS"])
+    assert egr.current_policy() == "all"

--- a/threadkeeper/brief.py
+++ b/threadkeeper/brief.py
@@ -31,7 +31,8 @@ from .i18n import SPAWN_CUE_RE as _SPAWN_CUE_RE  # noqa: E402
 
 
 def render_brief(conn: sqlite3.Connection, query: str = "", k: int = 6,
-                 scope: str = "full", lean: Optional[bool] = None) -> str:
+                 scope: str = "full", lean: Optional[bool] = None,
+                 consumer_cli: Optional[str] = None) -> str:
     now = int(time.time())
     out: list[str] = []
 
@@ -46,6 +47,23 @@ def render_brief(conn: sqlite3.Connection, query: str = "", k: int = 6,
     if lean is None:
         lean = BRIEF_LEAN
     eff_lean = lean or not full
+
+    # ── cross-provider egress gate (issue #74) ────────────────────────────
+    # Personal-class sections (verbatim quotes + dialectic user-model) egress to
+    # whatever LLM vendor backs the consuming CLI. Under a restricted
+    # THREADKEEPER_MEMORY_EGRESS policy, omit them when the consumer is a
+    # third-party vendor. Default ('all') keeps allow_personal True and never
+    # resolves the consumer — output stays byte-identical to pre-#74.
+    from . import egress
+    egress_policy = egress.current_policy()
+    allow_personal = True
+    if egress_policy != "all":
+        if consumer_cli is None:
+            consumer_cli = (
+                os.environ.get("THREADKEEPER_EGRESS_CONSUMER")
+                or identity.active_cli()
+            )
+        allow_personal = egress.personal_allowed(consumer_cli, egress_policy)
 
     # ── ctx ───────────────────────────────────────────────────────────────
     last = conn.execute(
@@ -599,11 +617,21 @@ def render_brief(conn: sqlite3.Connection, query: str = "", k: int = 6,
         "FROM verbatim v "
         "ORDER BY react DESC, v.created_at DESC, v.id DESC LIMIT 5"
     ).fetchall()
-    if qt and full:
+    if qt and full and allow_personal:
         out.append("")
         out.append("verbatim (reactivated first)")
         for r in qt:
             out.append(f"  react={r['react']} {r['speaker']}> {q(r['content'][:200])}")
+    elif full and not allow_personal:
+        # Personal memory withheld from a third-party vendor under the egress
+        # policy. Disclose it so the consuming agent knows personal context
+        # exists but was intentionally not sent (rather than assuming none).
+        out.append("")
+        out.append(
+            f"egress policy={egress_policy}: personal memory "
+            f"(verbatim + user_model) withheld from "
+            f"{egress.vendor_for(consumer_cli) or consumer_cli or 'this vendor'}"
+        )
 
     # ── relevant_to_query (only if query passed) ──────────────────────────
     if query:
@@ -705,7 +733,7 @@ def render_brief(conn: sqlite3.Connection, query: str = "", k: int = 6,
         ).fetchall()
     except sqlite3.OperationalError:
         syn_rows = []
-    if syn_rows and full:
+    if syn_rows and full and allow_personal:
         # Group by domain inline (keep total ≤ 10 lines incl. headers).
         out.append("")
         out.append("user_model (dialectic)")
@@ -750,7 +778,7 @@ def render_brief(conn: sqlite3.Connection, query: str = "", k: int = 6,
         ).fetchall()
     except sqlite3.OperationalError:
         hyp_rows = []
-    if hyp_rows and not eff_lean:
+    if hyp_rows and not eff_lean and allow_personal:
         out.append("")
         out.append("currently_testing (hypothesis — watch next user moves)")
         for r in hyp_rows:

--- a/threadkeeper/config.py
+++ b/threadkeeper/config.py
@@ -166,6 +166,20 @@ class Settings(BaseSettings):
         validation_alias=AliasChoices("THREADKEEPER_AUTO_REVIEW", "auto_review"),
     )
 
+    # ── Cross-provider memory egress (issue #74) ─────────────────────────────
+    # Which sensitivity classes may render into a brief() consumed by a
+    # third-party LLM vendor. Personal-class memory (verbatim quotes + dialectic
+    # user-model) egresses to whatever vendor backs the active/spawned CLI.
+    #   all          (default) — current behavior, no gating, egress everywhere
+    #   same-vendor  — personal renders only for the native vendor (Anthropic /
+    #                  Claude); omitted for OpenAI / Google / Microsoft
+    #   work-only    — personal never renders, for any vendor
+    # Unknown values normalize to `all` (fail-open — don't regress the product).
+    memory_egress: str = Field(
+        default="all",
+        validation_alias=AliasChoices("THREADKEEPER_MEMORY_EGRESS", "memory_egress"),
+    )
+
     # ── Shadow review daemon ─────────────────────────────────────────────────
     shadow_review_interval_s: float = 0.0
     shadow_review_window_s: int = 900
@@ -276,6 +290,14 @@ class Settings(BaseSettings):
     def _normalize_backend(cls, v: str) -> str:
         return v.strip().lower()
 
+    @field_validator("memory_egress", mode="after")
+    @classmethod
+    def _normalize_egress(cls, v: str) -> str:
+        # Light tidy only (lower/strip); canonicalization + alias mapping +
+        # fail-open fallback live in egress.normalize_policy so the policy
+        # vocabulary has a single owner and config stays import-cycle free.
+        return v.strip().lower()
+
     @field_validator("panel_roles", mode="before")
     @classmethod
     def _parse_panel_roles(cls, v):
@@ -342,6 +364,7 @@ def _derive_constants(s: "Settings") -> dict:
         "BRIEF_LEAN": s.brief_lean,
         "BRIEF_NO_THREAD_NUDGE": s.brief_no_thread_nudge,
         "AUTO_REVIEW_ENABLED": s.auto_review,
+        "MEMORY_EGRESS": s.memory_egress,
         "SPAWN_BUDGET_MB": s.spawn_budget_mb,
         "SPAWN_ESTIMATE_SLIM_MB": s.spawn_estimate_slim_mb,
         "SPAWN_ESTIMATE_FULL_MB": s.spawn_estimate_full_mb,

--- a/threadkeeper/egress.py
+++ b/threadkeeper/egress.py
@@ -1,0 +1,149 @@
+"""Cross-provider memory egress policy (issue #74).
+
+thread-keeper is "one user model … shared across CLIs" by design, and that
+sharing is the point. But the most sensitive memory it holds — `verbatim_user`
+quotes and the `dialectic` user-model (claims *about* the user) — is rendered
+into every `brief()`, and `brief()` is consumed by whatever LLM vendor backs
+the active or spawned CLI. A quote said in confidence to Claude, or a dialectic
+claim inferred about the user, can therefore be transmitted to OpenAI / Google /
+Microsoft on the next spawn or session-start under a third-party CLI.
+
+This module is the cheap, static control layer over that flow:
+
+  * a category → sensitivity-class map (`personal` / `work` / `shared`),
+  * a CLI → backing-vendor map, and
+  * a policy resolver that answers "may a `personal`-class section render into a
+    brief consumed by this CLI's vendor, under the active policy?"
+
+The policy is the `THREADKEEPER_MEMORY_EGRESS` knob (read live from
+`config.settings`, so hot-reload applies):
+
+  all          (default, current behavior) — no gating; everything egresses
+               everywhere, byte-identical to pre-#74.
+  same-vendor  — `personal`-class memory renders only for the native vendor
+               (Anthropic / Claude — thread-keeper's brief is Claude-native and
+               personal memory is authored in Claude sessions). Third-party
+               vendors (OpenAI / Google / Microsoft) get those sections omitted.
+  work-only    — `personal`-class memory never renders, for any vendor
+               (including Claude). Maximum-privacy mode: only `work`/`shared`
+               memory leaves the machine.
+
+`work` and `shared` classes always egress; only `personal` is gated. The gate
+is intentionally fail-open: an unknown policy string or an undetected consumer
+falls back to allowing personal, so a typo or a ppid-detection miss never
+silently strips the user's own brief. Spawn passes the resolved target CLI to
+the child via `THREADKEEPER_EGRESS_CONSUMER` so the gate is deterministic on the
+spawn path rather than relying on the child's own ppid walk.
+"""
+from __future__ import annotations
+
+from typing import Optional
+
+from . import config
+
+# ── Sensitivity classes ──────────────────────────────────────────────────────
+PERSONAL = "personal"   # verbatim quotes, dialectic user-model — about the user
+WORK = "work"           # threads, notes, tasks — what the user is working on
+SHARED = "shared"       # skills, lessons, concepts — reusable, subject-agnostic
+
+# Static memory-category → sensitivity-class map. Cheap (no per-row column);
+# the brief renderer keys section gating off these classes.
+CATEGORY_CLASS: dict[str, str] = {
+    "verbatim": PERSONAL,
+    "verbatim_user": PERSONAL,
+    "dialectic": PERSONAL,
+    "user_model": PERSONAL,
+    "currently_testing": PERSONAL,
+    "threads": WORK,
+    "notes": WORK,
+    "tasks": WORK,
+    "skills": SHARED,
+    "lessons": SHARED,
+    "concepts": SHARED,
+}
+
+# ── CLI → backing LLM vendor ──────────────────────────────────────────────────
+# Antigravity is Google's; copilot is Microsoft/GitHub. Aliases (agy) are
+# normalized before lookup.
+CLI_VENDOR: dict[str, str] = {
+    "claude": "anthropic",
+    "codex": "openai",
+    "gemini": "google",
+    "antigravity": "google",
+    "copilot": "microsoft",
+}
+_CLI_ALIASES = {"agy": "antigravity"}
+
+# The vendor thread-keeper's brief is native to. Personal memory is authored in
+# Claude sessions and the brief format is Claude-native, so Anthropic is the
+# first-party vendor; every other vendor is "third-party" for egress purposes.
+NATIVE_VENDOR = "anthropic"
+
+POLICIES = ("all", "same-vendor", "work-only")
+DEFAULT_POLICY = "all"
+
+# Accept a few friendly spellings of the restricted modes; anything else
+# normalizes to the permissive default (fail-open — don't regress the product).
+_POLICY_ALIASES = {
+    "same_vendor": "same-vendor",
+    "samevendor": "same-vendor",
+    "work_only": "work-only",
+    "workonly": "work-only",
+}
+
+
+def normalize_policy(value: Optional[str]) -> str:
+    """Canonicalize a raw policy string to one of POLICIES.
+
+    Unknown / empty values fall back to the permissive default so a typo can
+    never silently break the brief; restricted modes must be spelled correctly
+    (or via a known alias) to take effect.
+    """
+    p = (value or "").strip().lower()
+    p = _POLICY_ALIASES.get(p, p)
+    return p if p in POLICIES else DEFAULT_POLICY
+
+
+def current_policy() -> str:
+    """The active egress policy, read live from config (hot-reload aware)."""
+    return normalize_policy(getattr(config.settings, "memory_egress", DEFAULT_POLICY))
+
+
+def vendor_for(cli: Optional[str]) -> Optional[str]:
+    """Backing LLM vendor for a CLI short-name (alias-aware), or None."""
+    c = (cli or "").strip().lower()
+    c = _CLI_ALIASES.get(c, c)
+    return CLI_VENDOR.get(c)
+
+
+def class_for(category: str) -> str:
+    """Sensitivity class for a memory category. Unknown → WORK (the neutral,
+    always-egressed middle class — never silently treated as SHARED, never
+    silently leaked as if it were nothing)."""
+    return CATEGORY_CLASS.get((category or "").strip().lower(), WORK)
+
+
+def personal_allowed(consumer_cli: Optional[str], policy: Optional[str] = None) -> bool:
+    """May `personal`-class brief sections render for this consuming CLI?
+
+    Resolution:
+      all          → always True (default; no gating).
+      work-only    → always False (personal never egresses, any vendor).
+      same-vendor  → True only when the consumer's vendor is the native vendor
+                     (Anthropic / Claude); third-party vendors → False.
+
+    Fail-open: an undetected consumer (vendor_for → None) is treated as native
+    under same-vendor, so a ppid-detection miss never strips the foreground
+    user's own brief. Spawned third-party children always carry an explicit
+    target CLI, so they gate correctly regardless.
+    """
+    pol = normalize_policy(policy) if policy is not None else current_policy()
+    if pol == "all":
+        return True
+    if pol == "work-only":
+        return False
+    # same-vendor
+    vendor = vendor_for(consumer_cli)
+    if vendor is None:
+        return True  # unknown consumer → don't strip (fail-open)
+    return vendor == NATIVE_VENDOR

--- a/threadkeeper/tools/spawn.py
+++ b/threadkeeper/tools/spawn.py
@@ -501,6 +501,13 @@ def spawn(prompt: str, cwd: str = "", append_system: str = "",
     from .. import spawn_config as _sc, identity as _id
     chosen_cli = _sc.resolve_agent(role or "", _id.active_cli())
     chosen_model = model or _sc.resolve_model(chosen_cli, role or "")
+    # Cross-provider egress (issue #74): tell the child which LLM vendor will
+    # consume its brief() so render_brief gates personal-class memory
+    # deterministically on the spawn path — not relying on the child's own
+    # ppid walk. Propagated both to the child process env (non-claude adapters
+    # Popen with child_env) and the slim MCP config (claude children).
+    child_env["THREADKEEPER_EGRESS_CONSUMER"] = chosen_cli
+    mcp_env_overrides["THREADKEEPER_EGRESS_CONSUMER"] = chosen_cli
     stdin_text: Optional[str] = None
     stdin_path: Optional[Path] = None
     if chosen_cli != "claude":


### PR DESCRIPTION
## Problem

thread-keeper shares one user-model across CLIs by design — but there was **no policy, classification, or opt-out** controlling which memory categories egress to which LLM vendor. The most sensitive memory it holds — `verbatim_user` quotes and the `dialectic` user-model (claims *about the user*) — was rendered unconditionally into every `brief()`, and `brief()` is consumed by whichever vendor backs the active or spawned CLI. So a quote said in confidence to Claude, or a trait inferred about the user, could be transmitted to **OpenAI** (Codex), **Google** (Gemini / Antigravity), or **Microsoft-GitHub** (Copilot) on the next spawn or session-start — undocumented and unrestricted.

Verified data flow: `render_brief` emitted the `verbatim` and `user_model (dialectic)` sections with no provider gate; `spawn` resolves a child's target CLI by role + active CLI with no egress scoping, and a slim child still loads the thread-keeper MCP, so a child spawned to Codex/Gemini/Copilot would call `brief()` and pull the user-model into a third-party prompt.

## Change

Keeps the permissive default (no product regression), adds control + disclosure.

- **`threadkeeper/egress.py`** (new) — static control layer: category→sensitivity-class map (`personal`/`work`/`shared`), CLI→vendor map (Codex→OpenAI, Gemini/Antigravity→Google, Copilot→Microsoft), and a policy resolver. Native vendor = Anthropic (the brief format + personal memory are authored in Claude sessions). Fail-open on unknown policy / undetected consumer.
- **`THREADKEEPER_MEMORY_EGRESS` knob** (`config.py`, persisted in `~/.threadkeeper/.env`, real env wins):
  - `all` *(default)* — no gating; brief **byte-identical** to before
  - `same-vendor` — personal-class renders only for Anthropic/Claude; omitted for third-party vendors
  - `work-only` — personal-class renders for no vendor
- **`render_brief(..., consumer_cli=…)`** — resolves the consuming vendor (explicit arg → `THREADKEEPER_EGRESS_CONSUMER` → `active_cli()`) and, under a restricted policy, omits the `verbatim`, `user_model (dialectic)`, and `currently_testing` sections, leaving a one-line `egress policy=…: personal memory … withheld from <vendor>` disclosure. Default `all` never even resolves the consumer.
- **`spawn()`** — injects `THREADKEEPER_EGRESS_CONSUMER=<target CLI>` into the child process env **and** the slim MCP config, so a child spawned to a third-party CLI can't pull more personal memory than the policy allows — deterministically, not relying on the child's own ppid walk.
- `work`/`shared` classes (threads/notes/skills/lessons/concepts) always egress.

## Acceptance criteria

- ✅ Documented egress policy with `all` (default) + restricted modes; real env override honored over `.env`.
- ✅ `render_brief` omits `personal`-class sections when the resolved consumer is third-party **and** the policy restricts them; default behavior unchanged.
- ✅ A spawn to a third-party-CLI role produces a brief consistent with the policy (the child can't retrieve more than the policy allows for that vendor).
- ✅ README/ARCHITECTURE document the default egress behavior and the opt-out.

## Tests

`tests/test_egress_policy.py` — resolver matrix (policy × consumer), brief gating per policy × consumer, **default-mode (`all`) byte-parity** across consumers, env-resolved consumer, and spawn-target → policy resolution. Full suite green (`pytest -q`, exit 0).

## Docs

README: `THREADKEEPER_MEMORY_EGRESS` config row + a "Memory egress (cross-provider privacy)" section. ARCHITECTURE: package-map entry + a "Cross-provider memory egress" subsection under Spawn + env-knobs row. ROADMAP: `✅ DONE (#74)`. CHANGELOG: Security entry.

Distinct from the local-perms gap (#21/#68) and the prompt-injection surface (#22/#76).

Closes #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)