### PR TITLE
fix(spawn): measure visible (pid=0) child RSS + TTL-reap unresolved budget rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,20 @@ version bumps follow semver per the policy in
   over-fetch-past-orphans path, the consolidate apply path, and the
   dimension-mismatch warning. Distinct from the closed integrity issue #56
   (tampered-artifact verification) — this is dimension-compatibility.
+- **Spawn budget now measures visible (pid=0) children and reaps unresolvable
+  rows (#64).** The budget daemon skipped `pid<=0`, so a visible
+  (Terminal-launched) child's real (~1.3 GB) RSS was never measured — it only
+  ever counted as its static pre-launch estimate, letting combined visible-child
+  memory exceed `SPAWN_BUDGET_MB` while the accounting believed it was under cap.
+  And a visible row whose jsonl never resolved kept `ended_at` NULL, pinning its
+  full-estimate budget share indefinitely. Now: the daemon resolves a visible
+  child's live pid from the `--session-id <cid>` it carries in `ps` argv and
+  measures its real subtree RSS like any other child, and a new
+  `THREADKEEPER_SPAWN_VISIBLE_TTL_S` (3600 s default; 0 disables) wall-clock
+  backstop marks any `pid<=0` row whose cid never resolves to a live process as
+  ended once it outlives the TTL, so it can't pin capacity forever. The
+  admission-time check-then-spawn TOCTOU (#58), kill-path/pid-reuse hardening
+  (#66), and spool/tasks retention (#42) remain out of scope.
 
 - **Extract H4 paraphrase-cluster path no longer re-harvests rejected
   candidates (#62).** The semantic-cluster heuristic had its own inline dedup

--- a/README.md
+++ b/README.md
@@ -239,6 +239,14 @@ refuses a new spawn that would exceed `THREADKEEPER_SPAWN_BUDGET_MB`
 (3 GB default). Slim children that need semantic search delegate to the
 parent via `search_via_parent` — no per-child copy of the embedding model.
 
+Visible (`visible=True`, Terminal.app) children persist `pid=0`, so the
+daemon resolves their live pid from the `--session-id` it carries in `ps`
+argv and measures the real RSS tree — they count their true memory, not
+the static estimate. A visible row whose session-id never resolves to a
+live process is reaped once it outlives `THREADKEEPER_SPAWN_VISIBLE_TTL_S`
+(1 h default; 0 disables), so an unresolvable row can't pin budget
+capacity forever.
+
 `tk-agent-status` exposes autonomous learning loop status as structured JSON
 or compact text for external monitors:
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -395,10 +395,14 @@ children** (the parent itself is not counted). Default 3 GB.
 - After admission, INSERT into `tasks` writes an initial estimate
   (`SPAWN_ESTIMATE_SLIM_MB` / `SPAWN_ESTIMATE_FULL_MB`).
 - Daemon ticks update real RSS via `ps`; dead root pids → `ended_at`.
+- Visible spawns (Terminal.app) persist `pid=0`; the daemon resolves their live
+  pid from the `--session-id <cid>` the child carries in `ps` argv and measures
+  the same subtree RSS, so they contribute real memory, not the estimate. A
+  visible row whose cid never resolves to a live process is reaped past
+  `SPAWN_VISIBLE_TTL_S` (1 h default) so it can't pin budget capacity forever.
 
 Tools: `spawn_budget_status()` (cap/used/free/per-task), `spawn_budget_set(MB)`
-(runtime override, not persisted). Visible spawns (Terminal.app, pid=0) aren't
-tracked — their RSS column stays at the estimate.
+(runtime override, not persisted).
 
 ## Learning loop
 
@@ -989,6 +993,7 @@ rubric-sensitivity + a subprocess end-to-end run).
 | `THREADKEEPER_SPAWN_ESTIMATE_SLIM_MB` | 500 | initial slim child RSS guess |
 | `THREADKEEPER_SPAWN_ESTIMATE_FULL_MB` | 1500 | initial full child RSS guess |
 | `THREADKEEPER_SPAWN_BUDGET_POLL_S` | 10 | budget daemon tick; 0 disables |
+| `THREADKEEPER_SPAWN_VISIBLE_TTL_S` | 3600 | reap a visible (pid=0) row whose cid never resolves to a live process; 0 disables |
 | `THREADKEEPER_MENUBAR_AUTO_LAUNCH` | true | macOS: auto install/launch agent-status menu-bar app on MCP startup |
 | `THREADKEEPER_MENUBAR_RESTART_RSS_MB` | 1024 | macOS widget self-restart RSS threshold; 0 disables |
 | `THREADKEEPER_MEMORY_GUARD_POLL_S` | 30 | server RSS guard tick; 0 disables |

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -442,10 +442,14 @@ verified at the cited file:line, deduplicated against the issues above):
   identity is recorded in a local `roadmap_issue_claim_host` event. Removes the
   untrusted input at the boundary (complements #22/#76 fencing and #50
   skip-label) and is documented in README + ARCHITECTURE.
-- Spawn budget is blind to **visible (pid=0)** children: their real RSS is
-  never measured (the daemon skips `pid<=0`), and a visible row whose jsonl
-  never resolves pins its full-estimate budget share forever. (The
-  admission-time check-then-spawn TOCTOU is #58; kill-path safety is #66.) (#64).
+- ✅ DONE (#64). Spawn budget was blind to **visible (pid=0)** children: their
+  real RSS was never measured (the daemon skipped `pid<=0`), and a visible row
+  whose jsonl never resolved pinned its full-estimate budget share forever. Now:
+  the budget daemon resolves a visible child's live pid from the `--session-id`
+  it carries in `ps` argv and measures its real subtree RSS, and a
+  `SPAWN_VISIBLE_TTL_S` (1 h default) wall-clock backstop reaps any `pid<=0` row
+  whose cid never resolves to a live process so it can't pin capacity forever.
+  (The admission-time check-then-spawn TOCTOU is #58; kill-path safety is #66.)
 - ✅ DONE (#68). Spawn **slim MCP config** was written world-readable with no
   `chmod` and embedded the host server `env` block, while the stdin prompt file
   is correctly `0600` and the `.command` script was `0755`. Now: slim config

--- a/tests/test_spawn_budget.py
+++ b/tests/test_spawn_budget.py
@@ -43,6 +43,23 @@ def _insert_task(pkg, task_id, rss_kb=None, ended=False):
     conn.commit()
 
 
+def _insert_visible_task(pkg, task_id, cid, rss_kb=None, started_at=None):
+    """Insert a visible (Terminal-launched) task: pid=0, spawned_cid=cid.
+    `cwd` points at a non-existent project dir so _refresh_tasks's jsonl-idle
+    path resolves to 'no_jsonl' (the row stays running until the TTL/RSS path
+    decides), isolating the #64 budget behaviour under test."""
+    conn = pkg["db"].get_db()
+    now = int(time.time())
+    conn.execute(
+        "INSERT INTO tasks (id, pid, parent_cid, spawned_cid, cwd, prompt, "
+        "started_at, ended_at, rss_kb, rss_updated_at) "
+        "VALUES (?,?,?,?,?,?,?,?,?,?)",
+        (task_id, 0, _FAKE_CID, cid, "/tmp", "visible test",
+         (started_at if started_at is not None else now), None, rss_kb, now),
+    )
+    conn.commit()
+
+
 # ─────────────────────────────────────────────────────────────────────
 # estimate_child_rss_kb
 # ─────────────────────────────────────────────────────────────────────
@@ -156,6 +173,104 @@ def test_spawn_budget_status_when_disabled(mp_with_cid, monkeypatch):
     pkg = mp_with_cid(_FAKE_CID)
     txt = _txt(_tool(pkg, "spawn_budget_status")())
     assert "budget=disabled" in txt
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Visible (pid=0) child RSS attribution + TTL reaper (#64)
+# ─────────────────────────────────────────────────────────────────────
+
+def test_visible_child_rss_measured_via_cid(mp_with_cid, monkeypatch):
+    """A visible (pid=0) child's real RSS is resolved from its session-id and
+    reflected in spawn_budget_status, replacing the static estimate (#64)."""
+    monkeypatch.setenv("THREADKEEPER_SPAWN_BUDGET_MB", "3072")
+    pkg = mp_with_cid(_FAKE_CID)
+    # Admitted at the 1500MB full-estimate; real tree is 1300MB.
+    _insert_visible_task(pkg, "tk_vis", cid="vis-cid-1234", rss_kb=1500 * 1024)
+
+    import threadkeeper.spawn_budget as sb
+    monkeypatch.setattr(
+        sb, "_pid_for_cid",
+        lambda cid: 4242 if cid == "vis-cid-1234" else None,
+    )
+    monkeypatch.setattr(
+        sb, "measure_tree_rss_kb",
+        lambda pid: 1300 * 1024 if pid == 4242 else None,
+    )
+
+    conn = pkg["db"].get_db()
+    assert sb._refresh_all_running(conn) == 1
+
+    txt = _txt(_tool(pkg, "spawn_budget_status")())
+    assert "tk_vis" in txt
+    assert "pid=vis" in txt
+    assert "rss=1300MB" in txt  # real measurement, not the 1500 estimate
+
+
+def test_visible_pid_lookup_matches_session_id_in_argv(mp_with_cid, monkeypatch):
+    """_pid_for_cid finds the claude child by its --session-id arg in `ps`."""
+    pkg = mp_with_cid(_FAKE_CID)
+    import threadkeeper.spawn_budget as sb
+
+    fake_ps = (
+        "  111 /sbin/launchd\n"
+        "  222 claude -p hello --session-id abc-123-cid --model sonnet\n"
+        "  333 /usr/bin/python server.py\n"
+    )
+
+    class _R:
+        stdout = fake_ps
+
+    monkeypatch.setattr(sb.subprocess, "run", lambda *a, **k: _R())
+    assert sb._pid_for_cid("abc-123-cid") == 222
+    assert sb._pid_for_cid("not-present") is None
+    assert sb._pid_for_cid("") is None
+
+
+def test_visible_ttl_reaps_unresolved_row(mp_with_cid, monkeypatch):
+    """A visible row whose cid never resolves to a live process is reaped past
+    SPAWN_VISIBLE_TTL_S and stops counting against the budget (#64)."""
+    monkeypatch.setenv("THREADKEEPER_SPAWN_BUDGET_MB", "3072")
+    monkeypatch.setenv("THREADKEEPER_SPAWN_VISIBLE_TTL_S", "1800")
+    pkg = mp_with_cid(_FAKE_CID)
+    old = int(time.time()) - 2000  # older than the 1800s TTL
+    _insert_visible_task(
+        pkg, "tk_stuck", cid="ghost-cid", rss_kb=1500 * 1024, started_at=old,
+    )
+
+    import threadkeeper.spawn_budget as sb
+    monkeypatch.setattr(sb, "_pid_for_cid", lambda cid: None)  # never resolves
+
+    conn = pkg["db"].get_db()
+    sb._refresh_all_running(conn)
+
+    row = conn.execute(
+        "SELECT ended_at FROM tasks WHERE id='tk_stuck'"
+    ).fetchone()
+    assert row["ended_at"] is not None
+    assert sb._running_tasks_rss(conn) == 0  # no longer pins the budget
+
+
+def test_visible_within_ttl_not_reaped(mp_with_cid, monkeypatch):
+    """A young visible row with no resolvable process is left running until
+    the TTL elapses — the reaper must not close live work prematurely."""
+    monkeypatch.setenv("THREADKEEPER_SPAWN_BUDGET_MB", "3072")
+    monkeypatch.setenv("THREADKEEPER_SPAWN_VISIBLE_TTL_S", "1800")
+    pkg = mp_with_cid(_FAKE_CID)
+    young = int(time.time()) - 30
+    _insert_visible_task(
+        pkg, "tk_young", cid="ghost-cid", rss_kb=1500 * 1024, started_at=young,
+    )
+
+    import threadkeeper.spawn_budget as sb
+    monkeypatch.setattr(sb, "_pid_for_cid", lambda cid: None)
+
+    conn = pkg["db"].get_db()
+    sb._refresh_all_running(conn)
+
+    row = conn.execute(
+        "SELECT ended_at FROM tasks WHERE id='tk_young'"
+    ).fetchone()
+    assert row["ended_at"] is None  # still within TTL → keeps counting
 
 
 # ─────────────────────────────────────────────────────────────────────

--- a/threadkeeper/config.py
+++ b/threadkeeper/config.py
@@ -152,6 +152,11 @@ class Settings(BaseSettings):
     spawn_estimate_slim_mb: int = 500
     spawn_estimate_full_mb: int = 1500
     spawn_budget_poll_s: float = 10.0
+    # Wall-clock backstop for visible (pid=0) children: a Terminal-launched
+    # row whose process can't be resolved from its cid is marked ended once it
+    # outlives this, so an unresolvable row can't pin budget capacity forever
+    # (#64). 0 disables the reaper.
+    spawn_visible_ttl_s: float = 3600.0
 
     # ── Memory guard ─────────────────────────────────────────────────────────
     memory_guard_poll_s: float = 30.0
@@ -413,6 +418,7 @@ def _derive_constants(s: "Settings") -> dict:
         "SPAWN_ESTIMATE_SLIM_MB": s.spawn_estimate_slim_mb,
         "SPAWN_ESTIMATE_FULL_MB": s.spawn_estimate_full_mb,
         "SPAWN_BUDGET_POLL_S": s.spawn_budget_poll_s,
+        "SPAWN_VISIBLE_TTL_S": s.spawn_visible_ttl_s,
         "MEMORY_GUARD_POLL_S": s.memory_guard_poll_s,
         "MEMORY_GUARD_WARN_MB": s.memory_guard_warn_mb,
         "MEMORY_GUARD_KILL_MB": s.memory_guard_kill_mb,

--- a/threadkeeper/spawn_budget.py
+++ b/threadkeeper/spawn_budget.py
@@ -14,6 +14,11 @@ Flow:
   background daemon (start_budget_daemon):
     every SPAWN_BUDGET_POLL_S seconds, walk running tasks, compute real
     RSS of each process tree via `ps`, write back into tasks.rss_kb.
+    Visible (Terminal-launched) children persist pid=0, so their live pid
+    is resolved from their forced session-id (spawned_cid) in `ps` argv and
+    measured the same way — they contribute real RSS, not the static
+    estimate. A visible row whose cid never resolves to a live process is
+    reaped past SPAWN_VISIBLE_TTL_S so it can't pin budget capacity forever.
     Tasks that have ended → no update (their rss_kb stays as last seen
     but they're filtered out by ended_at IS NOT NULL anyway).
 
@@ -37,6 +42,7 @@ from .config import (
     SPAWN_ESTIMATE_SLIM_MB,
     SPAWN_ESTIMATE_FULL_MB,
     SPAWN_BUDGET_POLL_S,
+    SPAWN_VISIBLE_TTL_S,
 )
 from .db import get_db
 from .helpers import alive
@@ -133,6 +139,35 @@ def measure_tree_rss_kb(root_pid: int) -> Optional[int]:
     return _rss_for_pids(tree)
 
 
+def _pid_for_cid(cid: str) -> Optional[int]:
+    """Resolve the live OS pid of a visible (Terminal-launched) child from its
+    forced session-id. spawn() persists pid=0 for visible children, but a
+    claude child carries `--session-id <cid>` in its argv, so the cid is a
+    stable handle into `ps`. Returns the first process whose command line
+    contains the cid, or None when no live process carries it (child not yet
+    started, already exited, or a non-claude CLI that keeps the cid in env)."""
+    if not cid:
+        return None
+    try:
+        r = subprocess.run(
+            ["ps", "-ax", "-o", "pid=,command="],
+            capture_output=True, text=True, timeout=3,
+        )
+    except (subprocess.SubprocessError, OSError):
+        return None
+    for line in (r.stdout or "").splitlines():
+        parts = line.strip().split(None, 1)
+        if len(parts) < 2:
+            continue
+        pid_s, cmdline = parts
+        if cid in cmdline:
+            try:
+                return int(pid_s)
+            except ValueError:
+                continue
+    return None
+
+
 # ─────────────────────────────────────────────────────────────────────
 # Budget check
 # ─────────────────────────────────────────────────────────────────────
@@ -180,26 +215,69 @@ def check_budget(conn, new_child_kb: int) -> Tuple[bool, str]:
 # Daemon — refresh real RSS values
 # ─────────────────────────────────────────────────────────────────────
 
+def _measure_visible(conn, row, now: int) -> int:
+    """Account a visible (pid=0) child's memory, or reap an unresolvable row.
+
+    Resolves the live pid from the row's forced session-id (spawned_cid) and
+    writes its real RSS tree into rss_kb, so visible children contribute true
+    memory to the budget instead of the static pre-launch estimate (#64). When
+    no live process carries the cid and the row has outlived
+    SPAWN_VISIBLE_TTL_S, mark it ended so an unresolvable visible row cannot
+    pin budget capacity forever.
+
+    Returns 1 when rss_kb was refreshed, 2 when the row was reaped, else 0."""
+    cid = row["spawned_cid"]
+    vpid = _pid_for_cid(cid) if cid else None
+    if vpid:
+        rss = measure_tree_rss_kb(vpid)
+        if rss is not None:
+            conn.execute(
+                "UPDATE tasks SET rss_kb=?, rss_updated_at=? WHERE id=?",
+                (rss, now, row["id"]),
+            )
+            return 1
+        return 0  # live pid found but RSS unreadable this tick — leave as-is
+    started = row["started_at"] or 0
+    if SPAWN_VISIBLE_TTL_S > 0 and started and (now - started) >= SPAWN_VISIBLE_TTL_S:
+        conn.execute(
+            "UPDATE tasks SET ended_at=? WHERE id=? AND ended_at IS NULL",
+            (now, row["id"]),
+        )
+        return 2
+    return 0
+
+
 def _refresh_all_running(conn) -> int:
-    """Sweep running tasks, update rss_kb with real measurement. Tasks
-    whose pid is invalid (0 / visible spawn) are skipped — their RSS
-    can't be tracked from here. Returns number of rows updated."""
+    """Sweep running tasks, update rss_kb with real measurement.
+
+    pid>0 (headless) children are measured directly from their pid. Visible
+    (pid<=0, Terminal-launched) children are resolved to a live pid via their
+    forced session-id and measured too — and reaped past a TTL when no live
+    process carries the cid (#64). Returns the number of rows whose rss_kb was
+    refreshed."""
     rows = conn.execute(
-        "SELECT id, pid, spawned_cid FROM tasks "
+        "SELECT id, pid, spawned_cid, started_at FROM tasks "
         "WHERE ended_at IS NULL ORDER BY started_at DESC LIMIT 100"
     ).fetchall()
     now = int(time.time())
     updated = 0
+    changed = False
     for r in rows:
         pid = r["pid"]
         if not pid or pid <= 0:
-            continue  # visible spawns — Terminal-launched, pid not tracked
+            code = _measure_visible(conn, r, now)
+            if code:
+                changed = True
+                if code == 1:
+                    updated += 1
+            continue
         if not alive(pid):
             # Process gone — mark ended, leave rss_kb as last-known.
             conn.execute(
                 "UPDATE tasks SET ended_at=? WHERE id=? AND ended_at IS NULL",
                 (now, r["id"]),
             )
+            changed = True
             continue
         rss = measure_tree_rss_kb(pid)
         if rss is None:
@@ -209,7 +287,8 @@ def _refresh_all_running(conn) -> int:
             (rss, now, r["id"]),
         )
         updated += 1
-    if updated:
+        changed = True
+    if changed:
         try:
             conn.commit()
         except Exception:

--- a/threadkeeper/tools/spawn.py
+++ b/threadkeeper/tools/spawn.py
@@ -993,8 +993,10 @@ def spawn_budget_status() -> SpawnBudgetStatus:
 
     Values come from the budget daemon (refreshes every SPAWN_BUDGET_POLL_S
     seconds via `ps`). Just-spawned tasks show their initial estimate until
-    the daemon catches up. Tasks with pid=0 (visible Terminal-launched
-    spawns) aren't tracked from here — their RSS column stays as estimate.
+    the daemon catches up. Visible (pid=0, Terminal-launched) spawns are
+    tracked too: the daemon resolves their live pid from the forced
+    session-id and measures real RSS, and reaps a row whose cid never
+    resolves past SPAWN_VISIBLE_TTL_S (#64).
 
     Returns structuredContent (SpawnBudgetStatus) plus the legacy text block."""
     from ..config import SPAWN_BUDGET_MB, SPAWN_BUDGET_POLL_S


### PR DESCRIPTION
## Problem (#64)

The spawn budget (RSS admission control) was blind to **visible** (Terminal-launched) children:

1. **Visible children were never RSS-measured.** Visible spawns persist `pid=0`, and the budget daemon's RSS refresh skipped `pid<=0`, so a Terminal-launched child's real (~1.3 GB) RSS was never measured — it only ever counted as the static pre-launch estimate. Combined visible-child memory could therefore exceed `SPAWN_BUDGET_MB` while the accounting believed it was under cap.
2. **jsonl-unresolved visible rows pinned budget forever.** When a visible row's jsonl never bound, `_visible_task_status` never reached `idle`, `ended_at` stayed NULL, and the row consumed its full-estimate budget share indefinitely — a slow capacity leak.

## Change

- **Real RSS for visible children.** The budget daemon (`_refresh_all_running`) no longer gives up at `pid<=0`. It resolves the live OS pid from the child's forced session-id — a claude child carries `--session-id <cid>` in its `ps` argv, and `spawn()` already persists that cid as `spawned_cid` — via the new `_pid_for_cid()`, then measures the real subtree RSS through the existing `measure_tree_rss_kb()`. Visible children now contribute their true memory to `spawn_budget_status` and admission control.
- **TTL backstop.** New `THREADKEEPER_SPAWN_VISIBLE_TTL_S` (default `3600`s; `0` disables). A `pid<=0` row whose cid never resolves to a live process is marked `ended` once it outlives the TTL, so an unresolvable row can't pin budget capacity forever. Rows with a live, findable process are never reaped (they keep being measured).

## Scope

Per the issue, this is specifically about visible-child *measurement* and *reclamation*. Out of scope and untouched: admission-time check-then-spawn TOCTOU (#58), kill-path/pid-reuse hardening (#66), spool/tasks retention (#42).

## Tests

`tests/test_spawn_budget.py` (+4):
- `test_visible_child_rss_measured_via_cid` — stubbed `ps`/`measure_tree_rss_kb`; real RSS reflected in `spawn_budget_status`, replacing the estimate.
- `test_visible_pid_lookup_matches_session_id_in_argv` — `_pid_for_cid` matches the `--session-id` arg.
- `test_visible_ttl_reaps_unresolved_row` — unresolvable row past TTL is reaped and stops counting.
- `test_visible_within_ttl_not_reaped` — young unresolvable row is left running.

Full suite green (`PYTEST_EXIT=0`, deterministic order).

## Docs

README "Spawn", `docs/ARCHITECTURE.md` (Spawn budget + env table), `docs/ROADMAP.md` (#64 → DONE), `CHANGELOG.md`.

Closes #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)