### PR TITLE
fix(search): sync notes_vec on note delete + guard EMBED_DIM drift (#85)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,31 @@ version bumps follow semver per the policy in
 
 ### Fixed
 
+- **vec0 index integrity: delete-sync + EMBED_DIM dimension guard (#85).** Two
+  consistency gaps in the sqlite-vec (`notes_vec`) mirror are closed. **(1)
+  Orphaned vec rows on note delete.** `notes_fts` is trigger-synced but
+  `notes_vec` was not, so `consolidate()` deleting a merged note
+  (`DELETE FROM notes WHERE id=?`) left a permanent orphan — `notes.id` is
+  `AUTOINCREMENT`, never reused — that consumed a KNN slot and was then dropped
+  by the inner join in `_vec0_notes_search`, so a query could return *fewer than
+  `k`* live hits while dead entries piled up. `embeddings._vec_delete_note` now
+  removes the mirror row in the consolidate apply loop, and `_vec0_notes_search`
+  over-fetches (`2k+8`, trimmed to `k`) so any legacy orphan backlog drains
+  gracefully instead of shrinking results. **(2) Silent vec0-disable on
+  dimension drift.** `EMBED_DIM` was a hardcoded `384` while
+  `THREADKEEPER_EMBED_MODEL` is user-configurable; a non-384-dim model made
+  every `INSERT INTO notes_vec` raise `OperationalError` that `_vec_upsert_*`
+  silently swallowed — vec0 stayed empty while `_vec_on()` still claimed the
+  fast path, and `tk-migrate-embeddings` (same-dim only) never noticed.
+  `EMBED_DIM` is now config-driven (`THREADKEEPER_EMBED_DIM`, default 384) so a
+  different-width model can create the `*_vec` tables correctly, and
+  `embeddings._vec_dim_ok` validates vector width before insert, logging ONE
+  actionable warning (naming the model, both dimensions, and the env knob)
+  instead of swallowing the error. Tests cover delete→search consistency, the
+  over-fetch-past-orphans path, the consolidate apply path, and the
+  dimension-mismatch warning. Distinct from the closed integrity issue #56
+  (tampered-artifact verification) — this is dimension-compatibility.
+
 - **Extract H4 paraphrase-cluster path no longer re-harvests rejected
   candidates (#62).** The semantic-cluster heuristic had its own inline dedup
   (`status IN ('pending','accepted')`) that omitted `'rejected'`, so a rejected

--- a/README.md
+++ b/README.md
@@ -823,6 +823,15 @@ The migration is batched, resumable, and idempotent (a second run finds
 nothing stale). Both backends emit 384-dim vectors, so the `vec0` schema is
 unchanged.
 
+**Swapping in a different-width model.** The `notes_vec` / `dialog_vec` tables
+are created as `FLOAT[EMBED_DIM]`, default 384. If you point
+`THREADKEEPER_EMBED_MODEL` at a model of a different dimension, also set
+`THREADKEEPER_EMBED_DIM` to its width and recreate the `*_vec` tables —
+otherwise every vec0 insert mismatches the schema and the fast KNN path goes
+dead (semantic search still works via the legacy BLOB cosine path). thread-keeper
+logs a one-line warning naming both dimensions and this knob when it detects the
+mismatch, rather than failing silently.
+
 ---
 
 ## Verifying ingest across CLIs

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -726,6 +726,21 @@ The daemon-leak in tests (where `tests/` spawned orphan threads via fixture's
 Optional — not needed for basic functionality. Embeddings themselves are stored
 as BLOB in `notes.embedding` regardless of vec0 availability.
 
+**vec0 lifecycle (sync + dimension).** The `notes_vec` mirror is kept in sync
+with `notes` *explicitly*, not by trigger: inserts dual-write via
+`_vec_upsert_note`, and deletes (only `consolidate()` merges notes today) call
+`_vec_delete_note` so a removed note can't strand an orphan KNN row — `notes.id`
+is `AUTOINCREMENT` so a stale id is never reclaimed by reuse. As belt-and-braces
+for any pre-existing orphan backlog, `_vec0_notes_search` over-fetches from vec0
+and trims after the join so a query still yields `k` live hits. The vector width
+the `*_vec` tables are created with is `EMBED_DIM` (config-driven —
+`THREADKEEPER_EMBED_DIM`, default 384). Because `THREADKEEPER_EMBED_MODEL` is
+user-configurable, a model that emits a different width would otherwise make
+every vec0 insert raise and silently leave the mirror empty while `_vec_on()`
+still reports the fast path live; `_vec_dim_ok` validates the blob width before
+insert and logs one actionable warning (set `THREADKEEPER_EMBED_DIM` to the new
+width and recreate the `*_vec` tables) instead of swallowing the error.
+
 ### Embedding backend
 
 `embeddings.py` is backend-pluggable via `THREADKEEPER_EMBED_BACKEND`. The

--- a/tests/test_vec_search.py
+++ b/tests/test_vec_search.py
@@ -183,6 +183,148 @@ def test_backfill_vec_tables_picks_up_legacy_blobs(vec_pkg):
 # Fallback path (vec0 unavailable)
 # ─────────────────────────────────────────────────────────────────────
 
+# ─────────────────────────────────────────────────────────────────────
+# Delete-sync: notes_vec must not orphan when a note is deleted (#85)
+# ─────────────────────────────────────────────────────────────────────
+
+def _unit_blob(axis: int, dim: int) -> bytes:
+    import struct
+    arr = [0.0] * dim
+    arr[axis] = 1.0
+    return struct.pack(f"{dim}f", *arr)
+
+
+def _seed_note_with_vec(conn, emb, tid: int, axis: int):
+    """Insert a note row + its notes_vec mirror with a hand-crafted unit
+    vector, returning the new note id. Deterministic — no model needed."""
+    import time as _t
+    cur = conn.execute(
+        "INSERT INTO notes (thread_id, content, kind, created_at, embedding) "
+        "VALUES (?,?,?,?,?)",
+        (tid, f"axis {axis}", "insight", int(_t.time()), emb),
+    )
+    nid = cur.lastrowid
+    from threadkeeper.embeddings import _vec_upsert_note
+    _vec_upsert_note(conn, nid, emb)
+    return nid
+
+
+def test_note_delete_syncs_vec_and_search_returns_k(vec_pkg):
+    """Deleting a note + _vec_delete_note leaves no orphan vec row, and KNN
+    still returns the requested count of live hits."""
+    from threadkeeper import embeddings as emb
+    from threadkeeper.db import EMBED_DIM
+    conn = vec_pkg["db"].get_db()
+    tid = _tool(vec_pkg, "open_thread")(question="delete sync")
+
+    ids = [
+        _seed_note_with_vec(conn, _unit_blob(axis, EMBED_DIM), tid, axis)
+        for axis in range(6)
+    ]
+    conn.commit()
+
+    # Delete two notes WITH the sync helper.
+    for nid in ids[:2]:
+        conn.execute("DELETE FROM notes WHERE id=?", (nid,))
+        emb._vec_delete_note(conn, nid)
+    conn.commit()
+
+    live = {r["id"] for r in conn.execute("SELECT id FROM notes").fetchall()}
+    vec_ids = {r["id"] for r in conn.execute("SELECT id FROM notes_vec").fetchall()}
+    # No orphan: every notes_vec id maps to a live note.
+    assert vec_ids <= live
+    assert ids[0] not in vec_ids and ids[1] not in vec_ids
+
+    # KNN for axis-2 returns k live hits, axis-2 itself first.
+    hits = emb._vec0_notes_search(conn, _unit_blob(2, EMBED_DIM), k=4)
+    assert len(hits) == 4
+    assert all(h["id"] in live for h in hits)
+    assert hits[0]["content"] == "axis 2"
+
+
+def test_vec0_search_overfetches_past_legacy_orphans(vec_pkg):
+    """Pre-existing orphan vec rows (no matching notes row) must not shrink a
+    KNN result below k — the over-fetch in _vec0_notes_search compensates."""
+    from threadkeeper import embeddings as emb
+    from threadkeeper.db import EMBED_DIM
+    conn = vec_pkg["db"].get_db()
+    tid = _tool(vec_pkg, "open_thread")(question="orphan overfetch")
+
+    live_ids = [
+        _seed_note_with_vec(conn, _unit_blob(axis, EMBED_DIM), tid, axis)
+        for axis in range(3)
+    ]
+    # Legacy orphans: vec rows whose note id has no notes row, in the SAME
+    # directions as the query so they'd otherwise win the top KNN slots.
+    for off, axis in enumerate((0, 1)):
+        conn.execute(
+            "INSERT OR REPLACE INTO notes_vec(id, embedding) VALUES (?, ?)",
+            (10_000 + off, _unit_blob(axis, EMBED_DIM)),
+        )
+    conn.commit()
+
+    # k=3: a naive fetch(=k) would surface 2 orphans + 1 live, then the join
+    # drops the orphans down to 1. Over-fetch must still return 3 live hits.
+    hits = emb._vec0_notes_search(conn, _unit_blob(0, EMBED_DIM), k=3)
+    assert len(hits) == 3
+    assert all(h["id"] in set(live_ids) for h in hits)
+
+
+def test_consolidate_apply_leaves_no_orphan_vec_rows(vec_pkg):
+    """Acceptance: after consolidate() merges (deletes) a duplicate note,
+    notes_vec holds no row whose id is absent from notes."""
+    if not vec_pkg["config"].SEMANTIC_AVAILABLE:
+        pytest.skip("needs an embedding backend to mirror + cosine-merge notes")
+    tid = _tool(vec_pkg, "open_thread")(question="dup merge vec sync")
+    note = _tool(vec_pkg, "note")
+    note(thread_id=tid, content="exactly the same sentence for dedup", kind="insight")
+    note(thread_id=tid, content="exactly the same sentence for dedup", kind="insight")
+    conn = vec_pkg["db"].get_db()
+    assert len({r["id"] for r in conn.execute(
+        "SELECT id FROM notes_vec").fetchall()}) >= 2
+
+    _tool(vec_pkg, "consolidate")(dry_run=False, note_cosine=0.95)
+
+    notes_ids = {r["id"] for r in conn.execute("SELECT id FROM notes").fetchall()}
+    vec_ids = {r["id"] for r in conn.execute("SELECT id FROM notes_vec").fetchall()}
+    assert vec_ids <= notes_ids           # no orphan mirror rows
+    assert len(vec_ids) == len(notes_ids)  # the dropped dup's vec row is gone
+
+
+# ─────────────────────────────────────────────────────────────────────
+# EMBED_DIM drift: a wrong-width vector warns instead of silently dying (#85)
+# ─────────────────────────────────────────────────────────────────────
+
+def test_vec_upsert_warns_and_skips_on_dim_mismatch(vec_pkg, caplog):
+    import logging
+    import struct
+    from threadkeeper import embeddings as emb
+    from threadkeeper.db import EMBED_DIM
+    conn = vec_pkg["db"].get_db()
+
+    wrong_dim = EMBED_DIM // 2  # any width != EMBED_DIM
+    bad = struct.pack(f"{wrong_dim}f", *([0.1] * wrong_dim))
+
+    emb._dim_mismatch_warned = False  # reset the once-per-process latch
+    with caplog.at_level(logging.WARNING, logger="threadkeeper.embeddings"):
+        emb._vec_upsert_note(conn, 987654, bad)
+
+    # Insert was skipped (not silently attempted-and-swallowed).
+    assert conn.execute(
+        "SELECT id FROM notes_vec WHERE id=?", (987654,)
+    ).fetchone() is None
+    # One actionable, dimension-naming warning was logged.
+    msgs = [r.getMessage().lower() for r in caplog.records]
+    assert any("vec0" in m and "dim" in m for m in msgs)
+
+
+def test_embed_dim_is_config_driven(vec_pkg):
+    """EMBED_DIM flows from config (THREADKEEPER_EMBED_DIM) so a non-384 model
+    can create vec0 tables at the right width."""
+    assert vec_pkg["config"].EMBED_DIM == vec_pkg["db"].EMBED_DIM
+    assert vec_pkg["config"].EMBED_DIM == vec_pkg["config"].settings.embed_dim
+
+
 def test_legacy_cosine_still_works_when_vec_absent(mp_with_cid, monkeypatch):
     """Even when the connection can't load vec0 we should still get a
     valid top-k from the Python-side fallback. Verify by patching

--- a/threadkeeper/config.py
+++ b/threadkeeper/config.py
@@ -81,6 +81,17 @@ class Settings(BaseSettings):
         validation_alias=AliasChoices("THREADKEEPER_EMBED_MODEL", "embed_model"),
     )
     embed_backend: str = "onnx"
+    # Vector width the vec0 (`notes_vec`/`dialog_vec`) tables are CREATEd with.
+    # Defaults to 384 (paraphrase-multilingual-MiniLM-L12-v2). When swapping in
+    # a model of a different dimension via THREADKEEPER_EMBED_MODEL, set this to
+    # the new width AND drop & recreate the *_vec tables, otherwise every vec0
+    # insert mismatches FLOAT[384] and the fast KNN path silently goes dead (the
+    # legacy BLOB cosine path keeps working). See embeddings._vec_dim_ok, which
+    # warns loudly on a width mismatch instead of swallowing it.
+    embed_dim: int = Field(
+        default=384,
+        validation_alias=AliasChoices("THREADKEEPER_EMBED_DIM", "embed_dim"),
+    )
     no_embeddings: bool = False
 
     # ── Client / process identity ────────────────────────────────────────────
@@ -531,6 +542,12 @@ FASTEMBED_MODEL_ID: str = (
     if "/" in EMBED_MODEL_NAME
     else f"sentence-transformers/{EMBED_MODEL_NAME}"
 )
+
+# Embedding dimension the vec0 virtual tables are created with. Computed once
+# here (NOT via _derive_constants) because, like the embedding backend, it is
+# baked into already-created vec0 schema — hot-swapping it in a live process
+# would desync the tables from the data. Override with THREADKEEPER_EMBED_DIM.
+EMBED_DIM: int = int(settings.embed_dim)
 
 
 def _installed(*mods: str) -> bool:

--- a/threadkeeper/db.py
+++ b/threadkeeper/db.py
@@ -5,13 +5,17 @@ from __future__ import annotations
 import logging
 import sqlite3
 
-from .config import DB_PATH
+from .config import DB_PATH, EMBED_DIM
 
 logger = logging.getLogger(__name__)
 
-# Embedding dimension for paraphrase-multilingual-MiniLM-L12-v2.
-# When swapping models, change here AND drop & recreate the *_vec tables.
-EMBED_DIM = 384
+# Embedding dimension the vec0 tables are created with (FLOAT[EMBED_DIM]).
+# Sourced from config (THREADKEEPER_EMBED_DIM, default 384 for
+# paraphrase-multilingual-MiniLM-L12-v2). When swapping in a model of a
+# different dimension, set THREADKEEPER_EMBED_DIM AND drop & recreate the
+# *_vec tables; embeddings._vec_dim_ok warns loudly if a vector's width
+# doesn't match this. Re-exported here for callers that import db.EMBED_DIM.
+__all__ = ["EMBED_DIM", "get_db", "vec_available", "SCHEMA"]
 
 # sqlite-vec extension state. We probe once at first get_db() call and
 # cache the verdict. _VEC_AVAILABLE = True means vec0 virtual tables work

--- a/threadkeeper/embeddings.py
+++ b/threadkeeper/embeddings.py
@@ -13,6 +13,7 @@ vector in BOTH the BLOB column AND the vec0 virtual table, so the legacy
 path keeps working and we can roll back without data loss. Old rows are
 backfilled to vec0 lazily by the ingester.
 """
+import logging
 import sqlite3
 import threading
 from typing import Optional
@@ -21,14 +22,50 @@ from .config import (
     SEMANTIC_AVAILABLE,
     EMBED_MODEL_NAME,
     EMBED_BACKEND,
+    EMBED_DIM,
     FASTEMBED_MODEL_ID,
 )
 from . import db as _db
+
+logger = logging.getLogger(__name__)
 
 
 def _vec_on() -> bool:
     """Indirect lookup so monkeypatching db.vec_available in tests works."""
     return _db.vec_available()
+
+
+# Emit the dimension-mismatch warning at most once per process — a mismatched
+# model would otherwise log on every single note/dialog insert.
+_dim_mismatch_warned = False
+
+
+def _vec_dim_ok(emb_blob: bytes) -> bool:
+    """True when `emb_blob`'s float32 width matches the dimension the vec0
+    tables were created with (EMBED_DIM).
+
+    A user-configurable `THREADKEEPER_EMBED_MODEL` can emit vectors of a width
+    other than the hardcoded FLOAT[EMBED_DIM] the `*_vec` tables were CREATEd
+    with. Every such `INSERT ... INTO notes_vec` raises OperationalError; left
+    unchecked it is silently swallowed, so vec0 stays empty while `_vec_on()`
+    still claims the fast path is live and `tk-migrate-embeddings` (same-dim
+    only) never notices. We surface ONE actionable warning instead and let the
+    caller skip the insert so the legacy BLOB cosine path carries the load."""
+    expected = EMBED_DIM * 4  # float32 = 4 bytes/elem
+    if len(emb_blob) == expected:
+        return True
+    global _dim_mismatch_warned
+    if not _dim_mismatch_warned:
+        _dim_mismatch_warned = True
+        got = len(emb_blob) // 4
+        logger.warning(
+            "vec0 mirror disabled: embed model %r emits %d-dim vectors but the "
+            "notes_vec/dialog_vec tables are FLOAT[%d]. Set THREADKEEPER_EMBED_DIM=%d "
+            "(then drop & recreate the *_vec tables) to enable the fast KNN path; "
+            "falling back to the legacy Python cosine path until then.",
+            EMBED_MODEL_NAME, got, EMBED_DIM, got,
+        )
+    return False
 
 _model = None
 _model_lock = threading.RLock()
@@ -155,7 +192,16 @@ def _vec0_notes_search(conn: sqlite3.Connection, qv_blob: bytes,
     Distance is squared-Euclidean on normalized vectors; we convert to
     cosine score for compatibility with the legacy result shape:
         cos(q, v) = 1 - dist²/2  for unit-norm vectors.
+
+    Over-fetches from vec0: an orphaned vec row (a note deleted before the
+    delete-sync existed — notes.id is AUTOINCREMENT so the id is never reused)
+    consumes a KNN slot but is dropped by the inner join, shrinking the result
+    below `k`. We pull extra candidates so the join still yields `k` live hits,
+    then trim. `_vec_delete_note` keeps new deletes clean; this drains any
+    legacy orphan backlog gracefully.
     """
+    want = max(1, int(k))
+    fetch_k = want * 2 + 8
     rows = conn.execute(
         "SELECT n.id, n.content, n.kind, n.thread_id, n.created_at, "
         "       v.distance "
@@ -163,7 +209,7 @@ def _vec0_notes_search(conn: sqlite3.Connection, qv_blob: bytes,
         "JOIN notes n ON n.id = v.id "
         "WHERE v.embedding MATCH ? AND k = ? "
         "ORDER BY v.distance",
-        (qv_blob, max(1, int(k))),
+        (qv_blob, fetch_k),
     ).fetchall()
     out = []
     for r in rows:
@@ -172,7 +218,7 @@ def _vec0_notes_search(conn: sqlite3.Connection, qv_blob: bytes,
                                   "thread_id", "created_at")}
         d["score"] = float(score)
         out.append(d)
-    return out
+    return out[:want]
 
 
 def _dialog_cosine_search(conn, query: str, k: int) -> list[dict]:
@@ -206,7 +252,7 @@ def _vec_upsert_note(conn: sqlite3.Connection, note_id: int,
     """Mirror a note's embedding into notes_vec. No-op when vec0 isn't
     loaded or the blob is None. Safe to call multiple times — uses
     INSERT OR REPLACE keyed by integer id."""
-    if not _vec_on() or emb_blob is None:
+    if not _vec_on() or emb_blob is None or not _vec_dim_ok(emb_blob):
         return
     try:
         conn.execute(
@@ -217,12 +263,28 @@ def _vec_upsert_note(conn: sqlite3.Connection, note_id: int,
         pass  # vec0 table missing on this connection — silent fall-through
 
 
+def _vec_delete_note(conn: sqlite3.Connection, note_id: int) -> None:
+    """Drop a note's row from notes_vec so vec0 stays in sync with notes on
+    delete. No-op when vec0 isn't loaded. Mirror of `_vec_upsert_note` for the
+    delete path: without it, deleting a note (e.g. consolidate merge) leaves a
+    permanent orphan vec row — notes.id is AUTOINCREMENT so the id is never
+    reused — that consumes a KNN slot and is then dropped by the join in
+    `_vec0_notes_search`, shrinking results below `k` and accumulating dead
+    index entries over time."""
+    if not _vec_on():
+        return
+    try:
+        conn.execute("DELETE FROM notes_vec WHERE id=?", (note_id,))
+    except sqlite3.OperationalError:
+        pass  # vec0 table missing on this connection — silent fall-through
+
+
 def _vec_upsert_dialog(conn: sqlite3.Connection, uuid: str,
                        emb_blob: Optional[bytes]) -> None:
     """Mirror a dialog_message embedding into dialog_vec via the uuid map.
     Resolves or assigns a rowid for the given uuid in dialog_vec_map, then
     INSERT-OR-REPLACE keyed by that rowid in dialog_vec."""
-    if not _vec_on() or emb_blob is None:
+    if not _vec_on() or emb_blob is None or not _vec_dim_ok(emb_blob):
         return
     try:
         row = conn.execute(

--- a/threadkeeper/tools/consolidate.py
+++ b/threadkeeper/tools/consolidate.py
@@ -17,7 +17,7 @@ from ..db import get_db
 from ..config import SEMANTIC_AVAILABLE
 from ..helpers import fmt_age, q, normalize_text
 from ..identity import _ensure_session, _emit
-from ..embeddings import _get_model, _encode
+from ..embeddings import _get_model, _encode, _vec_delete_note
 
 
 CONSOLIDATE_NOTE_COSINE = 0.95
@@ -158,6 +158,9 @@ def consolidate(dry_run: bool = True,
     if not dry_run:
         for f in findings["merge_dup_notes"]:
             conn.execute("DELETE FROM notes WHERE id=?", (f["drop"],))
+            # Keep the vec0 mirror in sync — notes_fts is trigger-synced but
+            # notes_vec is not, so an explicit delete prevents orphan KNN rows.
+            _vec_delete_note(conn, f["drop"])
             applied["merge_dup_notes"] += 1
         for f in findings["idle_stale"]:
             conn.execute(


### PR DESCRIPTION
## Summary

Closes #85.

Fixes two consistency gaps in the sqlite-vec (vec0) `notes_vec` index identified by the evolve reviewer's internal audit.

### 1. Orphaned `notes_vec` rows on note delete
`notes_fts` is trigger-synced (`notes_fts_ai`/`notes_fts_ad`), but the parallel `notes_vec` vec0 mirror was not. `consolidate()` (applied by default) deletes merged notes via `DELETE FROM notes WHERE id=?` with no matching vec0 cleanup. Because `notes.id` is `AUTOINCREMENT` the id is never reused, so the orphan is permanent: `_vec0_notes_search` asks vec0 for exactly `k` rows then inner-joins to `notes`, so orphaned vec rows consume KNN slots and get dropped by the join — a query could return **fewer than `k`** live hits, and dead entries accumulate.

- Added `embeddings._vec_delete_note(conn, id)` (mirror of `_vec_upsert_note` for deletes) and call it in the consolidate apply loop right after the note delete.
- `_vec0_notes_search` now over-fetches (`2k+8`, trimmed to `k` after the join) so any **legacy** orphan backlog drains gracefully instead of shrinking results.

### 2. Unguarded `EMBED_DIM` dimension drift
`THREADKEEPER_EMBED_MODEL` is user-configurable but `EMBED_DIM` was a hardcoded `384` used to `CREATE` the vec0 tables as `FLOAT[384]`. A non-384-dim model made every `INSERT INTO notes_vec` raise `OperationalError` that `_vec_upsert_*` silently swallowed — vec0 stayed empty while `_vec_on()` still claimed the fast path, and `tk-migrate-embeddings` (same-dim only) never noticed.

- `EMBED_DIM` is now config-driven (`THREADKEEPER_EMBED_DIM`, default 384) so a different-width model can create the `*_vec` tables correctly (works end-to-end).
- `embeddings._vec_dim_ok()` validates vector width before insert and logs **one** actionable warning (naming the model, both dimensions, and the env knob) instead of swallowing the error.

Distinct from the closed integrity issue #56 (tampered-artifact verification) — this is dimension-compatibility / silent-vec0-disable for a legitimate model.

## Acceptance criteria
- [x] After `consolidate()` deletes notes, `notes_vec` holds no row whose id is absent from `notes`; KNN returns the requested count of live hits.
- [x] A non-384-dim embed model either works end-to-end (vec0 created at the right dim via `THREADKEEPER_EMBED_DIM`) or surfaces a clear warning instead of silently disabling vec0.
- [x] Tests cover delete→search consistency and the dimension-mismatch path.

## Tests / docs
- `tests/test_vec_search.py`: delete-sync orphan-free + returns-k, over-fetch-past-legacy-orphans, consolidate-apply leaves no orphan, dim-mismatch warns + skips insert, EMBED_DIM is config-driven.
- Full suite: **933 passed, 1 skipped, 0 failed**.
- Docs: `docs/ARCHITECTURE.md` vec0 lifecycle note, `README.md` different-width-model swap note, `CHANGELOG.md` entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)