### PR TITLE
feat: backoff + dead-letter for repeatedly-failing roadmap issues

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -86,6 +86,8 @@
 # THREADKEEPER_EVOLVE_REPO_URL=https://github.com/po4erk91/thread-keeper   # git URL the managed checkout is cloned from
 # THREADKEEPER_EVOLVE_REPO_BRANCH=main         # branch the managed checkout tracks
 # THREADKEEPER_ROADMAP_CLAIM_RACE_WINDOW_S=3   # multi-host TOCTOU window: after posting a claim, wait this long before re-fetching to detect a competing claim. 0=skip race detection (single-host setups)
+# THREADKEEPER_ROADMAP_ISSUE_MAX_ATTEMPTS=3    # poison-issue dead-letter cap: after this many implementer spawns with no PR, the roadmap issue gets a `blocked` label + one summary comment and drops out of the auto-drain until a human intervenes
+# THREADKEEPER_ROADMAP_ISSUE_BACKOFF_BASE_S=172800  # base failure-backoff window (s); doubles per attempt (base*2^(n-1), capped 30d). Defers re-selecting a repeatedly-aborting issue beyond the 24h claim TTL
 # THREADKEEPER_THREAD_JANITOR_INTERVAL_S=0
 # THREADKEEPER_THREAD_IDLE_CLOSE_DAYS=1
 # THREADKEEPER_DIALECTIC_MINE_INTERVAL_S=0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -324,6 +324,25 @@ version bumps follow semver per the policy in
   `lesson_remove` — `concept_manage` needs no `force` guard. The `concepts`
   table gains `embedding`/`embed_backend` columns to power the dedup gate.
   README, ARCHITECTURE, and ROADMAP document the lifecycle.
