### PR TITLE
feat: close mp_dashboard loop + mutation telemetry blind spots (#61)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -279,6 +279,22 @@ version bumps follow semver per the policy in
 
 ### Changed
 
+- **`mp_dashboard` no longer has loop + mutation telemetry blind spots (#61).**
+  The dashboard's loop list was a hand-maintained tuple that silently omitted
+  `dialectic_mine`, `dialectic_validate`, `evolve_apply`, and `thread_janitor`
+  — two of which spawn *paid* LLM children — so it disagreed with
+  `agent_status` on which loops even exist. It is now **derived from
+  `agent_status._LOOP_DEFS`** (single source of truth) and can never drift;
+  loop labels are the canonical loop ids. The **outcomes** section now also
+  counts knowledge-store mutations — `lesson_append`, `lesson_remove`,
+  `curator_report_applied`, `roadmap_issue_applied`, `evolve_applied`, and
+  `dialectic_claim` / `dialectic_supersede` — and a new **`curator_net_change
+  added=/removed=/patched=/net=`** line surfaces lessons-store growth or
+  shrinkage in the window, so a daemon silently auto-pruning the store now
+  produces a visible number. `lesson_append` now records a `lesson_append`
+  event (mirroring the existing `lesson_remove` event) with an
+  `op=create|replace` summary so additions are countable and split from
+  in-place patches.
 - **Autonomous Curator is now destructive by default.**
   `THREADKEEPER_CURATOR_DESTRUCTIVE` now defaults to `1`: once the curator
   daemon is enabled (`THREADKEEPER_CURATOR_INTERVAL_S > 0`), the child writes

--- a/README.md
+++ b/README.md
@@ -757,12 +757,19 @@ them with `dry_run=False` to apply:
   notes/dialog/distill/concepts counts, skills + claims by tier,
   extract-candidate and evolve queues, probe/task counts), **loops**
   (how many times each autonomous daemon fired in the window vs 30 days,
-  plus last-fire age), and **outcomes** (what those loops actually
-  produced — skills materialized, tier promotions, candidate
-  accept-vs-reject rate). Surfaces the gaps the point-tools can't:
-  a loop firing constantly while its outcomes stay flat, or a queue
-  backing up. Complements the per-loop `*_status` tools (`mp_health`,
-  `spawn_budget_status`, `shadow_review_status`).
+  plus last-fire age — the loop list is derived from the same source as
+  `agent_status`, so it covers *every* daemon including the paid-spawn
+  `dialectic_validate` / `evolve_apply` and the `thread_janitor`), and
+  **outcomes** (what those loops actually produced — skills materialized,
+  tier promotions, candidate accept-vs-reject rate, plus knowledge-store
+  mutation counts: `lesson_append` / `lesson_remove`,
+  `curator_report_applied`, `roadmap_issue_applied`, `evolve_applied`,
+  `dialectic_claim` / `dialectic_supersede`). A `curator_net_change
+  added/removed/patched/net` line makes a loop silently shrinking the
+  lessons store visible at a glance. Surfaces the gaps the point-tools
+  can't: a loop firing constantly while its outcomes stay flat, or a
+  queue backing up. Complements the per-loop `*_status` tools
+  (`mp_health`, `spawn_budget_status`, `shadow_review_status`).
 - **`shadow_review_status(snapshot_path="")`** — config, recent passes, and a
   per-loop **production-validation rollup** for the 24h and 7d windows: how
   often the daemon fired, the outcome mix (`no_window` / `too_short` /

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -176,6 +176,17 @@ partial schemas. The first live run surfaced the "Shadow-review proof"
 item below (shadow fires ≫ skills materialized). Possible follow-up:
 periodic dump-to-file for historical trend lines (currently a
 point-in-time snapshot). Scope of follow-up: S.
+  - **Telemetry blind spots closed (#61). ✅ DONE.** The loop list was a
+    hand-maintained tuple that omitted `dialectic_mine`, `dialectic_validate`,
+    `evolve_apply`, and `thread_janitor` (two spawn *paid* children) — it now
+    derives from `agent_status._LOOP_DEFS` so the two surfaces can't drift.
+    Outcomes now also count knowledge-store mutations (`lesson_append` /
+    `lesson_remove` / `curator_report_applied` / `roadmap_issue_applied` /
+    `evolve_applied` / `dialectic_claim` / `dialectic_supersede`), and a
+    `curator_net_change` line makes a daemon silently pruning the lessons
+    store a visible number. Partial overlap with the #40 destructive-curator
+    telemetry ask (the *visibility* half); the snapshot/restore safety net
+    remains in #40.
 
 **Shadow-review production telemetry.** ✅ DONE (#6). `shadow_review_status()`
 now carries a per-loop production-validation rollup for the 24h / 7d windows:

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -74,7 +74,8 @@ def test_dashboard_counts_stores_delta(fresh_mp):
 
 
 def _shadow_win(out: str) -> int:
-    m = re.search(r"shadow\s+(\d+) / \d+", out)
+    # Loop labels are now the agent_status loop ids (shadow_review, not shadow).
+    m = re.search(r"shadow_review\s+(\d+) / \d+", out)
     return int(m.group(1)) if m else 0
 
 
@@ -97,6 +98,108 @@ def test_dashboard_reflects_loop_and_outcome_events(fresh_mp):
     after_out = _tool(fresh_mp, "mp_dashboard")(window_days=7)
     assert _shadow_win(after_out) - before == 3, (before, after_out)
     assert "skill_materialized" in after_out, after_out
+
+
+def _loop_win(out: str, label: str) -> int:
+    m = re.search(rf"^\s+{re.escape(label)}\s+(\d+) / \d+", out, re.M)
+    return int(m.group(1)) if m else 0
+
+
+def _outcome_all(out: str, label: str) -> int:
+    m = re.search(rf"^\s+{re.escape(label)}\s+\d+ / \d+ / (\d+)", out, re.M)
+    return int(m.group(1)) if m else 0
+
+
+def _net_field(out: str, field: str) -> int:
+    m = re.search(rf"curator_net_change [^\n]*\b{field}=(\d+)", out)
+    return int(m.group(1)) if m else 0
+
+
+def _net_removed(out: str) -> int:
+    return _net_field(out, "removed")
+
+
+def test_dashboard_loop_list_matches_agent_status(fresh_mp):
+    # The two telemetry surfaces must agree on which loops exist: the dashboard
+    # derives its loop kinds from the same _LOOP_DEFS the menu-bar status reads.
+    from threadkeeper.tools import dashboard
+    from threadkeeper import agent_status
+
+    dash_events = {event for _, event in dashboard._LOOP_KINDS}
+    status_events = {d["event"] for d in agent_status._LOOP_DEFS}
+    assert dash_events == status_events, (dash_events, status_events)
+    # The previously-omitted loops (two spawn PAID children) must now be listed.
+    for kind in ("dialectic_mine_pass", "dialectic_validate_pass",
+                 "evolve_apply_pass", "janitor_pass"):
+        assert kind in dash_events, (kind, dash_events)
+
+
+def test_dashboard_reflects_previously_unlisted_loops(fresh_mp):
+    # Acceptance: fire counts show up for dialectic_mine, dialectic_validate,
+    # evolve_apply, and thread_janitor — loops the old hand-list omitted.
+    conn = fresh_mp["db"].get_db()
+    now = int(time.time())
+    dash = _tool(fresh_mp, "mp_dashboard")
+    # (loop id label, *_pass event kind)
+    seeded = [
+        ("dialectic_miner", "dialectic_mine_pass"),
+        ("dialectic_validator", "dialectic_validate_pass"),
+        ("evolve_apply", "evolve_apply_pass"),
+        ("thread_janitor", "janitor_pass"),
+    ]
+    before = {label: _loop_win(dash(window_days=7), label) for label, _ in seeded}
+    for _, kind in seeded:
+        for _ in range(2):
+            conn.execute(
+                "INSERT INTO events (session_id, kind, target, summary, created_at) "
+                "VALUES ('s', ?, '', '', ?)", (kind, now))
+    conn.commit()
+    after = dash(window_days=7)
+    for label, _ in seeded:
+        assert _loop_win(after, label) - before[label] == 2, (label, after)
+
+
+def test_dashboard_curator_removal_outcome(fresh_mp):
+    # Acceptance: a destructive curator pass that prunes 3 lessons shows a
+    # non-zero removal outcome AND a non-zero curator_net_change removed count.
+    conn = fresh_mp["db"].get_db()
+    now = int(time.time())
+    dash = _tool(fresh_mp, "mp_dashboard")
+    before_out = dash(window_days=7)
+    rem0 = _outcome_all(before_out, "lesson_remove")
+    net0 = _net_removed(before_out)
+    for i in range(3):
+        conn.execute(
+            "INSERT INTO events (session_id, kind, target, summary, created_at) "
+            "VALUES ('s', 'lesson_remove', ?, 'source=curator', ?)",
+            (f"stale-lesson-{i}", now))
+    conn.commit()
+    after = dash(window_days=7)
+    assert _outcome_all(after, "lesson_remove") - rem0 == 3, after
+    assert _net_removed(after) - net0 == 3, after
+
+
+def test_dashboard_lesson_append_emits_countable_outcome(fresh_mp):
+    # lesson_append now records an event so additions are visible as a number
+    # and split create-vs-patch in the curator_net_change line.
+    dash = _tool(fresh_mp, "mp_dashboard")
+    la = _tool(fresh_mp, "lesson_append")
+    before = dash(window_days=7)
+    add0 = _outcome_all(before, "lesson_append")
+    net_add0 = _net_field(before, "added")
+    net_patch0 = _net_field(before, "patched")
+
+    la(title="Dashboard test lesson", body="a durable rule worth keeping",
+       summary="tldr", source="curator")
+    # Re-append the same title → in-place patch, not a new addition.
+    la(title="Dashboard test lesson", body="the same rule, reworded",
+       summary="tldr", source="curator")
+
+    after = dash(window_days=7)
+    assert _outcome_all(after, "lesson_append") - add0 == 2, after
+    # One create, one in-place patch.
+    assert _net_field(after, "added") - net_add0 == 1, after
+    assert _net_field(after, "patched") - net_patch0 == 1, after
 
 
 def test_dashboard_accept_rate(fresh_mp):

--- a/threadkeeper/tools/dashboard.py
+++ b/threadkeeper/tools/dashboard.py
@@ -10,10 +10,14 @@ it), and safe to surface in any session.
 
 It reads only aggregates from existing tables + the `events` log; it does
 NOT spawn or mutate. Loop activity comes from the `*_pass` event rows each
-daemon already records (probe_pass, shadow_review_pass, curator_pass,
-extract_pass, candidate_review_pass, evolve_review_pass); outcomes come
-from the action events (skill_materialized, accept_candidate:*,
-reject_candidate, tier_promoted/demoted).
+daemon records — the loop list is derived from `agent_status._LOOP_DEFS`
+so it never drifts from the menu-bar status surface (it covers every loop,
+including the paid-spawn dialectic_validate and evolve_apply daemons and the
+thread_janitor). Outcomes come from the action events: skill/tier changes,
+accept/reject_candidate, AND knowledge-store mutations (lesson_append /
+lesson_remove, curator_report_applied, roadmap_issue_applied, evolve_applied,
+dialectic_claim / _supersede), plus a `curator_net_change` line so a loop
+silently shrinking the lessons store is visible at a glance.
 """
 
 from __future__ import annotations
@@ -22,6 +26,7 @@ import sqlite3
 import time
 
 from .._mcp import read_tool, write_tool
+from ..agent_status import _LOOP_DEFS
 from ..db import get_db
 from ..helpers import fmt_age
 from ..identity import _ensure_session
@@ -64,26 +69,39 @@ def _fmt_group(d: dict[str, int], order: tuple[str, ...]) -> str:
     return " ".join(parts) if parts else "0"
 
 
-# The autonomous loops, keyed by their events.kind='*_pass' marker.
-_LOOP_KINDS = (
-    ("ingest", "ingest_pass"),
-    ("shadow", "shadow_review_pass"),
-    ("extract", "extract_pass"),
-    ("candidate", "candidate_review_pass"),
-    ("curator", "curator_pass"),
-    ("probe", "probe_pass"),
-    ("evolve", "evolve_review_pass"),
-    ("auto_update", "auto_update_pass"),
-)
+# The autonomous loops, keyed by their events.kind='*_pass' marker. Derived
+# from agent_status._LOOP_DEFS — the SAME source the menu-bar status surface
+# reads — so the two telemetry views can never disagree on which loops exist.
+# (Previously hand-listed here, which silently omitted dialectic_mine,
+# dialectic_validate, evolve_apply, and thread_janitor — two of which spawn
+# paid LLM children.) Label is the loop id; kind is the '*_pass' event.
+_LOOP_KINDS = tuple((d["id"], d["event"]) for d in _LOOP_DEFS)
+_LOOP_LABEL_W = max((len(label) for label, _ in _LOOP_KINDS), default=10)
 
-# Outcome event kinds the loops are supposed to PRODUCE.
+# Outcome event kinds the loops are supposed to PRODUCE. Beyond the original
+# skill/tier/reject set, this now counts knowledge-store MUTATIONS — the most
+# consequential autonomous behavior — so a daemon adding to or deleting from
+# the lessons/claims store produces a visible number (issue #61):
+#   lesson_append / lesson_remove   — curator + shadow lesson writes/prunes
+#   curator_report_applied          — evolve_applier applied a curator report
+#   roadmap_issue_applied           — evolve_applier opened a roadmap-issue PR
+#   evolve_applied                  — evolve_applier marked a suggestion done
+#   dialectic_claim / _supersede    — user-model claim mutations
 _OUTCOME_KINDS = (
     ("skill_materialized", "skill_materialized"),
     ("tier_promoted", "tier_promoted"),
     ("tier_demoted", "tier_demoted"),
     ("skill_tier_promoted", "skill_tier_promoted"),
     ("reject_candidate", "reject_candidate"),
+    ("lesson_append", "lesson_append"),
+    ("lesson_remove", "lesson_remove"),
+    ("curator_report_applied", "curator_report_applied"),
+    ("roadmap_issue_applied", "roadmap_issue_applied"),
+    ("evolve_applied", "evolve_applied"),
+    ("dialectic_claim", "dialectic_claim"),
+    ("dialectic_supersede", "dialectic_supersede"),
 )
+_OUTCOME_LABEL_W = max((len(label) for label, _ in _OUTCOME_KINDS), default=22)
 
 
 @read_tool()
@@ -165,7 +183,7 @@ def mp_dashboard(window_days: int = 7) -> str:
         if n_30 == 0 and last == 0:
             continue  # never fired — skip to keep the view tight
         age = fmt_age(now - last) + "_ago" if last else "never"
-        out.append(f"  {label:<10} {n_win} / {n_30}   last={age}")
+        out.append(f"  {label:<{_LOOP_LABEL_W}} {n_win} / {n_30}   last={age}")
 
     # ── outcomes ──────────────────────────────────────────────────────
     out.append("")
@@ -186,7 +204,7 @@ def mp_dashboard(window_days: int = 7) -> str:
         )
         if n_all == 0:
             continue
-        out.append(f"  {label:<22} {n_win} / {n_30} / {n_all}")
+        out.append(f"  {label:<{_OUTCOME_LABEL_W}} {n_win} / {n_30} / {n_all}")
     # accept_candidate has a per-target-kind suffix (accept_candidate:note,
     # :verbatim, ...) so it needs a LIKE rather than equality.
     acc_all = _scalar(
@@ -202,6 +220,35 @@ def mp_dashboard(window_days: int = 7) -> str:
             f"  candidate_accept_rate {acc_all}/{decided} = {rate:.0%} "
             f"(accepted/decided, all-time)"
         )
+
+    # Knowledge-store net change in the window. A loop silently shrinking the
+    # lessons store (e.g. a destructive curator pass auto-pruning) is otherwise
+    # invisible — curator_pass only logs "spawned lessons=N..." at spawn time,
+    # not the deletions the async child makes. lesson_append events carry an
+    # `op=create|replace` summary prefix so we can split brand-new additions
+    # from in-place patches; lesson_remove is always a deletion. Always shown
+    # (even all-zero) so a shrink is visible at a glance.
+    added = _scalar(
+        conn,
+        "SELECT COUNT(*) FROM events WHERE kind='lesson_append' "
+        "AND summary LIKE 'op=create%' AND created_at>=?",
+        (cut_win,),
+    )
+    patched = _scalar(
+        conn,
+        "SELECT COUNT(*) FROM events WHERE kind='lesson_append' "
+        "AND summary LIKE 'op=replace%' AND created_at>=?",
+        (cut_win,),
+    )
+    removed = _scalar(
+        conn,
+        "SELECT COUNT(*) FROM events WHERE kind='lesson_remove' AND created_at>=?",
+        (cut_win,),
+    )
+    out.append(
+        f"  curator_net_change added={added} removed={removed} "
+        f"patched={patched} net={added - removed:+d} (lessons, {window_days}d)"
+    )
 
     # ── reliability ───────────────────────────────────────────────────
     weak = _scalar(

--- a/threadkeeper/tools/lessons.py
+++ b/threadkeeper/tools/lessons.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 
 from datetime import datetime
 import re
+import sqlite3
 from typing import Optional
 
 from .._mcp import read_tool, write_tool
@@ -146,9 +147,27 @@ def lesson_append(
                 f"score={score:.2f}; use lesson_get/skill_manage to patch "
                 "existing memory instead"
             )
+    # Was this an in-place patch of an existing slug, or a brand-new lesson?
+    # Determined BEFORE the write so the dashboard's curator-net-change line
+    # can split added vs patched.
+    existed = any(it["slug"] == _slugify(title) for it in iter_lessons())
     slug = append_lesson(
         title=title, body=body, summary=summary, source=source,
     )
+    # Record the write so mp_dashboard can count store growth (issue #61),
+    # mirroring the lesson_remove event below. The events table always exists
+    # (db schema); guard defensively anyway so a logging hiccup never loses
+    # the lesson the caller just materialized.
+    op = "replace" if existed else "create"
+    try:
+        conn.execute(
+            "INSERT INTO events (session_id, kind, target, summary, created_at) "
+            "VALUES (?, 'lesson_append', ?, ?, strftime('%s','now'))",
+            (identity._session_id or "", slug, f"op={op} source={source or '?'}"),
+        )
+        conn.commit()
+    except sqlite3.OperationalError:
+        pass
     return f"ok slug={slug} path={get_path()}"
 
 


### PR DESCRIPTION
## What

`mp_dashboard` (`tools/dashboard.py`) is the one-call rollup an in-session agent consults, but it under-reported the system. This closes both blind spots from #61.

### Loops were absent
`_LOOP_KINDS` was a hand-maintained tuple that silently omitted `dialectic_mine_pass`, `dialectic_validate_pass`, `evolve_apply_pass`, and `janitor_pass` — and `evolve_apply` + `dialectic_validate` both spawn **paid** LLM children. `agent_status._LOOP_DEFS` already listed them, so the two telemetry surfaces disagreed on which loops exist.

- `_LOOP_KINDS` is now **derived from `agent_status._LOOP_DEFS`** (single source of truth) → the two views can never drift. Loop labels are the canonical loop ids; the label column auto-widens.

### Mutation outcomes were uncounted
`_OUTCOME_KINDS` tracked only `skill_materialized`, tier changes, and `reject_candidate`. A daemon auto-deleting from the knowledge store produced **no number anywhere**.

- Added outcome counts: `lesson_append`, `lesson_remove`, `curator_report_applied`, `roadmap_issue_applied`, `evolve_applied`, `dialectic_claim`, `dialectic_supersede`.
- Added a **`curator_net_change added=/removed=/patched=/net=`** line so a loop silently shrinking the lessons store is visible at a glance.
- `lesson_append` now records a `lesson_append` event (mirroring the existing `lesson_remove` event) with an `op=create|replace` summary, so additions are countable and split from in-place patches.

## Acceptance criteria
- `mp_dashboard()` shows fire counts for dialectic_mine, dialectic_validate, evolve_apply, and thread_janitor; the loop list matches `agent_status` (asserted in `test_dashboard_loop_list_matches_agent_status`).
- A destructive curator pass that prunes 3 lessons shows a non-zero removal outcome (asserted in `test_dashboard_curator_removal_outcome`).

## Tests / docs
- Extended `tests/test_dashboard.py` with 4 delta-based tests (loop-list parity, previously-unlisted loop fire counts, curator removal outcome + net-change, lesson_append create/patch split).
- Updated README (Telemetry), `docs/ROADMAP.md`, and CHANGELOG.
- Full suite green (`env -u THREADKEEPER_NO_EMBEDDINGS .venv/bin/python -m pytest -q`): 0 failed.

Closes #61
