### PR TITLE
feat(security): gate autonomous issue pickup to trusted authors + opaque host token in claim comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,28 @@ version bumps follow semver per the policy in
 
 ### Security
 
+- **Author-trust gate for autonomous issue pickup + redacted claim comments
+  (#63).** This repo is **public**, so any GitHub account can open an issue —
+  and the evolve applier injected every open issue's body into a
+  permission-bypassing, shell-enabled implementer child with no author check
+  (`_fetch_open_issues` never even requested the author). Autonomous pickup is
+  now gated: only issues whose GitHub `authorAssociation` is in
+  `THREADKEEPER_EVOLVE_TRUSTED_AUTHOR_ASSOCIATIONS` (default
+  `OWNER,MEMBER,COLLABORATOR`) — or that carry a maintainer-applied label in
+  `THREADKEEPER_EVOLVE_TRUST_LABELS` (empty by default; only collaborators can
+  label a public repo, so a trust label is an endorsement) — are auto-drained.
+  Untrusted issues are skipped until a human promotes one (apply a trust label,
+  or name the exact number via `evolve_apply_roadmap_issue(issue_number=N)`,
+  which bypasses the gate as explicit promotion). Because `gh issue list --json`
+  cannot return `author_association`, `_fetch_open_issues` now fetches via the
+  REST API (`gh api …/issues`, filtering out pull requests). This removes the
+  untrusted input at the boundary and complements the in-prompt data-fencing of
+  #22/#76. Separately, the public claim comment leaked the developer machine's
+  hostname, PID, and an unreleased commit SHA on every claim; it now carries
+  only the opaque per-host token already used for branch names
+  (`sha1(hostname)[:6]`), with the full host identity kept in a local
+  `roadmap_issue_claim_host` event for multi-host triage. README +
+  `docs/ARCHITECTURE.md` document the trust model and both env knobs.
 - **Cross-provider memory egress policy + opt-out (#74).** thread-keeper shares
   one user-model across CLIs by design, but the most sensitive memory it holds —
   `verbatim_user` quotes and the `dialectic` user-model (claims *about the

--- a/README.md
+++ b/README.md
@@ -512,6 +512,22 @@ pushes to `main`, and it never marks an issue applied without a real PR URL. A
 manual `evolve_apply_roadmap_issue(issue_number=N)` remains exact: it reports
 why that issue cannot start instead of silently switching to another issue.
 
+**Author-trust gate (this repo is public).** Any GitHub account can open an
+issue, and an open issue's body is injected into the permission-bypassing
+implementer child — so **autonomous** pickup is gated on the issue author's
+GitHub association. Only issues whose `authorAssociation` is in
+`THREADKEEPER_EVOLVE_TRUSTED_AUTHOR_ASSOCIATIONS` (default
+`OWNER,MEMBER,COLLABORATOR`) are auto-drained; everything else is skipped until
+a human promotes it — by applying a label listed in
+`THREADKEEPER_EVOLVE_TRUST_LABELS` (empty by default; on a public repo only
+collaborators can label, so a trust label is itself a maintainer endorsement),
+or by naming the exact issue number via `evolve_apply_roadmap_issue(issue_number=N)`,
+which bypasses the gate as explicit promotion. This removes the untrusted input
+at the boundary and complements the in-prompt data-fencing of #22/#76. The
+public claim comment also carries only an opaque per-host token (a 6-char hash
+of the hostname), never the raw hostname/PID/git-rev; the full host identity is
+recorded in the local event log for multi-host triage.
+
 Fallback/manual paths remain:
 
 - `evolve_apply_curator_report(report_path="")` applies safe Curator memory
@@ -656,6 +672,8 @@ The most-used env knobs (full list in `threadkeeper/config.py`):
 | `THREADKEEPER_EVOLVE_AUTO_CLONE` | true | auto-provision (git clone + `.venv` with `[semantic,dev]`) a managed checkout when installed without a source tree (PyPI/site-packages), so the evolve loops work by default. Set `0`/`false` to disable — then a non-checkout install requires an editable install or an explicit `EVOLVE_REPO_ROOT`, otherwise the loops return `ERR evolve_repo_unavailable` |
 | `THREADKEEPER_EVOLVE_REPO_URL` | upstream repo | git URL the managed checkout is cloned from |
 | `THREADKEEPER_EVOLVE_REPO_BRANCH` | `main` | branch the managed checkout tracks |
+| `THREADKEEPER_EVOLVE_TRUSTED_AUTHOR_ASSOCIATIONS` | `OWNER,MEMBER,COLLABORATOR` | comma-separated GitHub author associations eligible for **autonomous** issue pickup on this public repo; issues from other authors are skipped unless promoted (trust label or exact-number invocation) |
+| `THREADKEEPER_EVOLVE_TRUST_LABELS` | (empty) | comma-separated labels that promote an untrusted-author issue into the autonomous queue; on a public repo only collaborators can apply labels, so a trust label is a maintainer endorsement |
 | `THREADKEEPER_DIALECTIC_MAX_NEW_CLAIMS` | 3 | max new dialectic claims the validator may create per pass |
 
 Persist them in `~/.threadkeeper/.env` (copy from `.env.example`) — one file,

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -221,14 +221,28 @@ All daemon threads are cheap (ticks 0.5–30 s), no-op when env-knobs disable th
   and create/update GitHub issues with acceptance criteria and research
   sources. It does not implement roadmap issues.
 - **evolve_applier** (`evolve_applier.start_evolve_applier_daemon`) — once per
-  `EVOLVE_APPLY_INTERVAL_S` (default 0 = off) fetches open GitHub issues with
-  `gh issue list`, prioritizes `roadmap`-labeled issues then FIFO, and spawns
-  one `evolve_applier` child to implement exactly one issue. Before spawning,
-  the parent runs five multi-host conflict guards in order: (1) skip if an
-  active `<!-- thread-keeper:evolve-applier-claim -->` comment already exists;
-  (2) skip if `gh pr list --search "in:body Closes #N"` shows an open PR
-  already closing the issue; (3) post the parent's own claim comment (body
-  carries hostname + PID + git-rev for triage); (4) wait
+  `EVOLVE_APPLY_INTERVAL_S` (default 0 = off) fetches open GitHub issues via the
+  REST API (`gh api repos/{owner}/{repo}/issues` — needed because `gh issue
+  list --json` cannot return `author_association`; pull requests in the
+  response are filtered out), prioritizes `roadmap`-labeled issues then FIFO,
+  and spawns one `evolve_applier` child to implement exactly one issue.
+  **Author-trust gate (#63):** the repo is public, so any account can open an
+  issue whose body is injected into the permission-bypassing child. Autonomous
+  pickup is therefore limited to issues whose `authorAssociation` is in
+  `EVOLVE_TRUSTED_AUTHOR_ASSOCIATIONS` (default `OWNER,MEMBER,COLLABORATOR`) or
+  that carry a maintainer-applied label in `EVOLVE_TRUST_LABELS` (empty by
+  default; only collaborators can label a public repo, so a trust label is
+  itself an endorsement). Untrusted issues are skipped until promoted; naming
+  the exact number (`evolve_apply_roadmap_issue(issue_number=N)`) bypasses the
+  gate as explicit human promotion. This removes the untrusted input at the
+  boundary and complements the in-prompt data-fencing of #22/#76. Before
+  spawning, the parent runs five multi-host conflict guards in order: (1) skip
+  if an active `<!-- thread-keeper:evolve-applier-claim -->` comment already
+  exists; (2) skip if `gh pr list --search "in:body Closes #N"` shows an open
+  PR already closing the issue; (3) post the parent's own claim comment (body
+  carries only an opaque per-host token — `sha1(hostname)[:6]` — never raw
+  hostname/PID/git-rev, which stay in the local `roadmap_issue_claim_host`
+  event for triage); (4) wait
   `ROADMAP_CLAIM_RACE_WINDOW_S` (default 3s), re-fetch claims, and delete the
   parent's own claim when a competing host got there first (earliest
   `createdAt` wins); (5) on `spawn()` failure, retract the just-posted claim

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -414,12 +414,21 @@ verified at the cited file:line, deduplicated against the issues above):
   overlapping window. Same incident class as the documented #157/#158
   prod loop, on the one heuristic path that never got the `_candidate_exists`
   fix (#62).
-- Author-trust boundary on autonomous issue pickup: the applier fetches no
-  `authorAssociation` and treats every open issue on this **public** repo as
-  backlog for a `bypassPermissions` child; separately, the Python-generated
-  claim comment leaks hostname/PID/git-rev even though an opaque
-  `_host_branch_slug()` already exists. Gate pickup by author association and
-  redact the claim body. Complements #22 (fencing) and #50 (skip-label) (#63).
+- ✅ DONE (#63). Author-trust boundary on autonomous issue pickup: the applier
+  fetched no `authorAssociation` and treated every open issue on this **public**
+  repo as backlog for a `bypassPermissions` child; separately, the
+  Python-generated claim comment leaked hostname/PID/git-rev even though an
+  opaque `_host_branch_slug()` already existed. Now `_fetch_open_issues` reads
+  the REST `/issues` endpoint (the `gh issue list --json` field set can't return
+  `author_association`; PRs are filtered out) and autonomous pickup is gated on
+  `EVOLVE_TRUSTED_AUTHOR_ASSOCIATIONS` (default `OWNER,MEMBER,COLLABORATOR`) or a
+  maintainer-applied label in `EVOLVE_TRUST_LABELS` (empty by default) —
+  untrusted-author issues are skipped until promoted, while exact-number
+  invocation bypasses the gate as explicit human promotion. The public claim
+  body now carries only the opaque `_host_branch_slug()` token; the full host
+  identity is recorded in a local `roadmap_issue_claim_host` event. Removes the
+  untrusted input at the boundary (complements #22/#76 fencing and #50
+  skip-label) and is documented in README + ARCHITECTURE.
 - Spawn budget is blind to **visible (pid=0)** children: their real RSS is
   never measured (the daemon skips `pid<=0`), and a visible row whose jsonl
   never resolves pins its full-estimate budget share forever. (The

--- a/tests/test_agent_status.py
+++ b/tests/test_agent_status.py
@@ -206,6 +206,7 @@ def test_agent_status_evolve_applier_ready_when_roadmap_issue_exists(
                 "labels": [{"name": "roadmap"}],
                 "body": "Need counters",
                 "url": "https://github.com/o/r/issues/6",
+                "authorAssociation": "OWNER",
             }],
             "",
         ),

--- a/tests/test_config_settings.py
+++ b/tests/test_config_settings.py
@@ -160,6 +160,23 @@ def test_panel_roles_is_list(monkeypatch):
     assert "skeptic" in c.PANEL_ROLES
 
 
+def test_evolve_author_trust_knobs_default_and_override(monkeypatch):
+    """#63: the autonomous-pickup author-trust gate is configurable."""
+    c = _fresh_config(monkeypatch)
+    assert c.EVOLVE_TRUSTED_AUTHOR_ASSOCIATIONS == [
+        "OWNER", "MEMBER", "COLLABORATOR",
+    ]
+    assert c.EVOLVE_TRUST_LABELS == []
+
+    c = _fresh_config(monkeypatch, env={
+        "THREADKEEPER_EVOLVE_TRUSTED_AUTHOR_ASSOCIATIONS": "owner, collaborator",
+        "THREADKEEPER_EVOLVE_TRUST_LABELS": "Approved, Roadmap",
+    })
+    # Associations normalize to upper, labels to lower; CSV is parsed to a list.
+    assert c.EVOLVE_TRUSTED_AUTHOR_ASSOCIATIONS == ["OWNER", "COLLABORATOR"]
+    assert c.EVOLVE_TRUST_LABELS == ["approved", "roadmap"]
+
+
 def test_spawn_settings_defaults(monkeypatch):
     """settings.spawn has the right defaults."""
     c = _fresh_config(monkeypatch)

--- a/tests/test_evolve_applier.py
+++ b/tests/test_evolve_applier.py
@@ -47,6 +47,12 @@ def _bootstrap(tmp_path, monkeypatch, interval="0"):
         del sys.modules[name]
     import threadkeeper.server  # noqa: F401
     from threadkeeper import _mcp, db, evolve_applier, identity
+    # Capture the real implementations before stubbing so tests that need to
+    # exercise the unstubbed gh/REST paths can restore them.
+    orig = {
+        "_fetch_open_issues": evolve_applier._fetch_open_issues,
+        "_comment_issue_claim": evolve_applier._comment_issue_claim,
+    }
     monkeypatch.setattr(
         evolve_applier, "_fetch_open_issues",
         lambda repo_root=None: ([], ""),
@@ -77,7 +83,8 @@ def _bootstrap(tmp_path, monkeypatch, interval="0"):
     import threadkeeper.config as _cfg
     monkeypatch.setattr(_cfg, "ROADMAP_CLAIM_RACE_WINDOW_S", 0.0)
     monkeypatch.setattr(evolve_applier, "ROADMAP_CLAIM_RACE_WINDOW_S", 0.0)
-    return {"mcp": _mcp.mcp, "db": db, "ea": evolve_applier, "identity": identity}
+    return {"mcp": _mcp.mcp, "db": db, "ea": evolve_applier,
+            "identity": identity, "orig": orig}
 
 
 def _tool(pkg, name):
@@ -118,13 +125,18 @@ def _write_report(pkg, name="REPORT-20260611T120000.md", complete=True):
     return path
 
 
-def _issue(number, title, labels=("roadmap",), body="Issue body"):
+def _issue(number, title, labels=("roadmap",), body="Issue body",
+           author_association="OWNER"):
+    # Default to a trusted (maintainer) author so existing pickup tests pass
+    # through the #63 author-trust gate unchanged; untrusted-author tests pass
+    # author_association="NONE"/"CONTRIBUTOR" explicitly.
     return {
         "number": number,
         "title": title,
         "labels": [{"name": name} for name in labels],
         "body": body,
         "url": f"https://github.com/o/r/issues/{number}",
+        "authorAssociation": author_association,
     }
 
 
@@ -385,6 +397,132 @@ def test_open_roadmap_issues_allows_stale_issue_claim(
 
     assert err == ""
     assert [int(i["number"]) for i in issues] == [1]
+
+
+def test_open_roadmap_issues_skips_untrusted_author(tmp_path, monkeypatch):
+    # #63: this repo is public; an issue from a non-trusted author must NOT be
+    # auto-picked-up. Trusted associations pass; NONE/CONTRIBUTOR are skipped.
+    pkg = _bootstrap(tmp_path, monkeypatch)
+    conn = pkg["db"].get_db()
+    monkeypatch.setattr(
+        pkg["ea"], "_fetch_open_issues",
+        lambda repo_root=None: (
+            [
+                _issue(1, "from owner", author_association="OWNER"),
+                _issue(2, "from outsider", author_association="NONE"),
+                _issue(3, "from member", author_association="MEMBER"),
+                _issue(4, "from drive-by", author_association="CONTRIBUTOR"),
+            ],
+            "",
+        ),
+    )
+
+    issues, err = pkg["ea"]._open_roadmap_issues(conn)
+
+    assert err == ""
+    # Only OWNER (#1) and MEMBER (#3) survive the gate.
+    assert [int(i["number"]) for i in issues] == [1, 3]
+
+
+def test_open_roadmap_issues_trust_label_promotes_untrusted_author(
+    tmp_path, monkeypatch,
+):
+    # A maintainer-applied trust label is an explicit human endorsement: on a
+    # public repo only collaborators can label, so it bypasses the author gate.
+    pkg = _bootstrap(tmp_path, monkeypatch)
+    conn = pkg["db"].get_db()
+    monkeypatch.setattr(
+        pkg["ea"], "EVOLVE_TRUST_LABELS", ["approved"],
+    )
+    monkeypatch.setattr(
+        pkg["ea"], "_fetch_open_issues",
+        lambda repo_root=None: (
+            [
+                _issue(1, "untrusted, no label", labels=("enhancement",),
+                       author_association="NONE"),
+                _issue(2, "untrusted, promoted",
+                       labels=("enhancement", "approved"),
+                       author_association="NONE"),
+            ],
+            "",
+        ),
+    )
+
+    issues, err = pkg["ea"]._open_roadmap_issues(conn)
+
+    assert err == ""
+    assert [int(i["number"]) for i in issues] == [2]
+
+
+def test_open_roadmap_issues_exact_mode_bypasses_author_gate(
+    tmp_path, monkeypatch,
+):
+    # Naming an exact issue number is itself the human promotion the gate
+    # requires, so enforce_author_trust=False keeps the untrusted issue.
+    pkg = _bootstrap(tmp_path, monkeypatch)
+    conn = pkg["db"].get_db()
+    monkeypatch.setattr(
+        pkg["ea"], "_fetch_open_issues",
+        lambda repo_root=None: (
+            [_issue(7, "outsider issue", author_association="NONE")], ""
+        ),
+    )
+
+    gated, _ = pkg["ea"]._open_roadmap_issues(conn)
+    assert [int(i["number"]) for i in gated] == []
+
+    promoted, err = pkg["ea"]._open_roadmap_issues(
+        conn, skip_claimed=False, enforce_author_trust=False,
+    )
+    assert err == ""
+    assert [int(i["number"]) for i in promoted] == [7]
+
+
+def test_fetch_open_issues_maps_rest_payload_and_filters_prs(
+    tmp_path, monkeypatch,
+):
+    # #63: _fetch_open_issues now uses the REST API (gh issue list can't return
+    # author_association). Verify the shape mapping and that PRs are dropped.
+    pkg = _bootstrap(tmp_path, monkeypatch)
+    rest_payload = [
+        {
+            "number": 10,
+            "title": "real issue",
+            "labels": [{"name": "roadmap"}],
+            "body": "do the thing",
+            "html_url": "https://github.com/o/r/issues/10",
+            "url": "https://api.github.com/repos/o/r/issues/10",
+            "author_association": "OWNER",
+            "user": {"login": "po4erk91"},
+        },
+        {
+            "number": 11,
+            "title": "a pull request",
+            "labels": [],
+            "body": "",
+            "html_url": "https://github.com/o/r/pull/11",
+            "author_association": "NONE",
+            "user": {"login": "outsider"},
+            "pull_request": {"url": "https://api.github.com/.../pulls/11"},
+        },
+    ]
+
+    class _Proc:
+        returncode = 0
+        stdout = __import__("json").dumps(rest_payload)
+        stderr = ""
+
+    monkeypatch.setattr(pkg["ea"].subprocess, "run", lambda *a, **k: _Proc())
+
+    issues, err = pkg["orig"]["_fetch_open_issues"]()
+
+    assert err == ""
+    assert [int(i["number"]) for i in issues] == [10]  # PR #11 filtered out
+    only = issues[0]
+    assert only["url"] == "https://github.com/o/r/issues/10"  # html_url, not api
+    assert only["authorAssociation"] == "OWNER"
+    assert only["authorLogin"] == "po4erk91"
+    assert pkg["ea"]._issue_labels(only) == ["roadmap"]
 
 
 def test_apply_roadmap_issue_builds_evolve_applier_spawn(
@@ -798,17 +936,64 @@ def test_resolve_claim_race_loses_and_deletes_own_claim(
     assert deleted == ["https://x/issues/6#issuecomment-200"]
 
 
-def test_claim_body_includes_host_pid_git_rev(tmp_path, monkeypatch):
+def test_claim_body_redacts_host_identity_to_opaque_token(tmp_path, monkeypatch):
+    # #63: the public claim comment must NOT leak raw hostname/PID/git-rev;
+    # only the opaque per-host slug is published for cross-host triage.
     pkg = _bootstrap(tmp_path, monkeypatch)
+    import socket
+    monkeypatch.setattr(
+        pkg["ea"], "_host_identity",
+        lambda: {"hostname": "dev-laptop.local", "pid": 4242,
+                 "git_rev": "deadbeef"},
+    )
     issue = _issue(42, "Cross-host check")
     body = pkg["ea"]._roadmap_issue_claim_body(issue, now_t=1781438400.0)
     assert pkg["ea"].ROADMAP_ISSUE_CLAIM_MARKER in body
-    # The new identity block fields must be present so multi-host triage works.
-    assert "- Host:" in body
-    assert "- PID:" in body
-    assert "- Git rev:" in body
+    # No raw host identity in the public body.
+    assert "- Host:" not in body
+    assert "- PID:" not in body
+    assert "- Git rev:" not in body
+    assert "dev-laptop.local" not in body
+    assert "4242" not in body
+    assert "deadbeef" not in body
+    # The opaque slug (and only that) identifies the host.
+    assert "- Host token:" in body
+    assert pkg["ea"]._host_branch_slug() in body
     assert "- Started:" in body
     assert "Claim TTL:" in body
+
+
+def test_comment_issue_claim_records_full_host_identity_locally(
+    tmp_path, monkeypatch,
+):
+    # #63: full hostname/PID/git-rev is kept in the LOCAL event log only — it
+    # never egresses to the public tracker (the comment is redacted above).
+    pkg = _bootstrap(tmp_path, monkeypatch)
+    conn = pkg["db"].get_db()
+    monkeypatch.setattr(
+        pkg["ea"], "_host_identity",
+        lambda: {"hostname": "dev-laptop.local", "pid": 4242,
+                 "git_rev": "deadbeef"},
+    )
+
+    class _Proc:
+        returncode = 0
+        stdout = "https://github.com/o/r/issues/42#issuecomment-99\n"
+        stderr = ""
+
+    monkeypatch.setattr(pkg["ea"].subprocess, "run", lambda *a, **k: _Proc())
+    url, err = pkg["orig"]["_comment_issue_claim"](_issue(42, "Cross-host check"))
+    assert err == ""
+    assert url.endswith("issuecomment-99")
+    row = conn.execute(
+        "SELECT target, summary FROM events WHERE kind=?",
+        (pkg["ea"].ROADMAP_ISSUE_CLAIM_HOST_KIND,),
+    ).fetchone()
+    assert row is not None
+    assert row["target"] == "42"
+    assert "host=dev-laptop.local" in row["summary"]
+    assert "pid=4242" in row["summary"]
+    assert "git_rev=deadbeef" in row["summary"]
 
 
 def test_roadmap_branch_name_carries_host_suffix(tmp_path, monkeypatch):

--- a/threadkeeper/config.py
+++ b/threadkeeper/config.py
@@ -16,10 +16,10 @@ from __future__ import annotations
 import importlib.util
 import os
 from pathlib import Path
-from typing import Optional
+from typing import Annotated, Optional
 
 from pydantic import AliasChoices, BaseModel, Field, field_validator
-from pydantic_settings import BaseSettings, SettingsConfigDict
+from pydantic_settings import BaseSettings, NoDecode, SettingsConfigDict
 
 # ── env-file path resolved at module load so THREADKEEPER_ENV_FILE override works ──
 _ENV_FILE: str = os.environ.get(
@@ -250,6 +250,23 @@ class Settings(BaseSettings):
     # comments, and retract our claim if another host raced us. Cross-host
     # TOCTOU guard. Set to 0 in tests to skip the wait.
     roadmap_claim_race_window_s: float = 3.0
+    # Author-trust gate for autonomous GitHub-issue pickup (issue #63). This
+    # repo is public, so any account can open an issue whose body is then
+    # injected into a permission-bypassing implementer child. Auto-pickup is
+    # limited to issues whose GitHub author association is in this set;
+    # everything else needs explicit human promotion (a trust label below, or
+    # invoking the applier on the exact issue number). CSV string or list.
+    # NoDecode: keep a raw env string out of pydantic-settings' JSON decoder so
+    # the CSV validator below handles it.
+    evolve_trusted_author_associations: Annotated[list[str], NoDecode] = [
+        "OWNER", "MEMBER", "COLLABORATOR",
+    ]
+    # Optional escape hatch for the author gate: issues carrying any of these
+    # labels are eligible for auto-pickup regardless of author association. On
+    # a public repo only collaborators can apply labels, so a trust label is
+    # itself a maintainer endorsement. Empty by default — association is the
+    # sole gate. CSV string or list.
+    evolve_trust_labels: Annotated[list[str], NoDecode] = []
 
     # ── Thread janitor daemon ─────────────────────────────────────────────────
     thread_janitor_interval_s: float = 0.0
@@ -305,6 +322,22 @@ class Settings(BaseSettings):
         if isinstance(v, str):
             return [r.strip() for r in v.split(",") if r.strip()]
         return v
+
+    @field_validator("evolve_trusted_author_associations", mode="before")
+    @classmethod
+    def _parse_trusted_assocs(cls, v):
+        """Accept CSV string or list; normalize to UPPER (GitHub's casing)."""
+        if isinstance(v, str):
+            v = [a for a in v.split(",")]
+        return [str(a).strip().upper() for a in (v or []) if str(a).strip()]
+
+    @field_validator("evolve_trust_labels", mode="before")
+    @classmethod
+    def _parse_trust_labels(cls, v):
+        """Accept CSV string or list; normalize to lower (case-insensitive)."""
+        if isinstance(v, str):
+            v = [a for a in v.split(",")]
+        return [str(a).strip().lower() for a in (v or []) if str(a).strip()]
 
 
 # ── Instantiate ──────────────────────────────────────────────────────────────
@@ -407,6 +440,10 @@ def _derive_constants(s: "Settings") -> dict:
         "EVOLVE_REPO_URL": s.evolve_repo_url,
         "EVOLVE_REPO_BRANCH": s.evolve_repo_branch,
         "ROADMAP_CLAIM_RACE_WINDOW_S": s.roadmap_claim_race_window_s,
+        "EVOLVE_TRUSTED_AUTHOR_ASSOCIATIONS": (
+            s.evolve_trusted_author_associations
+        ),
+        "EVOLVE_TRUST_LABELS": s.evolve_trust_labels,
         "THREAD_JANITOR_INTERVAL_S": s.thread_janitor_interval_s,
         "THREAD_IDLE_CLOSE_DAYS": s.thread_idle_close_days,
         "DIALECTIC_MINE_INTERVAL_S": s.dialectic_mine_interval_s,

--- a/threadkeeper/evolve_applier.py
+++ b/threadkeeper/evolve_applier.py
@@ -43,6 +43,8 @@ from .config import (
     EVOLVE_REPO_BRANCH,
     EVOLVE_REPO_ROOT,
     EVOLVE_REPO_URL,
+    EVOLVE_TRUST_LABELS,
+    EVOLVE_TRUSTED_AUTHOR_ASSOCIATIONS,
     ROADMAP_CLAIM_RACE_WINDOW_S,
 )
 from .db import get_db
@@ -140,6 +142,10 @@ When finished, output exactly ONE final line:
 CURATOR_REPORT_MARKER = "CURATOR_PASS_COMPLETE"
 CURATOR_REPORT_APPLIED_KIND = "curator_report_applied"
 ROADMAP_ISSUE_APPLIED_KIND = "roadmap_issue_applied"
+# Local-only event recording the full host identity behind a posted claim. The
+# public claim comment carries just the opaque _host_branch_slug() token; this
+# event keeps hostname/PID/git-rev in the local DB for multi-host triage (#63).
+ROADMAP_ISSUE_CLAIM_HOST_KIND = "roadmap_issue_claim_host"
 ROADMAP_ISSUE_FETCH_LIMIT = 50
 ROADMAP_ISSUE_CLAIM_MARKER = "<!-- thread-keeper:evolve-applier-claim -->"
 ROADMAP_ISSUE_CLAIM_TTL_S = 24 * 60 * 60
@@ -570,14 +576,55 @@ def _issue_labels(issue: dict) -> list[str]:
     return out
 
 
+def _issue_author_association(issue: dict) -> str:
+    """Normalized GitHub author association for an issue (e.g. 'OWNER',
+    'MEMBER', 'NONE'). Missing/blank → 'NONE' so the trust gate fails closed."""
+    raw = issue.get("authorAssociation")
+    return str(raw or "").strip().upper() or "NONE"
+
+
+def _issue_author_trusted(issue: dict) -> bool:
+    """Whether an open issue is eligible for AUTONOMOUS pickup by the applier.
+
+    This repo is public, so any GitHub account can open an issue whose body is
+    then injected into a permission-bypassing implementer child. Trust comes
+    from EITHER a maintainer-level author association
+    (EVOLVE_TRUSTED_AUTHOR_ASSOCIATIONS — OWNER/MEMBER/COLLABORATOR by default)
+    OR a maintainer-applied trust label (EVOLVE_TRUST_LABELS; empty by
+    default). On a public repo only collaborators can apply labels, so a trust
+    label is itself a maintainer endorsement. Exact-issue invocation (a human
+    naming the number) bypasses this gate upstream as explicit promotion (#63).
+    """
+    trusted = {str(a).strip().upper() for a in EVOLVE_TRUSTED_AUTHOR_ASSOCIATIONS}
+    if _issue_author_association(issue) in trusted:
+        return True
+    label_set = {str(name).strip().lower() for name in EVOLVE_TRUST_LABELS
+                 if str(name).strip()}
+    if label_set and {name.lower() for name in _issue_labels(issue)} & label_set:
+        return True
+    return False
+
+
 def _fetch_open_issues(repo_root: Optional[Path] = None) -> tuple[list[dict], str]:
-    """Fetch open GitHub issues via gh. Returns (issues, error)."""
+    """Fetch open GitHub issues via the REST API. Returns (issues, error).
+
+    Uses `gh api` rather than `gh issue list --json` because the autonomous-
+    pickup author-trust gate (#63) needs each issue's `author_association`
+    (OWNER/MEMBER/COLLABORATOR/…), which the `gh issue list --json` field set
+    does not expose. The REST `/issues` endpoint also returns pull requests (a
+    PR is an issue in GitHub's data model); those are filtered out so the
+    applier never treats a PR as backlog. Returned dicts keep the prior
+    internal shape (`number/title/labels/body/url`) plus the new
+    `authorAssociation`/`authorLogin` fields the gate reads.
+    """
     repo = str(repo_root or _repo_root())
     cmd = [
-        "gh", "issue", "list",
-        "--state", "open",
-        "--limit", str(ROADMAP_ISSUE_FETCH_LIMIT),
-        "--json", "number,title,labels,body,url,createdAt,updatedAt",
+        "gh", "api",
+        "-H", "Accept: application/vnd.github+json",
+        (
+            "repos/{owner}/{repo}/issues"
+            f"?state=open&per_page={ROADMAP_ISSUE_FETCH_LIMIT}"
+        ),
     ]
     try:
         proc = subprocess.run(
@@ -604,7 +651,25 @@ def _fetch_open_issues(repo_root: Optional[Path] = None) -> tuple[list[dict], st
         return [], f"gh_issue_list_bad_json: {e}"
     if not isinstance(data, list):
         return [], "gh_issue_list_bad_shape"
-    return data, ""
+    out: list[dict] = []
+    for item in data:
+        if not isinstance(item, dict):
+            continue
+        if item.get("pull_request"):
+            # REST /issues includes PRs; the applier only drains real issues.
+            continue
+        user = item.get("user")
+        login = user.get("login") if isinstance(user, dict) else ""
+        out.append({
+            "number": item.get("number"),
+            "title": item.get("title") or "",
+            "labels": item.get("labels") or [],
+            "body": item.get("body") or "",
+            "url": item.get("html_url") or item.get("url") or "",
+            "authorAssociation": item.get("author_association") or "",
+            "authorLogin": login or "",
+        })
+    return out, ""
 
 
 def _fetch_issue_comments(
@@ -736,21 +801,50 @@ def _roadmap_issue_claim_body(
         timezone.utc,
     ).replace(microsecond=0).isoformat().replace("+00:00", "Z")
     ttl_h = int(ROADMAP_ISSUE_CLAIM_TTL_S // 3600)
-    ident = _host_identity()
+    # Public tracker — carry only the opaque per-host token, never the raw
+    # hostname/PID/git-rev. The token is enough to tell two racing hosts apart
+    # for human triage; the full identity is kept in the local event log (#63).
+    host_token = _host_branch_slug()
     return (
         f"{ROADMAP_ISSUE_CLAIM_MARKER}\n"
         "Evolve applier is starting work on this issue.\n\n"
         f"- Issue: #{num} {title}\n"
         "- Agent role: evolve_applier\n"
-        f"- Host: {ident['hostname'] or '?'}\n"
-        f"- PID: {ident['pid']}\n"
-        f"- Git rev: {ident['git_rev'] or '?'}\n"
+        f"- Host token: {host_token}\n"
         f"- Started: {ts}\n"
         f"- Claim TTL: {ttl_h}h\n\n"
         "Other agents should not start parallel implementation while this "
         "claim is active. If no PR or status update appears after the TTL, "
         "treat the claim as stale."
     )
+
+
+def _record_claim_host_identity(
+    issue_number: int,
+    comment_url: str,
+) -> None:
+    """Persist the full host identity (hostname/PID/git-rev) behind a posted
+    claim to the LOCAL event log only — it never egresses to the public
+    tracker, which gets the opaque `_host_branch_slug()` token. Best-effort
+    debugging aid for which machine owns a claim (#63)."""
+    ident = _host_identity()
+    summary = (
+        f"host={ident.get('hostname') or '?'} pid={ident.get('pid')} "
+        f"git_rev={ident.get('git_rev') or '?'} slug={_host_branch_slug()} "
+        f"comment={comment_url or '?'}"
+    )[:300]
+    try:
+        conn = get_db()
+        conn.execute(
+            "INSERT INTO events (session_id, kind, target, summary, created_at) "
+            "VALUES (?, ?, ?, ?, ?)",
+            (identity._session_id or "", ROADMAP_ISSUE_CLAIM_HOST_KIND,
+             str(int(issue_number)), summary, int(time.time())),
+        )
+        conn.commit()
+    except (sqlite3.OperationalError, sqlite3.ProgrammingError,
+            ValueError, TypeError):
+        pass
 
 
 def _comment_issue_claim(
@@ -789,6 +883,8 @@ def _comment_issue_claim(
         ln.strip() for ln in (proc.stdout or "").splitlines() if ln.strip()
     ]
     url = url_lines[0] if url_lines else ""
+    # Keep the full host identity locally (the public comment is redacted).
+    _record_claim_host_identity(num, url)
     return url, ""
 
 
@@ -950,6 +1046,7 @@ def _open_roadmap_issues(
     repo_root: Optional[Path] = None,
     *,
     skip_claimed: bool = True,
+    enforce_author_trust: bool = True,
 ) -> tuple[list[dict], str]:
     """Open GitHub issues not already handed off by evolve_applier.
 
@@ -957,12 +1054,20 @@ def _open_roadmap_issues(
     explicit `roadmap` label are prioritized first, then FIFO by number. Active
     issue-claim comments are skipped so multiple appliers do not start the same
     item in parallel.
+
+    When `enforce_author_trust` is set (the autonomous-drain default), issues
+    whose author is not trusted (`_issue_author_trusted`) are skipped — this
+    repo is public, so an untrusted issue body must not reach the permission-
+    bypassing implementer child without explicit human promotion (#63). Exact-
+    issue invocation passes `enforce_author_trust=False`: naming the number is
+    itself the human promotion.
     """
     issues, err = _fetch_open_issues(repo_root)
     if err:
         return [], err
     out: list[dict] = []
     claim_errors: list[str] = []
+    untrusted: list[int] = []
     now_t = time.time()
     for issue in issues:
         try:
@@ -970,6 +1075,9 @@ def _open_roadmap_issues(
         except (TypeError, ValueError):
             continue
         if _roadmap_issue_applied(conn, num):
+            continue
+        if enforce_author_trust and not _issue_author_trusted(issue):
+            untrusted.append(num)
             continue
         if skip_claimed:
             claimed, claim_err = _issue_has_active_claim(
@@ -987,6 +1095,13 @@ def _open_roadmap_issues(
             int(issue.get("number") or 0),
         )
     )
+    if untrusted:
+        logger.info(
+            "evolve_applier: skipped %d untrusted-author issue(s) on autonomous "
+            "pickup (no trusted authorAssociation/label): %s",
+            len(untrusted),
+            ", ".join(f"#{n}" for n in untrusted[:20]),
+        )
     if not out and claim_errors:
         return [], "roadmap_issue_claim_check_failed: " + "; ".join(
             claim_errors
@@ -1313,6 +1428,10 @@ def apply_roadmap_issue(issue_number: int = 0) -> str:
     With issue_number=0, this is queue mode: try candidates in roadmap/FIFO
     order and advance past issue-local dispatch failures. With a specific
     issue_number, this is exact mode and returns that issue's failure directly.
+
+    Queue mode enforces the author-trust gate (#63); exact mode bypasses it —
+    naming an issue number is itself the explicit human promotion the gate
+    requires for an untrusted author.
     """
     with _apply_spawn_lock() as locked:
         if not locked:
@@ -1324,7 +1443,7 @@ def apply_roadmap_issue(issue_number: int = 0) -> str:
             return repo_err
         exact = bool(issue_number)
         issues, err = _open_roadmap_issues(
-            conn, skip_claimed=not exact
+            conn, skip_claimed=not exact, enforce_author_trust=not exact
         )
         if err:
             return f"ERR roadmap_issue_fetch_failed: {err}"


### PR DESCRIPTION
## What

Closes #63.

Two trust-boundary fixes on the autonomous evolve-applier's GitHub issue-pickup path. This repo is **public**, so any account can open an issue whose body is injected into a permission-bypassing, shell-enabled implementer child.

### 1. Author-trust gate on auto-pickup
- `_fetch_open_issues` now fetches via the REST API (`gh api repos/{owner}/{repo}/issues`) instead of `gh issue list --json`, because the `--json` field set **cannot** return `author_association`. Pull requests in the REST response are filtered out; the returned dict keeps the prior internal shape plus `authorAssociation`/`authorLogin`.
- `_open_roadmap_issues` gains `enforce_author_trust` (default on). Autonomous pickup is limited to issues whose `authorAssociation` is in `EVOLVE_TRUSTED_AUTHOR_ASSOCIATIONS` (default `OWNER,MEMBER,COLLABORATOR`) **or** that carry a maintainer-applied label in `EVOLVE_TRUST_LABELS` (empty by default — only collaborators can label a public repo, so a label is an endorsement).
- Untrusted-author issues are skipped until promoted. Exact-number invocation (`evolve_apply_roadmap_issue(issue_number=N)`) bypasses the gate as explicit human promotion.
- Removes the untrusted input **at the boundary** — complementary to the in-prompt data-fencing of #22/#76.

### 2. Opaque host token in public claim comments
- The Python-generated claim body leaked the dev machine's hostname, PID, and an unreleased commit SHA on every claim. It now carries only the opaque per-host token already used for branch names (`_host_branch_slug()` = `sha1(hostname)[:6]`).
- Full host identity is kept in a local `roadmap_issue_claim_host` event for multi-host triage — it never egresses to the public tracker.

## Config (both new knobs are documented)
- `THREADKEEPER_EVOLVE_TRUSTED_AUTHOR_ASSOCIATIONS` (default `OWNER,MEMBER,COLLABORATOR`)
- `THREADKEEPER_EVOLVE_TRUST_LABELS` (empty by default)

## Tests
New/updated tests cover: untrusted-author skip, trust-label promotion, exact-mode bypass, the REST mapping + PR filtering, the redacted claim body, the local identity event, and the config-knob parsing/normalization.

Full suite: **928 passed, 0 failed, 1 skipped**.

## Acceptance criteria
- [x] Issue from a non-trusted author is not auto-picked-up (test with stubbed `authorAssociation`).
- [x] Posted claim comments contain no raw hostname, PID, or commit SHA.
- [x] Behavior is configurable and documented (README + ARCHITECTURE + ROADMAP + CHANGELOG).