+- **Poison-issue backoff + dead-letter for the evolve applier (#82).** A roadmap
+  issue whose implementer child repeatedly aborts without opening a PR was
+  re-selected every ~24h once its claim TTL lapsed, burning a fresh
+  `bypassPermissions` Opus child each pass with no escalation or signal. The
+  applier now records a `roadmap_issue_attempt` event per spawned child and
+  gates re-selection on an **escalating backoff**
+  (`ROADMAP_ISSUE_BACKOFF_BASE_S * 2^(attempts-1)`, default base 2 days so it
+  exceeds the 24h claim TTL). After `ROADMAP_ISSUE_MAX_ATTEMPTS` (default 3) the
+  issue is **dead-lettered**: a `blocked` label and a one-time summary comment
+  are applied (composes with the #50 skip-label gate) and it is excluded from
+  the auto-drain until a human intervenes. A `roadmap_issue_dead_letter` event
+  is the authoritative idempotent marker; the label/comment are best-effort
+  signals. A successful child still writes `roadmap_issue_applied` (checked
+  first everywhere), so only genuinely-failing issues accrue attempts, and an
+  exact `evolve_apply_roadmap_issue(issue_number=N)` override bypasses the
+  cooldown/cap for a human-forced retry. Per-issue attempt counts/states surface
+  in `evolve_apply_status()` and stuck/dead-letter counts in `mp_dashboard()`.
+  Two new knobs: `THREADKEEPER_ROADMAP_ISSUE_MAX_ATTEMPTS`,
+  `THREADKEEPER_ROADMAP_ISSUE_BACKOFF_BASE_S`.
 
 - **Shadow-review production telemetry in `shadow_review_status()` (#6).** The
   status tool now appends a production-validation rollup for the 24h and 7d

--- a/README.md
+++ b/README.md
@@ -732,6 +732,8 @@ The most-used env knobs (full list in `threadkeeper/config.py`):
 | `THREADKEEPER_EVOLVE_REPO_BRANCH` | `main` | branch the managed checkout tracks |
 | `THREADKEEPER_EVOLVE_TRUSTED_AUTHOR_ASSOCIATIONS` | `OWNER,MEMBER,COLLABORATOR` | comma-separated GitHub author associations eligible for **autonomous** issue pickup on this public repo; issues from other authors are skipped unless promoted (trust label or exact-number invocation) |
 | `THREADKEEPER_EVOLVE_TRUST_LABELS` | (empty) | comma-separated labels that promote an untrusted-author issue into the autonomous queue; on a public repo only collaborators can apply labels, so a trust label is a maintainer endorsement |
+| `THREADKEEPER_ROADMAP_ISSUE_MAX_ATTEMPTS` | 3 | poison-issue dead-letter cap: after this many implementer spawns for a roadmap issue with no resulting PR, the issue gets a `blocked` label + one summary comment and is excluded from the auto-drain until a human intervenes. A manual `evolve_apply_roadmap_issue(issue_number=N)` still force-retries it |
+| `THREADKEEPER_ROADMAP_ISSUE_BACKOFF_BASE_S` | 172800 (2d) | base failure-backoff window for a roadmap issue; doubles per attempt (`base * 2^(attempts-1)`, capped at 30d). Defers re-selection of a repeatedly-aborting issue beyond the fixed 24h claim TTL |
 | `THREADKEEPER_DIALECTIC_MAX_NEW_CLAIMS` | 3 | max new dialectic claims the validator may create per pass |
 
 Persist them in `~/.threadkeeper/.env` (copy from `.env.example`) — one file,

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -263,7 +263,22 @@ All daemon threads are cheap (ticks 0.5–30 s), no-op when env-knobs disable th
   so the next pass can retry immediately. Claims expire after 24 hours as a
   fallback so crashed workers do not block issues forever; the implementer
   branch carries a 6-char hostname-hash suffix so two hosts past the claim
-  check do not collide on `git push`. In queue mode, issue-local dispatch
+  check do not collide on `git push`. **Poison-issue backoff + dead-letter
+  (#82):** each spawn records a `roadmap_issue_attempt` event, so an issue
+  whose child keeps aborting without a PR is not retried every ~24h forever.
+  An escalating cooldown — `ROADMAP_ISSUE_BACKOFF_BASE_S * 2^(attempts-1)`,
+  default base 2 days so it exceeds the 24h claim TTL — defers re-selection,
+  and after `ROADMAP_ISSUE_MAX_ATTEMPTS` (default 3) the issue is
+  **dead-lettered**: a `blocked` label and a one-time summary comment are
+  applied (composes with the #50 skip-label gate) and it drops out of the
+  auto-drain until a human intervenes. A `roadmap_issue_dead_letter` event is
+  the authoritative idempotent marker; the label/comment are best-effort
+  signals. A successful child writes `roadmap_issue_applied` (checked first
+  everywhere), so only genuinely-failing issues accrue attempts. An exact
+  `evolve_apply_roadmap_issue(issue_number=N)` override bypasses the cooldown
+  and the cap so a human can force a retry; per-issue attempt counts/states
+  surface in `evolve_apply_status()` and stuck/dead-letter counts in
+  `mp_dashboard()`. In queue mode, issue-local dispatch
   failures advance to the next issue; exact
   `evolve_apply_roadmap_issue(issue_number=N)` calls report the specific
   failure instead of switching tasks. The PR body must include `Closes #N`;

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -368,6 +368,17 @@ full 24h (TTL-only, no reaper), and a marker-write failure after `gh pr create`
 can open a duplicate PR. Add a claim reaper + open-PR dedup + the missing
 spawn-after-claim test. (#23) Scope: S.
 
+**Poison-issue backoff + dead-letter (done, #82).** An issue whose implementer
+child repeatedly aborts without opening a PR used to be re-selected every ~24h
+once its claim TTL lapsed, burning a fresh `bypassPermissions` child each time
+with no escalation. Each spawn now records a `roadmap_issue_attempt` event; an
+escalating cooldown (`ROADMAP_ISSUE_BACKOFF_BASE_S * 2^(attempts-1)`, default
+base 2 days) defers re-selection, and after `ROADMAP_ISSUE_MAX_ATTEMPTS`
+(default 3) the issue is dead-lettered — a `blocked` label + one summary
+comment — and excluded from the auto-drain until a human intervenes (composes
+with the #50 skip-label gate). Attempt counts/states show in
+`evolve_apply_status()`; stuck/dead-letter counts in `mp_dashboard()`.
+
 **Daemon robustness under load.** Curator lacks the machine-wide single-flight
 every other spawning daemon has, and `candidate_reviewer`/`curator` dump an
 unbounded queue/inventory into the child prompt argv (the `E2BIG` class already

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -200,6 +200,38 @@ def test_dashboard_lesson_append_emits_countable_outcome(fresh_mp):
     # One create, one in-place patch.
     assert _net_field(after, "added") - net_add0 == 1, after
     assert _net_field(after, "patched") - net_patch0 == 1, after
+def test_dashboard_surfaces_roadmap_applier_counts(fresh_mp):
+    """The roadmap-applier rollup splits attempted issues into stuck (mid-retry)
+    vs dead_letter (capped, blocked). Delta-based so it is contamination-proof."""
+    conn = fresh_mp["db"].get_db()
+    now = int(time.time())
+
+    def dead(out: str) -> int:
+        return _count(out, "dead_letter")
+
+    def stuck(out: str) -> int:
+        return _count(out, "stuck")
+
+    before = _tool(fresh_mp, "mp_dashboard")()
+    d0, s0 = dead(before), stuck(before)
+    # a stuck issue: attempted, not applied, not dead-lettered
+    for _ in range(2):
+        conn.execute(
+            "INSERT INTO events (session_id, kind, target, summary, created_at) "
+            "VALUES ('s','roadmap_issue_attempt','991001','',?)", (now,))
+    # a dead-lettered issue: attempted + flagged
+    conn.execute(
+        "INSERT INTO events (session_id, kind, target, summary, created_at) "
+        "VALUES ('s','roadmap_issue_attempt','991002','',?)", (now,))
+    conn.execute(
+        "INSERT INTO events (session_id, kind, target, summary, created_at) "
+        "VALUES ('s','roadmap_issue_dead_letter','991002','',?)", (now,))
+    conn.commit()
+
+    out = _tool(fresh_mp, "mp_dashboard")()
+    assert "roadmap applier" in out, out
+    assert dead(out) - d0 == 1, out
+    assert stuck(out) - s0 == 1, out
 
 
 def test_dashboard_accept_rate(fresh_mp):

--- a/tests/test_evolve_applier.py
+++ b/tests/test_evolve_applier.py
@@ -77,6 +77,19 @@ def _bootstrap(tmp_path, monkeypatch, interval="0"):
         evolve_applier, "_delete_issue_comment",
         lambda comment_url, repo_root=None: "",
     )
+    # Dead-letter side effects (gh label + summary comment) are stubbed so no
+    # test ever shells out to gh; the dead-letter tests below override these
+    # with capturing fakes.
+    monkeypatch.setattr(
+        evolve_applier, "_apply_blocked_label",
+        lambda issue_number, repo_root=None: "",
+    )
+    monkeypatch.setattr(
+        evolve_applier, "_comment_dead_letter",
+        lambda issue, attempts, repo_root=None: (
+            "https://x/issues/0#issuecomment-dl", ""
+        ),
+    )
     # Skip the real-time race-detection sleep in unit tests so the suite stays
     # snappy. The bootstrap defaults already make the race resolver return True
     # in the "no competing claim" common path.
@@ -1454,3 +1467,227 @@ def test_run_apply_pass_single_flight(tmp_path, monkeypatch):
     import threadkeeper.tools.spawn as spawn_mod
     monkeypatch.setattr(spawn_mod, "spawn", _boom)
     assert "applier_running" in pkg["ea"].run_evolve_apply_pass(force=True)
+
+
+# ── poison-issue backoff + dead-letter (#82) ───────────────────────────────
+
+def _seed_attempts(conn, ea, issue_number, n, created_at=None):
+    """Insert `n` roadmap_issue_attempt event rows for an issue."""
+    import time as _t
+    ts = created_at if created_at is not None else int(_t.time())
+    for _ in range(int(n)):
+        conn.execute(
+            "INSERT INTO events (session_id, kind, target, summary, created_at) "
+            "VALUES (?, ?, ?, ?, ?)",
+            ("s_seed", ea.ROADMAP_ISSUE_ATTEMPT_KIND, str(int(issue_number)),
+             "spawned", ts),
+        )
+    conn.commit()
+
+
+def test_roadmap_issue_backoff_window_escalates(tmp_path, monkeypatch):
+    pkg = _bootstrap(tmp_path, monkeypatch)
+    ea = pkg["ea"]
+    base = ea.ROADMAP_ISSUE_BACKOFF_BASE_S
+    assert ea._roadmap_issue_backoff_window_s(0) == 0
+    assert ea._roadmap_issue_backoff_window_s(1) == int(base)
+    assert ea._roadmap_issue_backoff_window_s(2) == int(base * 2)
+    assert ea._roadmap_issue_backoff_window_s(3) == int(base * 4)
+    # never exceeds the cap, even for a large attempt count
+    assert ea._roadmap_issue_backoff_window_s(50) == ea.ROADMAP_ISSUE_BACKOFF_CAP_S
+    # the first backoff window genuinely exceeds the fixed 24h claim TTL, so it
+    # defers re-selection beyond the claim expiry rather than re-firing at 24h
+    assert ea._roadmap_issue_backoff_window_s(1) > ea.ROADMAP_ISSUE_CLAIM_TTL_S
+
+
+def test_open_roadmap_issues_defers_issue_in_backoff(tmp_path, monkeypatch):
+    """A roadmap issue that just had an attempt is NOT re-selected on the very
+    next eligible pass — the escalating cooldown excludes it (acceptance: no
+    re-attempt on the next pass)."""
+    pkg = _bootstrap(tmp_path, monkeypatch)
+    conn = pkg["db"].get_db()
+    monkeypatch.setattr(
+        pkg["ea"], "_fetch_open_issues",
+        lambda repo_root=None: ([_issue(6, "Poison issue")], ""),
+    )
+    _seed_attempts(conn, pkg["ea"], 6, 1)  # one recent attempt → in backoff
+
+    issues, err = pkg["ea"]._open_roadmap_issues(conn)
+    assert err == ""
+    assert issues == []  # deferred by backoff
+
+    # an exact human override bypasses the cooldown
+    issues2, _ = pkg["ea"]._open_roadmap_issues(conn, skip_backoff=False)
+    assert [int(i["number"]) for i in issues2] == [6]
+
+
+def test_open_roadmap_issues_reselectable_after_backoff_lapses(
+    tmp_path, monkeypatch,
+):
+    pkg = _bootstrap(tmp_path, monkeypatch)
+    conn = pkg["db"].get_db()
+    monkeypatch.setattr(
+        pkg["ea"], "_fetch_open_issues",
+        lambda repo_root=None: ([_issue(6, "Slow issue")], ""),
+    )
+    # the single attempt is older than the first backoff window → eligible again
+    old = int(time.time()) - pkg["ea"]._roadmap_issue_backoff_window_s(1) - 10
+    _seed_attempts(conn, pkg["ea"], 6, 1, created_at=old)
+
+    issues, err = pkg["ea"]._open_roadmap_issues(conn)
+    assert err == ""
+    assert [int(i["number"]) for i in issues] == [6]
+
+
+def test_open_roadmap_issues_dead_letters_after_max_attempts(
+    tmp_path, monkeypatch,
+):
+    """After K attempts the issue is excluded from auto-selection and flagged
+    once (blocked label + summary comment); the flag is idempotent and the
+    read-only path never writes (acceptance: dead-letter excludes after K)."""
+    pkg = _bootstrap(tmp_path, monkeypatch)
+    conn = pkg["db"].get_db()
+    monkeypatch.setattr(
+        pkg["ea"], "_fetch_open_issues",
+        lambda repo_root=None: ([_issue(6, "Poison issue")], ""),
+    )
+    labeled, commented = [], []
+    monkeypatch.setattr(
+        pkg["ea"], "_apply_blocked_label",
+        lambda issue_number, repo_root=None: (
+            labeled.append(int(issue_number)) or ""
+        ),
+    )
+    monkeypatch.setattr(
+        pkg["ea"], "_comment_dead_letter",
+        lambda issue, attempts, repo_root=None: (
+            commented.append((int(issue["number"]), attempts))
+            or ("https://x/issues/6#issuecomment-dl", "")
+        ),
+    )
+    K = pkg["ea"].ROADMAP_ISSUE_MAX_ATTEMPTS
+    _seed_attempts(conn, pkg["ea"], 6, K)
+
+    # read-only selection: excluded, but NO gh writes
+    issues, err = pkg["ea"]._open_roadmap_issues(conn)
+    assert err == "" and issues == []
+    assert labeled == [] and commented == []
+
+    # the real drain path flags it exactly once
+    issues2, _ = pkg["ea"]._open_roadmap_issues(conn, flag_dead_letter=True)
+    assert issues2 == []
+    assert labeled == [6]
+    assert commented == [(6, K)]
+    assert pkg["ea"]._roadmap_issue_dead_lettered(conn, 6) is True
+
+    # idempotent: a second flagging pass does not re-label / re-comment
+    pkg["ea"]._open_roadmap_issues(conn, flag_dead_letter=True)
+    assert labeled == [6]
+    assert commented == [(6, K)]
+
+
+def test_apply_roadmap_issue_records_attempt_then_backs_off(
+    tmp_path, monkeypatch,
+):
+    """End-to-end: a spawned (mocked) child records an attempt; the very next
+    queue pass defers the issue via backoff instead of re-spawning a child."""
+    pkg = _bootstrap(tmp_path, monkeypatch)
+    conn = pkg["db"].get_db()
+    monkeypatch.setattr(
+        pkg["ea"], "_fetch_open_issues",
+        lambda repo_root=None: ([_issue(6, "Poison issue")], ""),
+    )
+    calls = {}
+    _mock_spawn(monkeypatch, calls)
+
+    out = pkg["ea"].apply_roadmap_issue()
+    assert out.startswith("spawned roadmap_issue=#6"), out
+    assert pkg["ea"]._roadmap_issue_attempt_state(conn, 6)[0] == 1
+
+    # next pass: #6 in backoff → nothing startable, child NOT re-spawned
+    def _boom(**kw):
+        raise AssertionError("issue in backoff must not re-spawn a child")
+    import threadkeeper.tools.spawn as spawn_mod
+    monkeypatch.setattr(spawn_mod, "spawn", _boom)
+
+    out2 = pkg["ea"].apply_roadmap_issue()
+    assert out2 == "no_roadmap_issue", out2
+    assert pkg["ea"]._roadmap_issue_attempt_state(conn, 6)[0] == 1
+
+
+def test_apply_roadmap_issue_dead_letter_blocks_auto_but_exact_overrides(
+    tmp_path, monkeypatch,
+):
+    """After the cap, the auto-drain excludes + flags the issue and never
+    spawns; an explicit exact-issue call still force-retries it."""
+    pkg = _bootstrap(tmp_path, monkeypatch)
+    conn = pkg["db"].get_db()
+    monkeypatch.setattr(
+        pkg["ea"], "_fetch_open_issues",
+        lambda repo_root=None: ([_issue(6, "Poison issue")], ""),
+    )
+    labeled = []
+    monkeypatch.setattr(
+        pkg["ea"], "_apply_blocked_label",
+        lambda issue_number, repo_root=None: (
+            labeled.append(int(issue_number)) or ""
+        ),
+    )
+    K = pkg["ea"].ROADMAP_ISSUE_MAX_ATTEMPTS
+    _seed_attempts(conn, pkg["ea"], 6, K)
+
+    def _boom(**kw):
+        raise AssertionError("dead-lettered issue must not auto-spawn")
+    import threadkeeper.tools.spawn as spawn_mod
+    monkeypatch.setattr(spawn_mod, "spawn", _boom)
+
+    out = pkg["ea"].apply_roadmap_issue()
+    assert out == "no_roadmap_issue", out
+    assert labeled == [6]
+
+    # exact mode bypasses the cap and spawns (records attempt K+1)
+    calls = {}
+    _mock_spawn(monkeypatch, calls)
+    out2 = pkg["ea"].apply_roadmap_issue(issue_number=6)
+    assert out2.startswith("spawned roadmap_issue=#6"), out2
+    assert pkg["ea"]._roadmap_issue_attempt_state(conn, 6)[0] == K + 1
+
+
+def test_roadmap_attempt_ledger_classifies_and_omits_applied(
+    tmp_path, monkeypatch,
+):
+    pkg = _bootstrap(tmp_path, monkeypatch)
+    conn = pkg["db"].get_db()
+    K = pkg["ea"].ROADMAP_ISSUE_MAX_ATTEMPTS
+    _seed_attempts(conn, pkg["ea"], 6, 1)        # backoff
+    _seed_attempts(conn, pkg["ea"], 7, K)        # dead-letter
+    _seed_attempts(conn, pkg["ea"], 8, 1)        # attempted then applied
+    pkg["ea"].mark_roadmap_issue_applied(conn, 8, "https://github.com/o/r/pull/8")
+
+    ledger = pkg["ea"].roadmap_attempt_ledger(conn)
+    states = {e["number"]: e["state"] for e in ledger}
+    assert states.get(6) == "backoff"
+    assert states.get(7) == "dead_letter"
+    assert 8 not in states  # applied issues are done, not stuck
+    six = next(e for e in ledger if e["number"] == 6)
+    assert six["attempts"] == 1
+    assert six["backoff_left_s"] > 0
+
+
+def test_evolve_apply_status_surfaces_attempt_ledger(tmp_path, monkeypatch):
+    pkg = _bootstrap(tmp_path, monkeypatch, interval="604800")
+    conn = pkg["db"].get_db()
+    monkeypatch.setattr(
+        pkg["ea"], "_fetch_open_issues",
+        lambda repo_root=None: ([], ""),
+    )
+    K = pkg["ea"].ROADMAP_ISSUE_MAX_ATTEMPTS
+    _seed_attempts(conn, pkg["ea"], 82, K)  # dead-letter
+    _seed_attempts(conn, pkg["ea"], 50, 1)  # backoff
+
+    out = _tool(pkg, "evolve_apply_status")()
+    assert "roadmap_dead_letter=1" in out
+    assert "roadmap_backoff=1" in out
+    assert "roadmap attempt ledger" in out
+    assert "#82  attempts=" in out and "dead_letter" in out
+    assert "#50  attempts=" in out and "backoff" in out

--- a/threadkeeper/config.py
+++ b/threadkeeper/config.py
@@ -283,6 +283,17 @@ class Settings(BaseSettings):
     # itself a maintainer endorsement. Empty by default — association is the
     # sole gate. CSV string or list.
     evolve_trust_labels: Annotated[list[str], NoDecode] = []
+    # Poison-issue guard for the evolve applier. After an implementer child is
+    # spawned for a roadmap issue but no PR results, the issue stays selectable
+    # once its 24h claim TTL lapses. Without a cap that re-spawns a costly
+    # bypassPermissions child every ~24h forever. So each spawn records an
+    # attempt; an escalating backoff (base * 2^(attempts-1)) defers re-selection,
+    # and after this many attempts the issue is dead-lettered: a `blocked` label
+    # is applied and it drops out of auto-selection until a human intervenes.
+    roadmap_issue_max_attempts: int = 3
+    # Base backoff window after the first failed attempt (seconds). The window
+    # doubles per attempt. Default 2 days so it always exceeds the 24h claim TTL.
+    roadmap_issue_backoff_base_s: float = 172800.0
 
     # ── Thread janitor daemon ─────────────────────────────────────────────────
     thread_janitor_interval_s: float = 0.0
@@ -461,6 +472,8 @@ def _derive_constants(s: "Settings") -> dict:
             s.evolve_trusted_author_associations
         ),
         "EVOLVE_TRUST_LABELS": s.evolve_trust_labels,
+        "ROADMAP_ISSUE_MAX_ATTEMPTS": s.roadmap_issue_max_attempts,
+        "ROADMAP_ISSUE_BACKOFF_BASE_S": s.roadmap_issue_backoff_base_s,
         "THREAD_JANITOR_INTERVAL_S": s.thread_janitor_interval_s,
         "THREAD_IDLE_CLOSE_DAYS": s.thread_idle_close_days,
         "DIALECTIC_MINE_INTERVAL_S": s.dialectic_mine_interval_s,

--- a/threadkeeper/evolve_applier.py
+++ b/threadkeeper/evolve_applier.py
@@ -8,6 +8,14 @@ Primary path:
   edits code/docs, runs the full suite, opens a PR with `Closes #N`, then calls
   `evolve_mark_roadmap_issue_applied(issue_number, pr_url)`.
 
+  Poison-issue guard: each spawn records a `roadmap_issue_attempt` event. An
+  escalating backoff (base * 2^(attempts-1), default base 2 days) defers
+  re-selection of an issue whose child keeps aborting without a PR, and after
+  `ROADMAP_ISSUE_MAX_ATTEMPTS` the issue is dead-lettered — a `blocked` label
+  plus a one-time summary comment — and dropped from the auto-drain until a
+  human intervenes. A successful child writes `roadmap_issue_applied` (checked
+  first everywhere), so only genuinely-failing issues accrue backoff.
+
 Fallback paths:
 
   apply_curator_report(report_path="") — apply safe Curator memory-maintenance
@@ -46,6 +54,8 @@ from .config import (
     EVOLVE_TRUST_LABELS,
     EVOLVE_TRUSTED_AUTHOR_ASSOCIATIONS,
     ROADMAP_CLAIM_RACE_WINDOW_S,
+    ROADMAP_ISSUE_BACKOFF_BASE_S,
+    ROADMAP_ISSUE_MAX_ATTEMPTS,
 )
 from .db import get_db
 from .helpers import daemon_sleep
@@ -146,6 +156,16 @@ ROADMAP_ISSUE_APPLIED_KIND = "roadmap_issue_applied"
 # public claim comment carries just the opaque _host_branch_slug() token; this
 # event keeps hostname/PID/git-rev in the local DB for multi-host triage (#63).
 ROADMAP_ISSUE_CLAIM_HOST_KIND = "roadmap_issue_claim_host"
+# Poison-issue failure ledger. One `roadmap_issue_attempt` row is recorded per
+# spawned implementer child; `roadmap_issue_dead_letter` is the one-time marker
+# written when an issue crosses the attempt cap and is flagged for a human.
+ROADMAP_ISSUE_ATTEMPT_KIND = "roadmap_issue_attempt"
+ROADMAP_ISSUE_DEAD_LETTER_KIND = "roadmap_issue_dead_letter"
+# Label applied to a dead-lettered issue so it is visibly excluded from the
+# auto-drain and surfaced for a human (composes with the #50 skip-label gate).
+ROADMAP_ISSUE_BLOCKED_LABEL = "blocked"
+# Upper bound on the escalating backoff window regardless of attempt count.
+ROADMAP_ISSUE_BACKOFF_CAP_S = 30 * 24 * 60 * 60
 ROADMAP_ISSUE_FETCH_LIMIT = 50
 ROADMAP_ISSUE_CLAIM_MARKER = "<!-- thread-keeper:evolve-applier-claim -->"
 ROADMAP_ISSUE_CLAIM_TTL_S = 24 * 60 * 60
@@ -1041,12 +1061,255 @@ def _roadmap_issue_applied(conn: sqlite3.Connection, issue_number: int) -> bool:
     return row is not None
 
 
+# ── Poison-issue failure backoff + dead-letter ──────────────────────────────
+#
+# A roadmap issue whose implementer child repeatedly aborts without opening a
+# PR used to be re-selected every ~24h (once its claim TTL lapsed), burning a
+# fresh bypassPermissions Opus child each pass with no escalation. The applier
+# now records one `roadmap_issue_attempt` event per spawned child and gates
+# re-selection on an escalating backoff; after a cap it dead-letters the issue
+# (a `blocked` label + a one-time human-facing comment) and excludes it from the
+# auto-drain. A successful child writes `roadmap_issue_applied`, which every
+# selection path checks first — so any non-applied issue with attempts>0 has
+# genuinely failed those spawns.
+
+
+def _roadmap_issue_attempt_state(
+    conn: sqlite3.Connection, issue_number: int
+) -> tuple[int, int]:
+    """Return (attempt_count, last_attempt_ts) for a roadmap issue."""
+    try:
+        row = conn.execute(
+            "SELECT COUNT(*) AS c, COALESCE(MAX(created_at), 0) AS last "
+            "FROM events WHERE kind=? AND target=?",
+            (ROADMAP_ISSUE_ATTEMPT_KIND, str(int(issue_number))),
+        ).fetchone()
+    except sqlite3.OperationalError:
+        return 0, 0
+    if not row:
+        return 0, 0
+    return int(row["c"] or 0), int(row["last"] or 0)
+
+
+def _roadmap_issue_backoff_window_s(attempts: int) -> int:
+    """Escalating cooldown after `attempts` failed spawns: base * 2^(n-1),
+    capped at ROADMAP_ISSUE_BACKOFF_CAP_S. 0 when no attempts yet."""
+    if attempts <= 0:
+        return 0
+    window = float(ROADMAP_ISSUE_BACKOFF_BASE_S) * (2 ** (attempts - 1))
+    return int(min(window, float(ROADMAP_ISSUE_BACKOFF_CAP_S)))
+
+
+def _roadmap_issue_dead_lettered(
+    conn: sqlite3.Connection, issue_number: int
+) -> bool:
+    """True once an issue has been flagged dead-letter (its marker exists)."""
+    try:
+        row = conn.execute(
+            "SELECT 1 FROM events WHERE kind=? AND target=? LIMIT 1",
+            (ROADMAP_ISSUE_DEAD_LETTER_KIND, str(int(issue_number))),
+        ).fetchone()
+    except sqlite3.OperationalError:
+        return False
+    return row is not None
+
+
+def _classify_roadmap_issue(
+    conn: sqlite3.Connection, issue_number: int, now_t: float
+) -> tuple[str, int, int]:
+    """Map a (non-applied) issue to ('ready'|'backoff'|'dead_letter',
+    attempts, last_ts).
+
+    'dead_letter' once attempts reach ROADMAP_ISSUE_MAX_ATTEMPTS (cap>0);
+    'backoff' while the escalating cooldown since the last attempt has not
+    elapsed; else 'ready'."""
+    attempts, last_ts = _roadmap_issue_attempt_state(conn, issue_number)
+    cap = int(ROADMAP_ISSUE_MAX_ATTEMPTS)
+    if cap > 0 and attempts >= cap:
+        return "dead_letter", attempts, last_ts
+    if attempts > 0:
+        window = _roadmap_issue_backoff_window_s(attempts)
+        if float(now_t) < last_ts + window:
+            return "backoff", attempts, last_ts
+    return "ready", attempts, last_ts
+
+
+def _record_roadmap_issue_attempt(
+    conn: sqlite3.Connection, issue_number: int, summary: str = ""
+) -> None:
+    """Append one attempt row for a roadmap issue (best-effort)."""
+    try:
+        conn.execute(
+            "INSERT INTO events (session_id, kind, target, summary, created_at) "
+            "VALUES (?, ?, ?, ?, ?)",
+            (identity._session_id or "", ROADMAP_ISSUE_ATTEMPT_KIND,
+             str(int(issue_number)), (summary or "")[:300], int(time.time())),
+        )
+        conn.commit()
+    except sqlite3.OperationalError:
+        logger.debug("evolve_applier: failed to record attempt", exc_info=True)
+
+
+def _apply_blocked_label(
+    issue_number: int, repo_root: Optional[Path] = None
+) -> str:
+    """Add the `blocked` label to a dead-lettered issue. Empty string =
+    success; best-effort (a label failure never blocks the marker write)."""
+    repo = str(repo_root or _repo_root())
+    cmd = [
+        "gh", "issue", "edit", str(int(issue_number)),
+        "--add-label", ROADMAP_ISSUE_BLOCKED_LABEL,
+    ]
+    try:
+        proc = subprocess.run(
+            cmd, cwd=repo, text=True, capture_output=True, timeout=30,
+            check=False,
+        )
+    except FileNotFoundError:
+        return "gh_not_found"
+    except subprocess.TimeoutExpired:
+        return "gh_issue_edit_timeout"
+    except OSError as e:
+        return f"gh_issue_edit_error: {e}"
+    if proc.returncode != 0:
+        err = (proc.stderr or proc.stdout or "").strip().splitlines()
+        msg = err[-1] if err else f"exit={proc.returncode}"
+        return f"gh_issue_edit_failed: {msg[:180]}"
+    return ""
+
+
+def _roadmap_issue_dead_letter_body(issue: dict, attempts: int) -> str:
+    num = int(issue["number"])
+    title = str(issue.get("title") or f"issue {num}")
+    return (
+        "Evolve applier: dead-lettered after repeated failed attempts.\n\n"
+        f"- Issue: #{num} {title}\n"
+        f"- Attempts: {attempts} implementer child(ren) spawned, no PR opened\n"
+        f"- Action: applied the `{ROADMAP_ISSUE_BLOCKED_LABEL}` label and "
+        "stopped auto-attempting this issue.\n\n"
+        "This issue is excluded from the automatic drain to stop burning a "
+        "bypassPermissions implementer child every cycle with no progress. A "
+        f"human should unblock it (remove the `{ROADMAP_ISSUE_BLOCKED_LABEL}` "
+        "label, then split/clarify the issue) before it is retried. A manual "
+        f"`evolve_apply_roadmap_issue(issue_number={num})` still force-retries "
+        "it regardless of this dead-letter state."
+    )
+
+
+def _comment_dead_letter(
+    issue: dict, attempts: int, repo_root: Optional[Path] = None
+) -> tuple[str, str]:
+    """Post the one-time dead-letter summary comment. Returns (url, error)."""
+    repo = str(repo_root or _repo_root())
+    num = int(issue["number"])
+    cmd = [
+        "gh", "issue", "comment", str(num),
+        "--body", _roadmap_issue_dead_letter_body(issue, attempts),
+    ]
+    try:
+        proc = subprocess.run(
+            cmd, cwd=repo, text=True, capture_output=True, timeout=30,
+            check=False,
+        )
+    except FileNotFoundError:
+        return "", "gh_not_found"
+    except subprocess.TimeoutExpired:
+        return "", "gh_issue_comment_timeout"
+    except OSError as e:
+        return "", f"gh_issue_comment_error: {e}"
+    if proc.returncode != 0:
+        err = (proc.stderr or proc.stdout or "").strip().splitlines()
+        msg = err[-1] if err else f"exit={proc.returncode}"
+        return "", f"gh_issue_comment_failed: {msg[:180]}"
+    url_lines = [
+        ln.strip() for ln in (proc.stdout or "").splitlines() if ln.strip()
+    ]
+    return (url_lines[0] if url_lines else ""), ""
+
+
+def _dead_letter_issue(
+    conn: sqlite3.Connection,
+    issue: dict,
+    attempts: int,
+    repo_root: Optional[Path] = None,
+) -> str:
+    """Flag a poison issue once: apply the `blocked` label, post a one-time
+    summary comment, and write the dead-letter marker. The marker is
+    authoritative for exclusion; the label/comment are best-effort signals."""
+    num = int(issue["number"])
+    if _roadmap_issue_dead_lettered(conn, num):
+        return f"already_dead_letter=#{num}"
+    label_err = _apply_blocked_label(num, repo_root)
+    _, comment_err = _comment_dead_letter(issue, attempts, repo_root)
+    note = f"attempts={attempts}"
+    if label_err:
+        note += f" label_err={label_err[:80]}"
+    if comment_err:
+        note += f" comment_err={comment_err[:80]}"
+    try:
+        conn.execute(
+            "INSERT INTO events (session_id, kind, target, summary, created_at) "
+            "VALUES (?, ?, ?, ?, ?)",
+            (identity._session_id or "", ROADMAP_ISSUE_DEAD_LETTER_KIND,
+             str(num), note[:300], int(time.time())),
+        )
+        conn.commit()
+    except sqlite3.OperationalError:
+        logger.debug("evolve_applier: failed to record dead-letter",
+                     exc_info=True)
+    return f"dead_letter=#{num} {note}"
+
+
+def roadmap_attempt_ledger(conn: sqlite3.Connection) -> list[dict]:
+    """Per-issue attempt summary for non-applied roadmap issues, newest
+    activity first. Pure read of the event ledger (no `gh`): each entry is
+    {number, attempts, last_ts, state, backoff_left_s} where state is
+    'dead_letter' | 'backoff' | 'ready'. Applied issues are omitted — they are
+    done, not stuck. Drives the status view + dashboard counters."""
+    try:
+        rows = conn.execute(
+            "SELECT target, COUNT(*) AS attempts, "
+            "COALESCE(MAX(created_at), 0) AS last "
+            "FROM events WHERE kind=? GROUP BY target "
+            "ORDER BY last DESC",
+            (ROADMAP_ISSUE_ATTEMPT_KIND,),
+        ).fetchall()
+    except sqlite3.OperationalError:
+        return []
+    now_t = time.time()
+    out: list[dict] = []
+    for r in rows:
+        try:
+            num = int(r["target"])
+        except (TypeError, ValueError):
+            continue
+        if _roadmap_issue_applied(conn, num):
+            continue
+        state, attempts, last_ts = _classify_roadmap_issue(conn, num, now_t)
+        backoff_left = 0
+        if state == "backoff":
+            backoff_left = max(
+                0,
+                int(last_ts + _roadmap_issue_backoff_window_s(attempts) - now_t),
+            )
+        out.append({
+            "number": num,
+            "attempts": attempts,
+            "last_ts": last_ts,
+            "state": state,
+            "backoff_left_s": backoff_left,
+        })
+    return out
+
+
 def _open_roadmap_issues(
     conn: sqlite3.Connection,
     repo_root: Optional[Path] = None,
     *,
     skip_claimed: bool = True,
     enforce_author_trust: bool = True,
+    skip_backoff: bool = True,
+    flag_dead_letter: bool = False,
 ) -> tuple[list[dict], str]:
     """Open GitHub issues not already handed off by evolve_applier.
 
@@ -1061,6 +1324,12 @@ def _open_roadmap_issues(
     bypassing implementer child without explicit human promotion (#63). Exact-
     issue invocation passes `enforce_author_trust=False`: naming the number is
     itself the human promotion.
+    `skip_backoff` (default True) additionally excludes issues in failure
+    backoff and dead-lettered poison issues from auto-selection; pass False for
+    a manual exact-issue override that should ignore the cooldown/cap. When
+    `flag_dead_letter` is set, a dead-lettered issue is flagged once (a
+    `blocked` label + one summary comment) as it is excluded — only the real
+    drain paths pass this so the read-only status view never writes to GitHub.
     """
     issues, err = _fetch_open_issues(repo_root)
     if err:
@@ -1079,6 +1348,14 @@ def _open_roadmap_issues(
         if enforce_author_trust and not _issue_author_trusted(issue):
             untrusted.append(num)
             continue
+        if skip_backoff:
+            state, attempts, _ = _classify_roadmap_issue(conn, num, now_t)
+            if state == "dead_letter":
+                if flag_dead_letter:
+                    _dead_letter_issue(conn, issue, attempts, repo_root)
+                continue
+            if state == "backoff":
+                continue
         if skip_claimed:
             claimed, claim_err = _issue_has_active_claim(
                 num, repo_root, now_t
@@ -1330,7 +1607,9 @@ def mark_roadmap_issue_applied(
     return f"ok issue=#{num} applied=1 pr={pr_url}"
 
 
-def _start_roadmap_issue_child(issue: dict, repo_root: Path) -> tuple[bool, str]:
+def _start_roadmap_issue_child(
+    conn: sqlite3.Connection, issue: dict, repo_root: Path
+) -> tuple[bool, str]:
     """Try to claim and spawn one roadmap issue.
 
     Multi-host safe. Order of checks:
@@ -1406,6 +1685,14 @@ def _start_roadmap_issue_child(issue: dict, repo_root: Path) -> tuple[bool, str]
         # issue immediately (no 24h-TTL hold on a transient spawn failure).
         _delete_issue_comment(comment_url, repo_root)
         return False, f"spawn_error issue=#{num}: {e}"
+    # Record the spawn as an attempt: the failure ledger that drives backoff +
+    # dead-letter. A child that completes the PR writes roadmap_issue_applied
+    # (checked first everywhere), so this only accrues on issues that fail.
+    _record_roadmap_issue_attempt(
+        conn, num,
+        "spawned branch="
+        f"{roadmap_issue_branch_name(num, str(issue.get('title') or ''))}",
+    )
     return True, f"spawned roadmap_issue=#{num} {str(result)[:140]}"
 
 
@@ -1442,8 +1729,14 @@ def apply_roadmap_issue(issue_number: int = 0) -> str:
         if repo_err:
             return repo_err
         exact = bool(issue_number)
+        # Queue mode honours the backoff/dead-letter gate and flags poison
+        # issues; exact mode is a deliberate human override that ignores it.
         issues, err = _open_roadmap_issues(
-            conn, skip_claimed=not exact, enforce_author_trust=not exact
+            conn, repo_root,
+            skip_claimed=not exact,
+            enforce_author_trust=not exact,
+            skip_backoff=not exact,
+            flag_dead_letter=not exact,
         )
         if err:
             return f"ERR roadmap_issue_fetch_failed: {err}"
@@ -1468,7 +1761,9 @@ def apply_roadmap_issue(issue_number: int = 0) -> str:
 
         failures: list[str] = []
         for issue in candidates:
-            started, status = _start_roadmap_issue_child(issue, repo_root)
+            started, status = _start_roadmap_issue_child(
+                conn, issue, repo_root
+            )
             if started:
                 if failures:
                     return f"{status} after_skipping={len(failures)}"
@@ -1697,7 +1992,12 @@ def run_evolve_apply_pass(force: bool = False) -> str:
     # clone exists on PyPI installs. A repo error is non-fatal here: the Curator
     # fallback below is memory-only and needs no checkout.
     _, repo_err = _ensure_repo_ready()
-    issues, issue_err = ([], repo_err) if repo_err else _open_roadmap_issues(conn)
+    # flag_dead_letter=True so a poison issue is flagged (label + one comment)
+    # and dropped even on a pass where it is the only open issue left.
+    issues, issue_err = (
+        ([], repo_err) if repo_err
+        else _open_roadmap_issues(conn, flag_dead_letter=True)
+    )
     if issues:
         out = apply_roadmap_issue()
         if out.startswith("spawned roadmap_issue=") or out.startswith(

--- a/threadkeeper/tools/dashboard.py
+++ b/threadkeeper/tools/dashboard.py
@@ -249,6 +249,41 @@ def mp_dashboard(window_days: int = 7) -> str:
         f"  curator_net_change added={added} removed={removed} "
         f"patched={patched} net={added - removed:+d} (lessons, {window_days}d)"
     )
+    # ── roadmap applier (poison-issue backoff / dead-letter) ───────────
+    # Issues the evolve applier has spawned a child for, split by outcome.
+    # `stuck` = attempted but neither handed off (PR) nor dead-lettered yet
+    # (in backoff or eligible-again); `dead_letter` = capped out and excluded
+    # from the auto-drain pending a human. A climbing dead_letter count is a
+    # poison-issue / cost-waste signal.
+    rm_attempted = _scalar(
+        conn,
+        "SELECT COUNT(DISTINCT target) FROM events "
+        "WHERE kind='roadmap_issue_attempt'",
+    )
+    if rm_attempted:
+        rm_applied = _scalar(
+            conn,
+            "SELECT COUNT(DISTINCT target) FROM events "
+            "WHERE kind='roadmap_issue_applied'",
+        )
+        rm_dead = _scalar(
+            conn,
+            "SELECT COUNT(DISTINCT target) FROM events "
+            "WHERE kind='roadmap_issue_dead_letter'",
+        )
+        rm_stuck = _scalar(
+            conn,
+            "SELECT COUNT(*) FROM (SELECT target FROM events "
+            "WHERE kind='roadmap_issue_attempt' AND target NOT IN "
+            "(SELECT target FROM events WHERE kind='roadmap_issue_applied') "
+            "AND target NOT IN (SELECT target FROM events "
+            "WHERE kind='roadmap_issue_dead_letter') GROUP BY target)",
+        )
+        out.append("")
+        out.append(
+            f"roadmap applier  attempted={rm_attempted} applied={rm_applied} "
+            f"stuck={rm_stuck} dead_letter={rm_dead}"
+        )
 
     # ── reliability ───────────────────────────────────────────────────
     weak = _scalar(

--- a/threadkeeper/tools/evolve_applier.py
+++ b/threadkeeper/tools/evolve_applier.py
@@ -33,6 +33,7 @@ import time
 
 from .._mcp import read_tool, write_tool
 from ..db import get_db
+from ..helpers import fmt_age
 from ..identity import _ensure_session
 from ..config import EVOLVE_APPLY_INTERVAL_S
 from ..evolve_applier import (
@@ -42,6 +43,7 @@ from ..evolve_applier import (
     mark_curator_report_applied,
     mark_applied,
     mark_roadmap_issue_applied,
+    roadmap_attempt_ledger,
     _open_roadmap_issues,
     _pending_curator_reports,
     _promoted_unapplied,
@@ -153,6 +155,9 @@ def evolve_apply_status() -> str:
     reports = _pending_curator_reports(conn)
     pending = _promoted_unapplied(conn)
     issues, issue_err = _open_roadmap_issues(conn)
+    ledger = roadmap_attempt_ledger(conn)
+    backoff = [e for e in ledger if e["state"] == "backoff"]
+    dead = [e for e in ledger if e["state"] == "dead_letter"]
     running = _running_applier_children(conn)
     floor = _last_apply_ts(conn)
     now = int(time.time())
@@ -160,6 +165,8 @@ def evolve_apply_status() -> str:
     lines = [
         f"interval_s={EVOLVE_APPLY_INTERVAL_S:.0f} "
         f"roadmap_issues={len(issues)} "
+        f"roadmap_backoff={len(backoff)} "
+        f"roadmap_dead_letter={len(dead)} "
         f"curator_reports={len(reports)} "
         f"promoted_unapplied={len(pending)} "
         f"applier_running={len(running)}",
@@ -174,6 +181,19 @@ def evolve_apply_status() -> str:
         for issue in issues[:10]:
             title = str(issue.get("title") or "")[:90].replace("\n", " ")
             lines.append(f"  #{int(issue['number'])}  {title}")
+    if ledger:
+        lines.append("")
+        lines.append("roadmap attempt ledger (non-applied; newest first):")
+        for e in ledger[:10]:
+            last = fmt_age(now - e["last_ts"]) + "_ago" if e["last_ts"] else "?"
+            if e["state"] == "backoff":
+                state = f"backoff(~{fmt_age(e['backoff_left_s'])} left)"
+            else:
+                state = e["state"]
+            lines.append(
+                f"  #{e['number']}  attempts={e['attempts']}  {state}  "
+                f"last={last}"
+            )
     if reports:
         lines.append("")
         lines.append("curator report pending:")
@@ -191,7 +211,8 @@ def evolve_apply_status() -> str:
         rows = conn.execute(
             "SELECT kind, created_at, summary FROM events "
             "WHERE kind IN ('evolve_apply_pass', 'curator_report_applied', "
-            "'evolve_applied', 'roadmap_issue_applied') "
+            "'evolve_applied', 'roadmap_issue_applied', "
+            "'roadmap_issue_dead_letter') "
             "ORDER BY created_at DESC, id DESC LIMIT 5"
         ).fetchall()
     except Exception:


### PR DESCRIPTION
## Problem

The evolve applier had **no failure backoff, attempt cap, or dead-letter state** for a roadmap issue whose implementer child repeatedly aborts without opening a PR. Once the 24h claim TTL lapsed, the same "poison issue" was re-selected and re-attempted every pass — burning a fresh `bypassPermissions` Opus child each time with **no progress, no escalation, and no signal** — and could wedge the queue ahead of completable work. Nothing distinguished "not yet attempted" from "attempted and failed 12 times."

## What changed

- **Attempt ledger.** Each spawned implementer child records a `roadmap_issue_attempt` event (in `_start_roadmap_issue_child`, after a successful `spawn()`).
- **Escalating backoff.** `ROADMAP_ISSUE_BACKOFF_BASE_S * 2^(attempts-1)` (default base **2 days**, so it exceeds the 24h claim TTL; capped at 30d) defers re-selection — an aborting issue is **not** retried on the very next eligible pass.
- **Dead-letter.** After `ROADMAP_ISSUE_MAX_ATTEMPTS` (default **3**) the issue is excluded from the auto-drain and flagged for a human: a `blocked` label + a **one-time** summary comment (composes with the #50 skip-label gate). A `roadmap_issue_dead_letter` event is the authoritative idempotent marker; the label/comment are best-effort.
- **Soundness.** A successful child writes `roadmap_issue_applied`, which every selection path checks first — so only genuinely-failing issues accrue attempts.
- **Human override.** An exact `evolve_apply_roadmap_issue(issue_number=N)` call bypasses the cooldown/cap to force a retry; the read-only status path never writes to GitHub.
- **Observability.** Per-issue attempt counts/states in `evolve_apply_status()`; stuck/dead-letter counts in `mp_dashboard()`.

## Acceptance criteria

- ✅ An issue that aborts without a PR is not re-attempted on the next eligible pass; an escalating cooldown applies.
- ✅ After K aborts the issue is dead-lettered (excluded + `blocked` label + comment) with no manual intervention.
- ✅ Per-issue attempt counts / states are queryable (event rows) and reflected in `evolve_apply_status()` + `mp_dashboard()`.
- ✅ Tests simulate repeated aborts via a mocked `spawn` and assert (a) backoff defers re-selection and (b) dead-letter excludes after K.

## New knobs

| Env var | Default | Meaning |
|---|---|---|
| `THREADKEEPER_ROADMAP_ISSUE_MAX_ATTEMPTS` | 3 | dead-letter cap |
| `THREADKEEPER_ROADMAP_ISSUE_BACKOFF_BASE_S` | 172800 (2d) | base backoff window; doubles per attempt, capped 30d |

## Tests / docs

- 8 new tests in `tests/test_evolve_applier.py` (backoff escalation, defer/lapse, dead-letter exclude + idempotent flag, end-to-end attempt→backoff, dead-letter blocks auto but exact overrides, ledger classification, status ledger) + 1 in `tests/test_dashboard.py`.
- Updated `docs/ARCHITECTURE.md`, `docs/ROADMAP.md`, `README.md`, `CHANGELOG.md`, `.env.example`.
- Full suite green locally (`env -u THREADKEEPER_NO_EMBEDDINGS .venv/bin/python -m pytest -q`, exit 0).

Generated by the evolve_applier role.

Closes #82

🤖 Generated with [Claude Code](https://claude.com/claude-code)