### PR TITLE
docs: reconcile hot-config-reload status across README/ARCHITECTURE (#77)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,17 @@ version bumps follow semver per the policy in
   (`candidate_reviewer` and `dialectic_validator` were never exposed — they
   re-scan the whole pending queue and use the cursor only for telemetry.)
 
+- **Docs: reconciled the hot-config-reload status across surfaces (#77).** The
+  three doc surfaces disagreed: the README pointed at the now-closed-completed
+  issue #2 as if it were a live tracker for unfinished work, and
+  `docs/ARCHITECTURE.md`'s "What is NOT done" still listed "No hot-config
+  reload … requires restarting the MCP process" — directly contradicting the
+  same file's `config_watcher` description and ROADMAP's `✅ DONE (#2)`. In-process
+  reload is in fact shipped (the `config_watcher` daemon re-applies changed
+  `THREADKEEPER_*` knobs from the watched `settings.json` without a restart), so
+  the README now states that plainly instead of linking the closed issue, and
+  the stale ARCHITECTURE bullet was removed. Docs-only; no code or behavior change.
+
 ### Security
 
 - **Author-trust gate for autonomous issue pickup + redacted claim comments

--- a/README.md
+++ b/README.md
@@ -680,8 +680,11 @@ Persist them in `~/.threadkeeper/.env` (copy from `.env.example`) — one file,
 read via pydantic-settings; real environment variables still override it. On
 macOS, the menu-bar app's gear button can edit the same file visually, save up
 to three local presets, and request a ThreadKeeper restart after saving.
-Hot-config reload is
-[tracked](https://github.com/po4erk91/thread-keeper/issues/2).
+Hot-config reload for the watched `settings.json` env block is implemented
+(shipped in #2): the `config_watcher` daemon re-applies changed `THREADKEEPER_*`
+knobs in-process within ~2 s, with no Claude Code restart — toggle it via
+`THREADKEEPER_CONFIG_WATCH_INTERVAL_S` (above; `0` disables) and inspect with
+`config_watch_status()`.
 
 ### Per-loop agent dispatch
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1013,9 +1013,6 @@ real-estate cost.
   (`agy`) is wired for MCP/instructions/skills/spawn, but its sqlite/protobuf
   conversation history and hook schema are not parsed/wired yet.
 - Extraction heuristics are simple regexes; no ML quality classifier.
-- No hot-config reload: changing an env-knob still requires restarting the MCP
-  process. The macOS menu-bar Settings window can request that restart after
-  writing `.env`, but daemons do not yet re-read config in-process.
 - MCP-native `sampling/createMessage` (a native review fork without
   pay-per-use tokens) is not yet implemented in Claude Code
   (anthropics/claude-code#1785). spawn-subprocess is the fallback, slim-config


### PR DESCRIPTION
## What

Reconcile the hot-config-reload documentation so README, `docs/ARCHITECTURE.md`, and `docs/ROADMAP.md` describe one consistent status. Docs-only; no code or tests change.

## Why

The three surfaces disagreed, and the README pointed at a closed-completed issue as if it were the live tracker for unfinished work:

- **README** said *"Hot-config reload is [tracked](.../issues/2)."* — but **#2 was closed as COMPLETED**. A reader following the link landed on a closed issue, implying the feature was dropped or still pending.
- **docs/ARCHITECTURE.md → "What is NOT done"** still listed *"No hot-config reload: changing an env-knob still requires restarting the MCP process"* — directly contradicting the **same file's** `config_watcher` description (lines ~189-208) and ROADMAP's `✅ DONE (#2)`.

The implementation reality (verified in-repo): in-process reload **is shipped**. The `config_watcher` daemon polls the watched `settings.json`, mirrors changed `THREADKEEPER_*` knobs into the live process, and calls `config.reload_settings()` so daemons/tools pick them up with no Claude Code restart (`config_reload()` manual trigger, `config_watch_status()` diagnostics). So the consistent status is **DONE**.

## Changes

- **README**: replaced the closed-issue "tracked" link with a plain statement that hot-config reload is implemented (shipped in #2), pointing at the live `THREADKEEPER_CONFIG_WATCH_INTERVAL_S` knob and `config_watch_status()`.
- **docs/ARCHITECTURE.md**: removed the stale "No hot-config reload" bullet from "What is NOT done" (the `config_watcher` section already documents the shipped path).
- **docs/ROADMAP.md**: unchanged — already states the status once as `✅ DONE (#2)` (the file's DONE-in-place convention).
- **CHANGELOG.md**: noted the reconciliation under `[Unreleased] → Fixed`.

## Acceptance criteria

- [x] No doc links a closed-completed issue as the *live* tracker for unfinished work (`grep` for `issues/2` across README/docs/CHANGELOG → none).
- [x] README, ROADMAP, and ARCHITECTURE describe hot-config reload with one consistent status (DONE / shipped).
- [x] The status is stated once, in ROADMAP (`✅ DONE (#2)`).

## Verification

- `grep -rn "issues/2" README.md docs/ CHANGELOG.md` → no matches.
- "What is NOT done" no longer contains a reload bullet.
- Full suite green (docs-only): `env -u THREADKEEPER_NO_EMBEDDINGS python -m pytest -q` → ran to `[100%]`, exit 0, no failures.

Closes #77