### PR TITLE
fix(extract): route H4 cluster dedup through _enqueue so rejected counts (#62)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,17 @@ version bumps follow semver per the policy in
 
 ### Fixed
 
+- **Extract H4 paraphrase-cluster path no longer re-harvests rejected
+  candidates (#62).** The semantic-cluster heuristic had its own inline dedup
+  (`status IN ('pending','accepted')`) that omitted `'rejected'`, so a rejected
+  cluster — keyed by a deterministic `cluster:<sorted-uuid-prefixes>` the daemon
+  re-derives on every overlapping window — was invisible to the gate and
+  re-enqueued on the next tick: the same incident class as the documented
+  #157/#158 prod loop, on the one path that never received the
+  `_candidate_exists` fix. The H4 path now routes through `_enqueue`, so its
+  dedup shares the rejected-counting semantics of H1/H2/H3 (single source of
+  truth). Internal heuristic only — no API or env change.
+
 - **Late / out-of-order ingested dialog was evaluated by neither learning loop
   (#69).** `shadow_review` and `dialectic_miner` advanced a single global
   high-water cursor over `dialog_messages.created_at` (the message's own

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -408,12 +408,14 @@ Follow-up gaps from the 2026-06-17 audit:
 
 Deep code-audit pass (2026-06-17, evolve_reviewer second pass; each finding
 verified at the cited file:line, deduplicated against the issues above):
-- Extract H4 paraphrase-cluster path re-harvests **rejected** candidates
-  forever — its inline dedup checks `status IN ('pending','accepted')` only,
-  omitting `'rejected'`, so a rejected cluster reappears on the next
-  overlapping window. Same incident class as the documented #157/#158
-  prod loop, on the one heuristic path that never got the `_candidate_exists`
-  fix (#62).
+- ✅ DONE (#62). Extract H4 paraphrase-cluster path re-harvested **rejected**
+  candidates forever — its inline dedup checked `status IN ('pending','accepted')`
+  only, omitting `'rejected'`, so a rejected cluster (keyed by a deterministic
+  `cluster:<sorted-uuid-prefixes>`) reappeared on the next overlapping window.
+  Same incident class as the documented #157/#158 prod loop, on the one
+  heuristic path that never got the `_candidate_exists` fix. The H4 path now
+  routes through `_enqueue`, so its dedup shares the rejected-counting
+  semantics of H1/H2/H3 (single source of truth).
 - ✅ DONE (#63). Author-trust boundary on autonomous issue pickup: the applier
   fetched no `authorAssociation` and treated every open issue on this **public**
   repo as backlog for a `bypassPermissions` child; separately, the

--- a/tests/test_extract_daemon.py
+++ b/tests/test_extract_daemon.py
@@ -13,6 +13,8 @@ import sys
 import time
 from pathlib import Path
 
+import pytest
+
 
 _FAKE_CID = "aaaa1111-2222-3333-4444-555566667777"
 
@@ -49,14 +51,16 @@ def _bootstrap(tmp_path, monkeypatch, interval="0", window_min="30"):
     }
 
 
-def _seed_dialog(conn, role, content, ts, session_id="user-sess"):
+def _seed_dialog(conn, role, content, ts, session_id="user-sess",
+                 embedding=None):
     uid = f"u-{ts}-{role}-{abs(hash(content)) % 100000}"
     conn.execute(
         "INSERT INTO dialog_messages (uuid, source, project, session_id, "
-        "role, content, model, created_at) "
-        "VALUES (?, 'claude-code', 'p1', ?, ?, ?, ?, ?)",
-        (uid, session_id, role, content, "test-model", ts),
+        "role, content, model, created_at, embedding) "
+        "VALUES (?, 'claude-code', 'p1', ?, ?, ?, ?, ?, ?)",
+        (uid, session_id, role, content, "test-model", ts, embedding),
     )
+    return uid
 
 
 # ──────────────────────────────────────────────────────────────────────
@@ -510,6 +514,64 @@ def test_extract_filters_codex_spawned_marker_without_task_link(
     ).fetchall()
     assert any(r["source_cid"] == "real-sess" for r in rows)
     assert not any(r["source_cid"] == codex_rollout for r in rows)
+
+
+def test_extract_h4_rejected_cluster_not_reharvested(tmp_path, monkeypatch):
+    """H4 paraphrase-cluster path must share the rejected-counting dedup of
+    H1/H2/H3. A cluster keyed by its deterministic cluster_key, once
+    rejected, must NOT be re-enqueued when the daemon re-scans the
+    overlapping window — the #157/#158 prod re-harvest loop, on the one
+    heuristic path that bypassed _candidate_exists (issue #62)."""
+    np = pytest.importorskip("numpy")
+    pkg = _bootstrap(tmp_path, monkeypatch)
+    # H4 only runs when semantic clustering is available; force it on so the
+    # test is independent of the ambient THREADKEEPER_NO_EMBEDDINGS setting.
+    monkeypatch.setattr("threadkeeper.tools.extract.SEMANTIC_AVAILABLE", True)
+    conn = pkg["db"].get_db()
+    now = int(time.time())
+    # Identical unit-norm embeddings → pairwise cosine 1.0 ≥ 0.80, so the
+    # three paraphrases collapse into one H4 note cluster. The texts differ
+    # but none trips H1/H2/H3 (assistant role, short, no headers/bullets).
+    vec = np.ones(8, dtype=np.float32)
+    vec /= np.linalg.norm(vec)
+    emb = vec.tobytes()
+    for i, text in enumerate([
+        "We should retry transient deploy failures before paging anyone.",
+        "Transient deploy errors ought to be retried prior to alerting.",
+        "Retry transient failures in the deploy step before sending a page.",
+    ]):
+        _seed_dialog(
+            conn, "assistant", text, now - (300 - i * 10),
+            session_id="cluster-sess", embedding=emb,
+        )
+    conn.commit()
+
+    # First pass enqueues exactly one H4 cluster candidate.
+    out = pkg["extract_daemon"].run_extract_pass(force=True)
+    assert "ok" in out, out
+    rows = conn.execute(
+        "SELECT id FROM extract_candidates WHERE kind='note' "
+        "AND source_uuid LIKE 'cluster:%'"
+    ).fetchall()
+    assert len(rows) == 1, f"expected one H4 cluster row, got {len(rows)}"
+    cluster_id = rows[0]["id"]
+
+    # Reviewer rejects it.
+    conn.execute(
+        "UPDATE extract_candidates SET status='rejected' WHERE id=?",
+        (cluster_id,),
+    )
+    conn.commit()
+
+    # Daemon re-scans the overlapping window: same messages → same
+    # deterministic cluster_key. The rejected row must suppress re-harvest.
+    pkg["extract_daemon"].run_extract_pass(force=True)
+    rows = conn.execute(
+        "SELECT status FROM extract_candidates WHERE kind='note' "
+        "AND source_uuid LIKE 'cluster:%'"
+    ).fetchall()
+    assert len(rows) == 1, f"rejected H4 cluster re-harvested: {len(rows)} rows"
+    assert rows[0]["status"] == "rejected"
 
 
 # ──────────────────────────────────────────────────────────────────────

--- a/threadkeeper/tools/extract.py
+++ b/threadkeeper/tools/extract.py
@@ -275,23 +275,23 @@ def extract_recent(window_min: int = 60, max_messages: int = 500) -> str:
                         cluster_key = "cluster:" + ",".join(
                             u[:8] for u in member_uuids[:6]
                         )
-                        if conn.execute(
-                            "SELECT 1 FROM extract_candidates WHERE source_uuid=? "
-                            "AND status IN ('pending','accepted')",
-                            (cluster_key,),
-                        ).fetchone():
-                            skipped += 1
-                            continue
-                        conn.execute(
-                            "INSERT INTO extract_candidates (kind, source_uuid, "
-                            "source_cid, content, rationale, status, created_at) "
-                            "VALUES (?,?,?,?,?,?,?)",
-                            ("note", cluster_key, sid, rep["content"][:2000],
-                             f"H4 paraphrase_repeat n={len(members)} "
-                             f"sess={sid[:8]} centroid={rep['uuid'][:8]}",
-                             "pending", now),
+                        # Route through _enqueue (single source of truth) so
+                        # the H4 dedup counts 'rejected' too. The inline query
+                        # this replaced checked only ('pending','accepted'),
+                        # so a rejected cluster — keyed by a deterministic
+                        # cluster_key the daemon re-derives every overlapping
+                        # window — was re-harvested forever, the exact #157/#158
+                        # prod loop on the one path that never got the fix.
+                        res = _enqueue(
+                            conn, "note", cluster_key, sid,
+                            rep["content"][:2000],
+                            f"H4 paraphrase_repeat n={len(members)} "
+                            f"sess={sid[:8]} centroid={rep['uuid'][:8]}",
                         )
-                        counts["note"] += 1
+                        if res:
+                            counts["note"] += 1
+                        else:
+                            skipped += 1
     _emit(conn, "extract_recent",
           summary=" ".join(f"{k}={v}" for k, v in counts.items()))
     conn.commit()


### PR DESCRIPTION
## Problem

The extract daemon's **H4 paraphrase-cluster** path had its own inline dedup
(`threadkeeper/tools/extract.py`) that checked only:

```sql
SELECT 1 FROM extract_candidates WHERE source_uuid=?
AND status IN ('pending','accepted')
```

This **omits `'rejected'`**. The cluster key is deterministic
(`"cluster:" + sorted member uuid prefixes`) and the daemon re-scans an
overlapping window (default `EXTRACT_INTERVAL_S=600` over
`EXTRACT_WINDOW_MIN=30`), so a rejected cluster is invisible to the gate and
re-inserted on the next tick — the exact incident class documented for
`_candidate_exists` (#157 → byte-identical re-harvest as #158 ~19m after
rejection), on the one heuristic path that never received that fix.

## Fix

Route the H4 path through `_enqueue` / `_candidate_exists` (the single source of
truth, which deliberately counts candidates in **any** state including
`rejected`). H4 dedup now shares the rejected-counting semantics of H1/H2/H3.
Surgical: the inline SELECT + INSERT is replaced by one `_enqueue(...)` call,
matching the H1/H2/H3 call sites exactly.

## Test

`tests/test_extract_daemon.py::test_extract_h4_rejected_cluster_not_reharvested`
seeds three same-session messages with identical unit-norm embeddings (cosine
1.0 → one H4 cluster), runs a pass, rejects the candidate, then re-runs the
pass over the overlapping window and asserts **no duplicate row** — mirroring
the existing #157/#158 H1 regression.

## Acceptance criteria

- [x] A rejected H4 cluster candidate is not re-enqueued on subsequent
  overlapping-window passes.
- [x] H4 dedup shares the same rejected-counting semantics as H1/H2/H3.

## Test/docs impact

- Full suite green: 928 passed, 1 skipped, 0 failed.
- CHANGELOG + ROADMAP updated (internal heuristic — no API/env change).

Closes #62