### PR TITLE
feat(mcp): adopt Resources & Prompts primitives (#78)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,30 @@ version bumps follow semver per the policy in
 
 ### Added
 
+- **MCP Resources & Prompts primitives (#78).** thread-keeper exposed its whole
+  surface as MCP **tools** and zero of the other two server primitives. It now
+  adopts both for the views that fit them. **Resources** (`tools/resources.py`,
+  `@mcp.resource`) expose the read-only memory snapshots at stable URIs —
+  `memory://brief`, `memory://context`, `memory://dashboard`,
+  `memory://agent-status` — each backed by the same render function as the
+  matching tool (`render_brief` / `render_context` / `mp_dashboard` /
+  `agent_status`). A host can now pull the brief as attachable / `@`-mentionable
+  read-only context instead of relying on a hookless agent *remembering* to call
+  `brief()`. The brief resource renders `lean=True` (and agent-status uses
+  `refresh=False`) so an automatic host pull is side-effect-free — no
+  `*_hint_shown` events, no process re-scan. **Prompts** (`tools/prompts.py`,
+  `@mcp.prompt`) expose the curation / audit / review flows as host-native,
+  parameterized commands — `review_recent_threads`, `run_library_curation`,
+  `audit_threadkeeper` — which Claude Code surfaces as
+  `/mcp__thread-keeper__<name>` slash commands. Both are additive: the server
+  advertises the `resources` / `prompts` capabilities, and a host that uses
+  neither falls back to the unchanged tool-only surface (and the SessionStart
+  hook path) with identical content. No tool was added, removed, or altered;
+  `context()` now shares `brief.render_context()` with its resource. New
+  `tests/test_mcp_resources_prompts.py` covers list/read, prompt rendering,
+  capability advertisement, side-effect-freeness, and the tool-only fallback.
+  Composes with the tool-annotation work (#67) and the elicitation item (#26);
+  both are different MCP capabilities, neither covered there.
 - **MCP tool annotations + structured outputs (#67).** Every thread-keeper tool
   was a bare `@mcp.tool()` with no machine-readable read/write signal. Now each
   of the 113 tools registers through one of two wrappers in

--- a/README.md
+++ b/README.md
@@ -82,8 +82,11 @@ each CLI's per-user instructions file (`CLAUDE.md` / `AGENTS.md` /
 have no global instructions file, so that step is skipped for them).
 
 Restart your CLI of choice. Hook-capable clients inject a brief on the first
-message; hookless clients such as Codex and Antigravity CLI follow the managed
-instructions block and call `brief()` / `context()` manually before answering.
+message; hookless clients such as Codex and Antigravity CLI either follow the
+managed instructions block and call `brief()` / `context()` before answering, or
+— on hosts that support MCP **resources** — pull the brief as the read-only
+`memory://brief` resource the host attaches automatically (see
+[MCP primitives](#mcp-primitives-tools-resources-prompts)).
 
 ### Alternative installs
 
@@ -150,6 +153,35 @@ Cline, … — so a single registration there reaches all of them at once.
 
 Adding a new CLI = one file under `threadkeeper/adapters/` implementing
 the `CLIAdapter` contract. See [CONTRIBUTING.md](CONTRIBUTING.md).
+
+### MCP primitives (tools, resources, prompts)
+
+MCP has three server primitives. thread-keeper uses all three, mapped to the
+read/act split:
+
+| Primitive | Control | What thread-keeper exposes | When to use |
+|---|---|---|---|
+| **Tools** | model-controlled (may act) | the full surface — `brief`, `note`, `spawn`, `search`, `curator_review`, … | the agent decides to call them |
+| **Resources** | application-controlled, read-only | `memory://brief`, `memory://context`, `memory://dashboard`, `memory://agent-status` | the **host** attaches/pulls them automatically |
+| **Prompts** | user-controlled templates | `review_recent_threads`, `run_library_curation`, `audit_threadkeeper` | the user runs them (Claude Code: `/mcp__thread-keeper__<name>`) |
+
+**Resources** back the genuinely read-only memory views with the same render
+functions as the matching tools, so the content is identical — `memory://brief`
+is `brief()`, `memory://context` is `context()`, and so on. The win is for
+**hookless CLIs**: instead of depending on the agent *remembering* to call
+`brief()` (agents focused on their task often skip it), a resource lets the host
+surface memory as attachable / `@`-mentionable context through a mechanical
+channel. The brief resource renders lean and agent-status uses a cached snapshot,
+so an automatic host pull is **side-effect-free**.
+
+**Prompts** turn the curation / audit / review flows into discoverable,
+parameterized commands; each just drives the existing tools.
+
+Everything here is **additive and capability-gated**: a host that advertises the
+`resources` / `prompts` capabilities sees them; one that doesn't falls back to
+the SessionStart hook plus the `brief()` / `context()` tools — same content, no
+regression. Static URIs only for now (resource *templates* with `{param}` are
+still unevenly supported across hosts).
 
 ### Memory egress (cross-provider privacy)
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -13,7 +13,7 @@ read-write the same database simultaneously. One state file:
 
 ```
 threadkeeper/
-├── _mcp.py            FastMCP singleton (shared @mcp.tool registrar)
+├── _mcp.py            FastMCP singleton (shared @mcp.tool / .resource / .prompt registrar)
 ├── server.py          entry point: import all tools/ → mcp.run() (stdio)
 ├── config.py          pydantic-settings Settings ← ~/.threadkeeper/.env (DB_PATH, …)
 ├── db.py              SCHEMA + migrations + WAL-knobs + sqlite-vec loader
@@ -63,6 +63,8 @@ threadkeeper/
     ├── dialog.py      dialog_search/open_dialog_window/ingest
     ├── validate.py    validate_threads
     ├── style.py       style_set/verbatim_user
+    ├── resources.py   @mcp.resource — memory://brief|context|dashboard|agent-status (#78)
+    ├── prompts.py     @mcp.prompt — review_recent_threads/run_library_curation/audit_threadkeeper (#78)
     ├── invariants.py, missed_spawns.py, consolidate.py, session.py, …
 ```
 
@@ -817,6 +819,37 @@ which calls warrant a prompt (substrate for #26). The five status tools
 (typed models in `tool_schemas.py`, built via `structured_result()`), keeping
 the legacy human-readable text block for backward compatibility. The contract
 is enforced by `tests/test_tool_annotations.py`.
+
+### MCP resources & prompts (#78)
+
+Tools are only one of MCP's three server primitives. thread-keeper also adopts
+the other two for the read/act split they fit naturally:
+
+- **Resources** (`tools/resources.py`, `@mcp.resource`) — *application-controlled,
+  read-only* memory snapshots at stable URIs: `memory://brief`,
+  `memory://context`, `memory://dashboard`, `memory://agent-status`. Each is
+  backed by the same render function as the matching tool (`render_brief`,
+  `render_context`, `mp_dashboard`, `agent_status`), so a host can pull memory as
+  attachable / `@`-mentionable context without the agent *remembering* to call a
+  tool — the mechanical channel that hookless CLIs lacked. The brief resource
+  renders `lean=True` and agent-status uses `refresh=False`, so an automatic host
+  pull is **side-effect-free** (no `*_hint_shown` events, no process re-scan).
+  URIs are static: resource *templates* (`{param}`) are still unevenly supported
+  across hosts, so parameterized URIs are a later, host-gated step.
+- **Prompts** (`tools/prompts.py`, `@mcp.prompt`) — *user-controlled,
+  parameterized* templates for the curation / audit / review flows:
+  `review_recent_threads`, `run_library_curation`, `audit_threadkeeper`. Claude
+  Code surfaces them as `/mcp__thread-keeper__<name>` slash commands; each returns
+  one instruction message that drives the existing read/act tools (it does not act
+  on its own).
+
+Both are **additive**: FastMCP advertises the `resources` / `prompts`
+capabilities, which only changes what a capability-aware host *sees* — never the
+tool surface. A host that uses neither falls back to the hook-injected brief and
+the `brief()` / `context()` tools, with identical content. Resource/prompt functions register on
+their own managers, so they never enter the tool registry (pinned by
+`tests/test_mcp_resources_prompts.py`, which also covers list/read, prompt
+rendering, capability advertisement, and the tool-only fallback).
 
 ## Tests
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -507,6 +507,28 @@ verified at the cited file:line, deduplicated against the issues above):
   legacy human-readable text block alongside the typed JSON. Gives hosts a
   mechanical confirmation signal and composes with #22 and the elicitation work
   in #26.
+- ✅ DONE (#78). MCP **Resources & Prompts** primitives. thread-keeper exposed
+  its whole surface as MCP **tools** and zero of the other two server primitives;
+  it now adopts both where they fit the read/act split. **Resources**
+  (`tools/resources.py`, `@mcp.resource`) expose the read-only memory snapshots at
+  stable URIs — `memory://brief`, `memory://context`, `memory://dashboard`,
+  `memory://agent-status` — each backed by the same render function as the
+  matching tool (`render_brief` / `render_context` / `mp_dashboard` /
+  `agent_status`), so a host can pull memory as attachable / `@`-mentionable
+  context instead of a hookless agent *remembering* to call `brief()`. The brief
+  resource renders `lean=True` and agent-status uses `refresh=False`, so an
+  automatic host pull is side-effect-free (no `*_hint_shown` events, no process
+  re-scan). **Prompts** (`tools/prompts.py`, `@mcp.prompt`) expose the curation /
+  audit / review flows as host-native parameterized commands —
+  `review_recent_threads`, `run_library_curation`, `audit_threadkeeper` (Claude
+  Code renders them as `/mcp__thread-keeper__<name>`). Additive: the server
+  advertises the `resources` / `prompts` capabilities, and a host using neither
+  falls back to the unchanged tool-only surface + SessionStart hook with identical
+  content. Static URIs only (resource *templates* are still unevenly supported
+  across hosts — a later, host-gated step). `tests/test_mcp_resources_prompts.py`
+  pins list/read, prompt rendering, capability advertisement, side-effect-freeness,
+  and the tool-only fallback. Different MCP capabilities from #67 (annotations) and
+  #26 (elicitation); neither covered them.
 - **Learning-loop memory poisoning** — the synthesis children (`shadow_review`,
   `candidate_reviewer`, close-thread auto-review, `dialectic_validator`) turn the
   **raw observed-dialog stream** into **auto-loaded** `SKILL.md` / `lessons.md` /

--- a/tests/test_mcp_resources_prompts.py
+++ b/tests/test_mcp_resources_prompts.py
@@ -1,0 +1,194 @@
+"""MCP Resources & Prompts primitives (roadmap #78).
+
+thread-keeper historically exposed only MCP **tools**. This pins the two
+newly-adopted primitives:
+
+  * **Resources** — read-only memory snapshots (``memory://brief`` /
+    ``memory://context`` / ``memory://dashboard`` / ``memory://agent-status``)
+    reachable at stable URIs, returning the same content the matching tool
+    renders.
+  * **Prompts** — curation / audit / review flows as host-native, parameterized
+    commands.
+
+Plus the additive contract: the server advertises both capabilities, the
+resource/prompt functions never leak into the tool registry, and the tool-only
+fallback path (a host that ignores resources still gets ``brief()``) is intact.
+
+Uses the ``fresh_mp`` bootstrap (clean DB + isolated CLI homes) from conftest.
+The list/read/get MCP APIs are async; we drive them with ``asyncio.run`` since
+each call is self-contained (no shared event loop needed).
+"""
+from __future__ import annotations
+
+import asyncio
+
+from mcp.server.lowlevel.server import NotificationOptions
+
+
+RESOURCE_URIS = {
+    "memory://brief",
+    "memory://context",
+    "memory://dashboard",
+    "memory://agent-status",
+}
+PROMPT_NAMES = {
+    "review_recent_threads",
+    "run_library_curation",
+    "audit_threadkeeper",
+}
+
+
+def _tool(pkg, name):
+    return pkg["mcp"]._tool_manager._tools[name].fn
+
+
+def _resource_uris(pkg):
+    return {str(r.uri) for r in asyncio.run(pkg["mcp"].list_resources())}
+
+
+def _read_resource(pkg, uri):
+    contents = asyncio.run(pkg["mcp"].read_resource(uri))
+    return "".join(c.content for c in contents)
+
+
+def _prompt_names(pkg):
+    return {p.name for p in asyncio.run(pkg["mcp"].list_prompts())}
+
+
+def _render_prompt(pkg, name, args=None):
+    res = asyncio.run(pkg["mcp"].get_prompt(name, args or {}))
+    return "\n".join(m.content.text for m in res.messages)
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Resources: listing + read content
+# ──────────────────────────────────────────────────────────────────────
+
+def test_resources_are_listed_with_stable_uris(fresh_mp):
+    assert RESOURCE_URIS <= _resource_uris(fresh_mp)
+
+
+def test_brief_resource_returns_brief_content(fresh_mp):
+    """memory://brief is backed by render_brief and reflects live thread state."""
+    pkg = fresh_mp
+    tid = _tool(pkg, "open_thread")(question="resource-backed brief thread")
+
+    body = _read_resource(pkg, "memory://brief")
+    assert body.startswith("ctx sess=")
+    # The brief renders the live working set, so the just-opened thread shows up.
+    assert tid in body
+    assert "resource-backed brief thread" in body
+
+
+def test_brief_resource_is_side_effect_free(fresh_mp):
+    """A host pulling the brief resource must not write *_hint_shown events
+    (lean render): repeated pulls leave the events table untouched."""
+    pkg = fresh_mp
+    conn = pkg["db"].get_db()
+
+    def hint_events():
+        return conn.execute(
+            "SELECT COUNT(*) c FROM events WHERE kind LIKE '%_hint_shown'"
+        ).fetchone()["c"]
+
+    before = hint_events()
+    _read_resource(pkg, "memory://brief")
+    _read_resource(pkg, "memory://brief")
+    assert hint_events() == before
+
+
+def test_context_resource_matches_context_tool_text(fresh_mp):
+    """memory://context returns the same text block the context() tool renders."""
+    pkg = fresh_mp
+    _tool(pkg, "open_thread")(question="ctx thread")
+
+    body = _read_resource(pkg, "memory://context")
+    assert "sess=" in body
+    assert "db=" in body
+    # one active thread seeded → reflected in the thread-counts segment
+    assert "active=1" in body
+
+    # The tool's structuredContent path and the resource share render_context;
+    # the tool's legacy text block matches the resource body modulo the live
+    # clock, so compare the stable structural prefix.
+    tool_result = _tool(pkg, "context")()
+    tool_text = next(
+        c.text for c in tool_result.content if getattr(c, "type", None) == "text"
+    )
+    assert tool_text.split(" started=")[0] == body.split(" started=")[0]
+
+
+def test_dashboard_and_agent_status_resources_read(fresh_mp):
+    pkg = fresh_mp
+    dash = _read_resource(pkg, "memory://dashboard")
+    assert dash.startswith("dashboard window=")
+    agent = _read_resource(pkg, "memory://agent-status")
+    assert "loops" in agent
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Prompts: listing + render
+# ──────────────────────────────────────────────────────────────────────
+
+def test_prompts_are_listed(fresh_mp):
+    assert PROMPT_NAMES <= _prompt_names(fresh_mp)
+
+
+def test_review_recent_threads_prompt_renders_with_param(fresh_mp):
+    text = _render_prompt(fresh_mp, "review_recent_threads", {"limit": "7"})
+    assert "7 most recent" in text
+    assert "brief()" in text
+
+
+def test_run_library_curation_prompt_reflects_force(fresh_mp):
+    plain = _render_prompt(fresh_mp, "run_library_curation", {})
+    assert "curator_review(force=false)" in plain
+    forced = _render_prompt(fresh_mp, "run_library_curation", {"force": "true"})
+    assert "curator_review(force=true)" in forced
+
+
+def test_audit_threadkeeper_prompt_renders(fresh_mp):
+    text = _render_prompt(fresh_mp, "audit_threadkeeper")
+    assert "mp_dashboard()" in text
+    assert "validate_threads()" in text
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Capability negotiation + additive / fallback contract
+# ──────────────────────────────────────────────────────────────────────
+
+def test_server_advertises_resources_and_prompts_capabilities(fresh_mp):
+    caps = fresh_mp["mcp"]._mcp_server.get_capabilities(NotificationOptions(), {})
+    assert caps.resources is not None
+    assert caps.prompts is not None
+    assert caps.tools is not None  # tools unaffected
+
+
+def test_resource_and_prompt_functions_are_not_tools(fresh_mp):
+    """Resources/prompts register on their own managers — they must never
+    appear in the tool registry, so the #67 annotation contract is unchanged."""
+    tool_names = set(fresh_mp["mcp"]._tool_manager._tools.keys())
+    assert "brief" in tool_names and "context" in tool_names  # the tools stay
+    for leaked in (
+        "brief_resource", "context_resource", "dashboard_resource",
+        "agent_status_resource", "review_recent_threads",
+        "run_library_curation", "audit_threadkeeper",
+    ):
+        assert leaked not in tool_names, f"{leaked} leaked into tool registry"
+
+
+def test_tool_only_fallback_path_still_works(fresh_mp):
+    """A host that advertises no `resources` capability falls back to the
+    brief() tool: it must still render the brief independently of the resource
+    layer, and surface the same live thread the resource does."""
+    pkg = fresh_mp
+    tid = _tool(pkg, "open_thread")(question="fallback thread")
+
+    tool_brief = _tool(pkg, "brief")()
+    assert tool_brief.startswith("ctx sess=")
+    assert tid in tool_brief
+
+    resource_brief = _read_resource(pkg, "memory://brief")
+    # Both channels surface the same working-set thread — the resource is an
+    # additional delivery path, not a replacement for the tool.
+    assert tid in resource_brief

--- a/threadkeeper/brief.py
+++ b/threadkeeper/brief.py
@@ -17,7 +17,7 @@ import time
 from datetime import datetime, timezone
 from typing import Optional
 
-from .config import SEMANTIC_AVAILABLE, DIALOG_LOG, TASK_LOG_DIR, BRIEF_LEAN
+from .config import SEMANTIC_AVAILABLE, DIALOG_LOG, TASK_LOG_DIR, BRIEF_LEAN, DB_PATH
 from .helpers import fmt_age, q
 from . import identity
 from .identity import _detect_self_cid, _ensure_cursor
@@ -881,6 +881,42 @@ def render_brief(conn: sqlite3.Connection, query: str = "", k: int = 6,
         )
 
     return "\n".join(out)
+
+
+def render_context(conn: sqlite3.Connection) -> tuple[str, dict]:
+    """Build the runtime-context snapshot shared by the ``context()`` tool and
+    the ``memory://context`` MCP resource.
+
+    Returns ``(text, fields)`` where ``text`` is the legacy human-readable block
+    and ``fields`` keys match the ``ContextStatus`` model constructor. Read-only:
+    a single ``GROUP BY`` over ``threads``, no writes — safe for a host to pull
+    automatically as a resource.
+    """
+    now = int(time.time())
+    counts = conn.execute(
+        "SELECT state, COUNT(*) c FROM threads GROUP BY state"
+    ).fetchall()
+    thread_counts = {r["state"]: r["c"] for r in counts}
+    cs = " ".join(f"{k}={v}" for k, v in thread_counts.items()) or "empty"
+    started = identity._session_start or now
+    now_iso = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%MZ")
+    text = (
+        f"sess={identity._session_id} "
+        f"started={fmt_age(now - started)}_ago "
+        f"sem={'on' if SEMANTIC_AVAILABLE else 'off'} "
+        f"db={DB_PATH} "
+        f"threads[{cs}] "
+        f"now={now_iso}"
+    )
+    fields = {
+        "session_id": identity._session_id,
+        "started_age_s": now - started,
+        "semantic": bool(SEMANTIC_AVAILABLE),
+        "db_path": str(DB_PATH),
+        "thread_counts": thread_counts,
+        "now": now_iso,
+    }
+    return text, fields
 
 
 def _append_dialog_log(from_cid: Optional[str], to_cid: Optional[str],

--- a/threadkeeper/server.py
+++ b/threadkeeper/server.py
@@ -59,6 +59,14 @@ from .tools import dashboard  # noqa: F401
 from .tools import agent_status  # noqa: F401
 from .tools import config_watch  # noqa: F401
 
+# MCP Resources & Prompts (roadmap #78) — the other two MCP server primitives.
+# Importing these registers @mcp.resource / @mcp.prompt entries (NOT tools) on
+# the shared instance: read-only memory snapshots as resources, curation/audit
+# flows as prompts. Additive — every existing tool stays unchanged, and hosts
+# without the resources/prompts capability fall back to the tool-only surface.
+from .tools import resources  # noqa: F401
+from .tools import prompts  # noqa: F401
+
 
 if __name__ == "__main__":
     from .menubar_app import ensure_menubar_app

--- a/threadkeeper/tools/prompts.py
+++ b/threadkeeper/tools/prompts.py
@@ -1,0 +1,80 @@
+"""User-controlled MCP **Prompts** for thread-keeper (roadmap #78).
+
+The third MCP server primitive (after tools and resources): **Prompts** are
+user-controlled, parameterized templates a host surfaces as native entry points.
+Claude Code renders server prompts as ``/mcp__thread-keeper__<name>`` slash
+commands; other hosts list them in a prompt picker.
+
+These map the existing curation / audit / review flows onto discoverable,
+parameterized commands. Each returns a single instruction message that drives the
+matching read/act tools — it does NOT act on its own (a prompt is a template the
+user invokes, not an automatic action). Hosts that don't advertise the
+``prompts`` capability simply don't see them; every underlying tool stays usable.
+
+  * ``review_recent_threads`` — summarize + triage recent threads
+  * ``run_library_curation``  — fire a Curator audit of lessons + skills
+  * ``audit_threadkeeper``    — whole-system health + hygiene audit
+"""
+from __future__ import annotations
+
+from .._mcp import mcp
+
+
+@mcp.prompt(
+    name="review_recent_threads",
+    title="Review my recent threads",
+    description="Summarize and triage the most recent thread-keeper threads "
+    "(open / idle / recently closed) and propose next moves.",
+)
+def review_recent_threads(limit: int = 10) -> str:
+    """Triage the `limit` most recent threads via brief() + validate_threads()."""
+    return (
+        f"Review my {limit} most recent thread-keeper threads. "
+        "Start by calling brief() for the live working set, then for each open "
+        "or idle thread give a one-line status and a concrete next move; flag "
+        "any that look stale or abandoned. Use validate_threads() to spot "
+        "structural issues (orphans, missing outcomes) and review_thread(<id>) "
+        "to pull detail on anything that needs it. Finish with the single "
+        "highest-leverage thread to act on next."
+    )
+
+
+@mcp.prompt(
+    name="run_library_curation",
+    title="Run library curation",
+    description="Fire one Curator audit pass over the lessons + skills library "
+    "(KEEP / PATCH / CONSOLIDATE / PRUNE recommendations).",
+)
+def run_library_curation(force: bool = False) -> str:
+    """Drive curator_review() and apply the resulting recommendations."""
+    force_note = (
+        " Pass force=True — the curator daemon interval may be disabled."
+        if force else ""
+    )
+    return (
+        "Run a curation pass over the thread-keeper lessons + skills library. "
+        f"Call curator_review(force={str(force).lower()}) to spawn the audit "
+        "child, which writes a REPORT.md with KEEP / PATCH / CONSOLIDATE / "
+        "PRUNE recommendations." + force_note + " When it returns, summarize the "
+        "recommendations and, for any PATCH / CONSOLIDATE / PRUNE you agree with, "
+        "apply it via skill_manage / lesson_remove / consolidate. Use "
+        "curator_review_status() first if you need to check the last pass."
+    )
+
+
+@mcp.prompt(
+    name="audit_threadkeeper",
+    title="Audit thread-keeper",
+    description="Whole-system health + hygiene audit: telemetry rollup, thread "
+    "integrity, and pending evolve suggestions.",
+)
+def audit_threadkeeper() -> str:
+    """Run an end-to-end health audit via mp_dashboard/validate_threads/evolve."""
+    return (
+        "Audit the thread-keeper system end to end. Call mp_dashboard() for the "
+        "store sizes + loop-activity rollup (look for loops that fire but "
+        "produce nothing, or a climbing backlog), validate_threads() for "
+        "structural integrity, and evolve_review() for pending self-improvement "
+        "suggestions. Summarize overall health, call out the top 3 issues, and "
+        "recommend a concrete fix for each."
+    )

--- a/threadkeeper/tools/resources.py
+++ b/threadkeeper/tools/resources.py
@@ -1,0 +1,100 @@
+"""Read-only MCP **Resources** for thread-keeper (roadmap #78).
+
+MCP defines three core server primitives. thread-keeper historically exposed
+only **tools** (model-controlled, may act). This module adds the second
+primitive — **Resources** (application-controlled, read-only, safe for a host to
+pull automatically) — for the genuinely read-only memory snapshots:
+
+  * ``memory://brief``        — the session-start memory brief (``render_brief``)
+  * ``memory://context``      — runtime context (session id, age, thread counts)
+  * ``memory://dashboard``    — whole-system telemetry rollup (``mp_dashboard``)
+  * ``memory://agent-status`` — autonomous-loop status snapshot
+
+Why resources and not just the existing tools: on hookless CLIs (Codex /
+Antigravity / Gemini-legacy / Copilot) the managed instructions block asks the
+agent to *remember* to call ``brief()`` before answering, and the project's own
+docs note agents focused on their task often skip such calls. A Resource lets
+the host surface the brief as attachable / ``@``-mentionable read-only context
+through a mechanical channel, independent of whether the agent calls a tool. The
+hook-injected brief and the ``brief()`` tool remain the fallback for hosts that
+don't advertise the ``resources`` capability — nothing here changes the tool
+surface (no tool is added, removed, or altered).
+
+These resources are deliberately **side-effect-free**. ``memory://brief`` renders
+with ``lean=True`` so the behavioral nudge/hint blocks (which ``INSERT``
+``*_hint_shown`` events) never fire on an automatic host pull — a resource a host
+refreshes on a timer must not mutate the escalation counters. The static memory
+(core_memory, style, verbatim, user_model) is still rendered. ``memory://
+agent-status`` uses ``refresh=False`` so a pull never triggers a process re-scan.
+
+URIs are static on purpose: the spec's resource *templates* (``{param}``) are
+still unevenly implemented across hosts, so parameterized URIs are left as a
+later, host-gated step (see roadmap #78).
+"""
+from __future__ import annotations
+
+from .._mcp import mcp
+from ..db import get_db
+from ..identity import _ensure_session
+from ..brief import render_brief, render_context
+from .dashboard import mp_dashboard
+from ..agent_status import agent_status_snapshot, format_agent_status
+
+
+@mcp.resource(
+    "memory://brief",
+    name="brief",
+    title="thread-keeper memory brief",
+    description="Session-start memory brief: core memory, open/idle/closed "
+    "threads, live peers, style, verbatim, user-model. Read-only, rendered "
+    "lean (no behavioral nudges, no side effects). Mirrors the brief() tool.",
+    mime_type="text/plain",
+)
+def brief_resource() -> str:
+    conn = get_db()
+    _ensure_session(conn)
+    # lean=True keeps the pull side-effect-free: the spawn/thread/skill hint
+    # blocks (which write *_hint_shown events) are all gated on `not eff_lean`.
+    return render_brief(conn, scope="full", lean=True)
+
+
+@mcp.resource(
+    "memory://context",
+    name="context",
+    title="thread-keeper runtime context",
+    description="Runtime context: session id, age, semantic on/off, db path, "
+    "thread counts. Read-only. Mirrors the context() tool's text block.",
+    mime_type="text/plain",
+)
+def context_resource() -> str:
+    conn = get_db()
+    _ensure_session(conn)
+    text, _ = render_context(conn)
+    return text
+
+
+@mcp.resource(
+    "memory://dashboard",
+    name="dashboard",
+    title="thread-keeper system dashboard",
+    description="One-call rollup: store sizes, autonomous-loop fire counts, and "
+    "what those loops produced. Read-only. Mirrors the mp_dashboard() tool.",
+    mime_type="text/plain",
+)
+def dashboard_resource() -> str:
+    # mp_dashboard() is the read_tool() function; FastMCP leaves it directly
+    # callable. It opens its own db handle and is defensive on partial schemas.
+    return mp_dashboard()
+
+
+@mcp.resource(
+    "memory://agent-status",
+    name="agent-status",
+    title="thread-keeper autonomous-loop status",
+    description="Autonomous learning loops: state, backlog, last pass, RSS. "
+    "Read-only cached snapshot (refresh=False, no process re-scan). Mirrors "
+    "the agent_status() tool's formatted summary.",
+    mime_type="text/plain",
+)
+def agent_status_resource() -> str:
+    return format_agent_status(agent_status_snapshot(refresh=False))

--- a/threadkeeper/tools/threads.py
+++ b/threadkeeper/tools/threads.py
@@ -8,18 +8,17 @@ suggestion box.
 
 import sqlite3
 import time
-from datetime import datetime, timezone
 from typing import Optional
 
 from .._mcp import read_tool, write_tool, structured_result
-from ..config import SEMANTIC_AVAILABLE, DB_PATH
+from ..config import SEMANTIC_AVAILABLE
 from ..tool_schemas import ContextStatus
 from ..db import get_db
 from ..helpers import gen_thread_id, fmt_age, q, _fts_query
 from .. import identity
 from ..identity import _ensure_session, _detect_self_cid, _emit
 from ..embeddings import _embed, _cosine_search, _vec_upsert_note, embed_tag
-from ..brief import render_brief
+from ..brief import render_brief, render_context
 
 
 @read_tool()
@@ -47,33 +46,13 @@ def brief(query: str = "", k: int = 6, scope: str = "full") -> str:
 def context() -> ContextStatus:
     """Runtime context: session id, age, semantic on/off, db path, thread counts.
 
-    Returns structuredContent (ContextStatus) plus the legacy text block."""
+    Returns structuredContent (ContextStatus) plus the legacy text block.
+    The same snapshot is reachable read-only as the ``memory://context``
+    resource — both render through ``brief.render_context``."""
     conn = get_db()
     _ensure_session(conn)
-    now = int(time.time())
-    counts = conn.execute(
-        "SELECT state, COUNT(*) c FROM threads GROUP BY state"
-    ).fetchall()
-    thread_counts = {r["state"]: r["c"] for r in counts}
-    cs = " ".join(f"{k}={v}" for k, v in thread_counts.items()) or "empty"
-    started = identity._session_start or now
-    now_iso = datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%MZ')
-    text = (
-        f"sess={identity._session_id} "
-        f"started={fmt_age(now - started)}_ago "
-        f"sem={'on' if SEMANTIC_AVAILABLE else 'off'} "
-        f"db={DB_PATH} "
-        f"threads[{cs}] "
-        f"now={now_iso}"
-    )
-    return structured_result(text, ContextStatus(
-        session_id=identity._session_id,
-        started_age_s=now - started,
-        semantic=bool(SEMANTIC_AVAILABLE),
-        db_path=str(DB_PATH),
-        thread_counts=thread_counts,
-        now=now_iso,
-    ))
+    text, fields = render_context(conn)
+    return structured_result(text, ContextStatus(**fields))
 
 
 @write_tool()


### PR DESCRIPTION
## What

Adopts the two unused MCP server primitives — **Resources** and **Prompts** — alongside the existing 113 tools, where they fit thread-keeper's read/act split. Closes #78.

Before: 113 `@mcp.tool()` registrations, **0 resources, 0 prompts**.

## Resources (`threadkeeper/tools/resources.py`, `@mcp.resource`)

Read-only memory snapshots at stable URIs, each backed by the **same render function** as the matching tool (so content is identical):

| URI | Backed by | Tool mirror |
|---|---|---|
| `memory://brief` | `render_brief(scope=full, lean=True)` | `brief()` |
| `memory://context` | `render_context()` (new shared helper) | `context()` |
| `memory://dashboard` | `mp_dashboard()` | `mp_dashboard()` |
| `memory://agent-status` | `agent_status_snapshot(refresh=False)` | `agent_status()` |

The win is **hookless CLIs** (Codex / Antigravity / Gemini-legacy / Copilot): instead of depending on the agent *remembering* to call `brief()`, a host can pull the brief as attachable / `@`-mentionable read-only context through a mechanical channel.

**Side-effect-free by design:** the brief resource renders `lean=True` so the behavioral nudge/hint blocks (which `INSERT` `*_hint_shown` events) never fire on an automatic host pull, and agent-status uses `refresh=False` so a pull never triggers a process re-scan.

## Prompts (`threadkeeper/tools/prompts.py`, `@mcp.prompt`)

Curation / audit / review flows as host-native, parameterized commands (Claude Code renders them as `/mcp__thread-keeper__<name>`). Each returns one instruction message that drives the existing tools — it does not act on its own.

- `review_recent_threads(limit=10)` → `brief()` + `validate_threads()` triage
- `run_library_curation(force=False)` → `curator_review()`
- `audit_threadkeeper()` → `mp_dashboard()` + `validate_threads()` + `evolve_review()`

## Additive + graceful fallback

- The server advertises the `resources` / `prompts` capabilities (FastMCP, auto).
- A host that uses neither falls back to the SessionStart hook + the `brief()` / `context()` tools — **identical content, no regression**.
- **No tool added, removed, or altered.** Resource/prompt functions register on their own managers and never enter the tool registry (pinned by a test), so the #67 annotation contract is untouched. `context()` now shares `brief.render_context()` with its resource.
- Static URIs only — resource *templates* (`{param}`) are still unevenly supported across hosts, so parameterized URIs are left as a later, host-gated step.

## Tests — `tests/test_mcp_resources_prompts.py`

Resource list/read returns brief/context content (and reflects live thread state); brief resource is side-effect-free across repeated pulls; context resource matches the tool's text block; prompts list + render with parameters; capabilities advertised; resource/prompt fns are **not** tools; tool-only fallback path still surfaces the brief.

## Verification

Full suite green from the worktree: **940 tests, 0 failures/errors, `PYTEST_EXIT=0`** (`env -u THREADKEEPER_NO_EMBEDDINGS .venv/bin/python -m pytest -q`). Existing `test_tool_annotations.py` (tool registry contract) and `test_brief_*` unaffected.

## Docs

README MCP-primitives table + hookless-CLI benefit (and Quickstart hookless line now mentions pulling the brief as a resource), `docs/ARCHITECTURE.md` (package map + "MCP resources & prompts (#78)" section), `docs/ROADMAP.md` (DONE entry next to #67), `CHANGELOG.md`.

Distinct from #67 (tool annotations) and #26 (elicitation) — different MCP capabilities, neither covered there.

Closes #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)