### PR TITLE
fix: daemon wake-up jitter, bounded notify dict, no-op janitor event suppression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,33 @@ version bumps follow semver per the policy in
 
 ## [Unreleased]
 
+### Changed
+
+- **Background daemon resource hygiene (#86).** Three low-grade resource gaps in
+  the background daemon family are closed:
+  - **Wake-up jitter.** Every daemon sleep is now scaled by ±15% random jitter
+    (`helpers.daemon_sleep`, which most daemons already route through). The
+    three loops that still slept on a bare `time.sleep` — `memory_guard`,
+    `skill_watcher`, `spawn_budget` — were migrated onto `daemon_sleep` too. The
+    always-on guards bootstrap on *every* MCP instance during `_ensure_session`,
+    so with several clients open (Code CLI, Desktop, VS Code, headless
+    `claude -p`) they used to tick in near-lockstep, firing `ps`/`osascript`
+    work simultaneously every interval — a synchronized subprocess storm that
+    scaled with instance count. Jitter de-synchronizes concurrent instances
+    without meaningfully changing any daemon's cadence.
+  - **Bounded `_last_notify_at`.** `memory_guard`'s module-level
+    `_last_notify_at[(pid, level)]` was insert-only, so on the long-lived
+    aggregate-guard coordinator every transient MCP pid that ever crossed a
+    threshold leaked a permanent entry. `_maybe_notify` now prunes entries past
+    their cooldown window (after which they no longer suppress anything) or for
+    a dead pid, keeping the coordinator's footprint flat.
+  - **No-op `janitor_pass` event suppression.** `run_janitor_pass` recorded a
+    `janitor_pass` event on *every* tick, including the common `no_stale`
+    no-op — steady unbounded growth of the `events` table with zero-signal rows
+    that `brief()`/nudge queries scan. Consecutive no-op ticks now collapse into
+    a single row (the first `no_stale` after activity still lands, so the
+    dashboard keeps a heartbeat).
+
 ### Added
 
 - **MCP Resources & Prompts primitives (#78).** thread-keeper exposed its whole

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -203,7 +203,9 @@ All daemon threads are cheap (ticks 0.5–30 s), no-op when env-knobs disable th
   change the shadow interval, `shadow_review_status()` reflects it within
   ~1 s). A daemon whose interval crossed 0 → >0 is started here; the rest
   self-adjust (and `daemon_sleep` keeps a hot-disabled loop from busy-spinning
-  on `time.sleep(0)`). Cold start records only a baseline (the env is already
+  on `time.sleep(0)`, and jitters every sleep by ±15% so concurrent MCP
+  instances on one host don't fire their `ps`/notify work in lockstep — #86).
+  Cold start records only a baseline (the env is already
   applied at spawn); a half-written file is skipped via the mtime-cursor +
   JSON-parse guard and retried. Manual trigger `config_reload()`; diagnostics
   `config_watch_status()`. Embedding-backend / process-identity flags are

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -379,6 +379,20 @@ comment — and excluded from the auto-drain until a human intervenes (composes
 with the #50 skip-label gate). Attempt counts/states show in
 `evolve_apply_status()`; stuck/dead-letter counts in `mp_dashboard()`.
 
+**Background daemon resource hygiene (done, #86).** Three low-grade resource
+gaps in the daemon family: (1) every loop slept on a bare interval with zero
+jitter, so the always-on guards (`memory_guard`, `skill_watcher`) — which start
+during `_ensure_session` bootstrap on *every* MCP instance — ticked in near-
+lockstep across concurrent clients, a synchronized `ps`/notification subprocess
+storm scaling with instance count; (2) `memory_guard._last_notify_at[(pid,
+level)]` was insert-only, leaking a permanent entry per transient MCP pid on the
+long-lived coordinator; (3) `run_janitor_pass` recorded a `janitor_pass` event
+on every tick including the `no_stale` no-op, growing the `events` table with
+zero-signal rows. Fixed by ±15% wake-up jitter in `daemon_sleep` (+ migrating
+the three bare-`time.sleep` loops onto it), pruning `_last_notify_at` of
+past-cooldown / dead-pid entries each `_maybe_notify`, and collapsing
+consecutive no-op janitor passes into a single recorded row. Scope: S.
+
 **Daemon robustness under load.** Curator lacks the machine-wide single-flight
 every other spawning daemon has, and `candidate_reviewer`/`curator` dump an
 unbounded queue/inventory into the child prompt argv (the `E2BIG` class already

--- a/tests/test_config_watcher.py
+++ b/tests/test_config_watcher.py
@@ -239,7 +239,14 @@ def test_daemon_sleep_idles_when_interval_zero(tmp_path, monkeypatch):
     helpers.daemon_sleep(0, idle_s=0.05)
     helpers.daemon_sleep(7.5)
     helpers.daemon_sleep(-3, idle_s=0.05)
-    assert seen == [0.05, 7.5, 0.05]
+    # interval<=0 idles on idle_s (never 0 → no busy-spin); interval>0 sleeps
+    # the interval. Each is now jittered by ±_JITTER_FRAC (#86), so the sleeps
+    # land within the band around their nominal value rather than exactly on it.
+    frac = helpers._JITTER_FRAC
+    assert len(seen) == 3
+    for got, nominal in zip(seen, [0.05, 7.5, 0.05]):
+        assert nominal * (1 - frac) <= got <= nominal * (1 + frac)
+        assert got > 0
 
 
 # ── MCP tools ─────────────────────────────────────────────────────────────

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,0 +1,69 @@
+"""Stateless helpers: daemon-sleep wake-up jitter (issue #86)."""
+from __future__ import annotations
+
+import time
+
+from threadkeeper import helpers
+
+
+def test_jittered_within_bounds():
+    """_jittered never leaves the ±_JITTER_FRAC band."""
+    frac = helpers._JITTER_FRAC
+    lo, hi = 100.0 * (1 - frac), 100.0 * (1 + frac)
+    for _ in range(2000):
+        v = helpers._jittered(100.0)
+        assert lo <= v <= hi
+
+
+def test_jittered_actually_varies():
+    """Jitter must de-synchronize: many draws are not all identical."""
+    seen = {helpers._jittered(100.0) for _ in range(200)}
+    assert len(seen) > 50  # overwhelmingly not the same value
+
+
+def test_jittered_mean_near_input():
+    """Jitter is symmetric, so the average stays close to the nominal."""
+    n = 5000
+    avg = sum(helpers._jittered(100.0) for _ in range(n)) / n
+    assert 97.0 <= avg <= 103.0
+
+
+def test_jittered_passthrough_for_non_positive():
+    """0 / negative are returned unchanged (idle path stays well-defined)."""
+    assert helpers._jittered(0.0) == 0.0
+    assert helpers._jittered(-5.0) == -5.0
+
+
+def _capture_sleep(monkeypatch):
+    calls: list[float] = []
+    monkeypatch.setattr(time, "sleep", lambda s: calls.append(s))
+    return calls
+
+
+def test_daemon_sleep_jitters_active_interval(monkeypatch):
+    calls = _capture_sleep(monkeypatch)
+    frac = helpers._JITTER_FRAC
+    for _ in range(500):
+        helpers.daemon_sleep(100.0)
+    assert calls
+    for s in calls:
+        assert 100.0 * (1 - frac) <= s <= 100.0 * (1 + frac)
+    assert len(set(calls)) > 10  # not lockstep
+
+
+def test_daemon_sleep_idles_when_disabled(monkeypatch):
+    """interval<=0 sleeps the (jittered) idle floor, never 0 (no busy-spin)."""
+    calls = _capture_sleep(monkeypatch)
+    frac = helpers._JITTER_FRAC
+    helpers.daemon_sleep(0, idle_s=30.0)
+    helpers.daemon_sleep(-1, idle_s=30.0)
+    assert len(calls) == 2
+    for s in calls:
+        assert 30.0 * (1 - frac) <= s <= 30.0 * (1 + frac)
+        assert s > 0
+
+
+def test_daemon_sleep_non_numeric_idles(monkeypatch):
+    calls = _capture_sleep(monkeypatch)
+    helpers.daemon_sleep("not-a-number", idle_s=30.0)
+    assert calls and calls[0] > 0

--- a/tests/test_memory_guard.py
+++ b/tests/test_memory_guard.py
@@ -319,3 +319,44 @@ def test_guard_tool_does_not_leak_daemon_thread(mp_with_cid, monkeypatch):
         if t.name == "memory_guard" and t.is_alive()
     } - before
     assert leaked == set(), f"memory_guard daemon thread leaked: {leaked}"
+
+
+# ──────────────────────────────────────────────────────────────────────
+# _last_notify_at pruning (issue #86 — bound the long-lived coordinator)
+# ──────────────────────────────────────────────────────────────────────
+
+def test_prune_notify_state_drops_stale_and_dead(monkeypatch):
+    """Entries past the cooldown window or for a dead pid are pruned; a
+    fresh entry for a live pid survives."""
+    from threadkeeper import memory_guard as mg
+
+    monkeypatch.setattr(mg, "MEMORY_GUARD_COOLDOWN_S", 60)
+    monkeypatch.setattr(mg, "_pid_alive", lambda pid: pid == 100)
+    now = 1_000_000.0
+    mg._last_notify_at.clear()
+    mg._last_notify_at[(100, "warn")] = now - 10   # fresh + alive → keep
+    mg._last_notify_at[(100, "kill")] = now - 120  # stale → drop
+    mg._last_notify_at[(200, "warn")] = now - 10   # dead pid → drop
+    try:
+        mg._prune_notify_state(now)
+        assert set(mg._last_notify_at) == {(100, "warn")}
+    finally:
+        mg._last_notify_at.clear()
+
+
+def test_maybe_notify_keeps_dict_bounded(monkeypatch):
+    """Notifying about a churn of transient (dead) pids does not grow the
+    module dict without bound — each tick prunes the prior dead entries."""
+    from threadkeeper import memory_guard as mg
+
+    monkeypatch.setattr(mg, "MEMORY_GUARD_COOLDOWN_S", 0)  # cooldown disabled
+    monkeypatch.setattr(mg, "_pid_alive", lambda pid: False)
+    monkeypatch.setattr(mg, "_notify_user", lambda *a, **k: True)
+    monkeypatch.setattr(mg, "_log_line", lambda *a, **k: None)
+    mg._last_notify_at.clear()
+    try:
+        for pid in range(1000, 1200):
+            mg._maybe_notify(pid, "warn", "rss over limit")
+        assert len(mg._last_notify_at) <= 1
+    finally:
+        mg._last_notify_at.clear()

--- a/tests/test_thread_janitor.py
+++ b/tests/test_thread_janitor.py
@@ -179,3 +179,42 @@ def test_daemon_does_not_start_at_interval_zero(tmp_path, monkeypatch):
     pkg = _bootstrap(tmp_path, monkeypatch, interval="0")
     pkg["thread_janitor"].start_thread_janitor()
     assert pkg["thread_janitor"]._started is False
+
+
+# ──────────────────────────────────────────────────────────────────────
+# no-op event suppression (issue #86 — don't grow events one row per tick)
+# ──────────────────────────────────────────────────────────────────────
+
+def test_no_stale_events_collapse_to_one(tmp_path, monkeypatch):
+    """Consecutive no-op ticks record at most one janitor_pass row."""
+    pkg = _bootstrap(tmp_path, monkeypatch)
+    conn = pkg["db"].get_db()
+    for _ in range(5):
+        assert pkg["thread_janitor"].run_janitor_pass(force=True) == "no_stale"
+    n = conn.execute(
+        "SELECT COUNT(*) c FROM events WHERE kind='janitor_pass'"
+    ).fetchone()["c"]
+    assert n == 1, n
+
+
+def test_no_stale_records_again_after_activity(tmp_path, monkeypatch):
+    """A close transitions the loop out of quiet, so the next no_stale is a
+    real state change and IS recorded — collapse, not permanent suppression."""
+    pkg = _bootstrap(tmp_path, monkeypatch, idle_days="1")
+    conn = pkg["db"].get_db()
+    # quiet → exactly one no_stale marker
+    pkg["thread_janitor"].run_janitor_pass(force=True)
+    pkg["thread_janitor"].run_janitor_pass(force=True)
+    # activity: one stale thread closed
+    tid = _tool(pkg, "open_thread")(question="stale")
+    _age_thread(conn, tid, days_ago=2)
+    assert pkg["thread_janitor"].run_janitor_pass(force=True) == "closed=1"
+    # quiet again → a fresh no_stale recorded (transition)
+    pkg["thread_janitor"].run_janitor_pass(force=True)
+    pkg["thread_janitor"].run_janitor_pass(force=True)
+    summaries = [
+        r["summary"] for r in conn.execute(
+            "SELECT summary FROM events WHERE kind='janitor_pass' ORDER BY id"
+        ).fetchall()
+    ]
+    assert summaries == ["no_stale", "closed=1", "no_stale"], summaries

--- a/threadkeeper/helpers.py
+++ b/threadkeeper/helpers.py
@@ -3,15 +3,32 @@ short-quoting, ID generation, process-aliveness check."""
 from __future__ import annotations
 
 import os
+import random
 import secrets
 import sqlite3
 import subprocess
 import time
 from typing import Optional
 
+# ±15% wake-up jitter. Every always-on daemon (memory_guard, skill_watcher)
+# starts during `_ensure_session` bootstrap on every MCP instance, so with
+# several clients open (Code CLI, Desktop, VS Code, headless `claude -p`) they
+# all bootstrap near the same moment and would then tick in near-lockstep —
+# a synchronized `ps`/notification subprocess storm that scales with instance
+# count (#86). Scaling each sleep by a per-tick random factor de-synchronizes
+# concurrent instances without meaningfully changing any daemon's cadence.
+_JITTER_FRAC = 0.15
+
+
+def _jittered(seconds: float) -> float:
+    """Scale `seconds` by a uniform factor in [1-_JITTER_FRAC, 1+_JITTER_FRAC]."""
+    if seconds <= 0:
+        return seconds
+    return seconds * (1.0 + random.uniform(-_JITTER_FRAC, _JITTER_FRAC))
+
 
 def daemon_sleep(interval_s, idle_s: float = 30.0) -> None:
-    """Sleep one daemon tick without ever busy-spinning.
+    """Sleep one daemon tick without ever busy-spinning, with wake-up jitter.
 
     Daemon `_serve_loop`s read their interval from a module global that the
     hot-config reload (issue #2) can rewrite at runtime. If a live interval is
@@ -19,12 +36,15 @@ def daemon_sleep(interval_s, idle_s: float = 30.0) -> None:
     into a CPU-pegging spin. This helper idles for `idle_s` instead so the
     daemon goes quiet (its `run_*_pass` already short-circuits on interval<=0)
     until the knob is raised again.
+
+    The actual sleep is jittered by ±`_JITTER_FRAC` (see above) so multiple
+    MCP server instances on one host don't fire their work in lockstep.
     """
     try:
         interval = float(interval_s)
     except (TypeError, ValueError):
         interval = 0.0
-    time.sleep(interval if interval > 0 else idle_s)
+    time.sleep(_jittered(interval if interval > 0 else idle_s))
 
 
 def fmt_age(seconds: int) -> str:

--- a/threadkeeper/memory_guard.py
+++ b/threadkeeper/memory_guard.py
@@ -34,6 +34,7 @@ from .config import (
     TASK_LOG_DIR,
 )
 from .db import get_db
+from .helpers import daemon_sleep
 from . import process_health
 
 logger = logging.getLogger(__name__)
@@ -115,8 +116,39 @@ def _notify_user(title: str, message: str) -> bool:
         return False
 
 
+def _prune_notify_state(now: float) -> None:
+    """Bound `_last_notify_at`. It is only ever inserted into, so on the
+    long-lived aggregate-guard coordinator each transient MCP `(pid, level)`
+    that ever crossed a threshold would persist forever — slow unbounded
+    growth in the one process that should stay lean (#86). An entry only
+    matters until its cooldown lapses (after that `_maybe_notify` would notify
+    again regardless), and an entry for a dead pid can never matter, so both
+    are safe to drop. Window falls back to 1h when the cooldown is disabled."""
+    window = MEMORY_GUARD_COOLDOWN_S if MEMORY_GUARD_COOLDOWN_S > 0 else 3600.0
+    drop = []
+    for (pid, level), last in _last_notify_at.items():
+        if now - last >= window or not _pid_alive(pid):
+            drop.append((pid, level))
+    for key in drop:
+        _last_notify_at.pop(key, None)
+
+
+def _pid_alive(pid: int) -> bool:
+    """Cheap liveness check (no subprocess) for notify-state pruning."""
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    except OSError:
+        return False
+    return True
+
+
 def _maybe_notify(pid: int, level: str, message: str, *, force: bool = False) -> None:
     now = time.time()
+    _prune_notify_state(now)
     key = (pid, level)
     last = _last_notify_at.get(key, 0)
     if not force and MEMORY_GUARD_COOLDOWN_S > 0 and now - last < MEMORY_GUARD_COOLDOWN_S:
@@ -521,7 +553,7 @@ def _daemon_loop() -> None:
             check_once(dry_run=False, notify=True)
         except Exception:
             logger.debug("memory_guard daemon tick failed", exc_info=True)
-        time.sleep(MEMORY_GUARD_POLL_S)
+        daemon_sleep(MEMORY_GUARD_POLL_S)
 
 
 def start_memory_guard_daemon() -> None:

--- a/threadkeeper/skill_watcher.py
+++ b/threadkeeper/skill_watcher.py
@@ -11,11 +11,11 @@ from __future__ import annotations
 import logging
 import os
 import threading
-import time
 from typing import Optional
 
 from .config import CLAUDE_SKILLS_DIR
 from .db import get_db
+from .helpers import daemon_sleep
 
 logger = logging.getLogger(__name__)
 
@@ -79,7 +79,7 @@ def _watch_loop() -> None:
                 conn.close()
         except Exception:
             logger.debug("skill_watcher tick failed", exc_info=True)
-        time.sleep(_tick_interval_s)
+        daemon_sleep(_tick_interval_s)
 
 
 def start_skill_watcher() -> None:

--- a/threadkeeper/spawn_budget.py
+++ b/threadkeeper/spawn_budget.py
@@ -44,6 +44,7 @@ from .config import (
     SPAWN_BUDGET_POLL_S,
     SPAWN_VISIBLE_TTL_S,
 )
+from .helpers import daemon_sleep
 from .db import get_db
 from .helpers import alive
 
@@ -306,7 +307,7 @@ def _daemon_loop() -> None:
                 conn.close()
         except Exception:
             logger.debug("spawn_budget daemon tick failed", exc_info=True)
-        time.sleep(SPAWN_BUDGET_POLL_S)
+        daemon_sleep(SPAWN_BUDGET_POLL_S)
 
 
 def start_budget_daemon() -> None:

--- a/threadkeeper/thread_janitor.py
+++ b/threadkeeper/thread_janitor.py
@@ -54,6 +54,18 @@ def _record_janitor_pass(conn: sqlite3.Connection, outcome: str) -> None:
         logger.debug("thread_janitor: failed to record pass", exc_info=True)
 
 
+def _last_janitor_outcome(conn: sqlite3.Connection) -> str | None:
+    """Summary of the most recent recorded janitor_pass, or None."""
+    try:
+        row = conn.execute(
+            "SELECT summary FROM events WHERE kind='janitor_pass' "
+            "ORDER BY id DESC LIMIT 1"
+        ).fetchone()
+    except sqlite3.OperationalError:
+        return None
+    return row["summary"] if row else None
+
+
 def _stale_threads(conn: sqlite3.Connection, cutoff: int) -> list[sqlite3.Row]:
     """Active or idle threads not touched since `cutoff`, oldest first."""
     try:
@@ -83,7 +95,13 @@ def run_janitor_pass(force: bool = False) -> str:
     cutoff = now - int(max(0.0, THREAD_IDLE_CLOSE_DAYS) * 86400)
     stale = _stale_threads(conn, cutoff)
     if not stale:
-        _record_janitor_pass(conn, "no_stale")
+        # Collapse consecutive no-op ticks: record `no_stale` only on the
+        # transition into quiet, not on every tick. Otherwise the `events`
+        # table grows one zero-signal row per interval forever — rows that
+        # brief()/nudge queries then have to scan (#86). The first no_stale
+        # after any activity still lands, so the dashboard keeps a heartbeat.
+        if _last_janitor_outcome(conn) != "no_stale":
+            _record_janitor_pass(conn, "no_stale")
         return "no_stale"
 
     # Late import — tools.threads imports brief/embeddings; importing at


### PR DESCRIPTION
## Summary

Closes three low-grade-but-real resource gaps in the background daemon family (issue #86).

### 1. Wake-up jitter (multi-instance herd)
Every daemon loop slept on a bare interval with zero jitter. The always-on guards (`memory_guard`, `skill_watcher`) start during `_ensure_session` bootstrap on **every** MCP instance, so with several clients open (Code CLI, Desktop, VS Code, headless `claude -p`) they bootstrapped near the same moment and then ticked in near-lockstep — a synchronized `ps`/`osascript` subprocess storm that scaled with instance count.

- Added ±15% random jitter in `helpers.daemon_sleep` (which most daemons already route through), so concurrent instances de-synchronize without meaningfully changing any daemon's cadence.
- Migrated the three loops that still slept on a bare `time.sleep` — `memory_guard`, `skill_watcher`, `spawn_budget` — onto `daemon_sleep`.

### 2. Bounded `_last_notify_at`
`memory_guard`'s module-level `_last_notify_at[(pid, level)]` was insert-only, so on the long-lived aggregate-guard coordinator every transient MCP pid that ever crossed a threshold leaked a permanent entry. `_maybe_notify` now prunes entries past their cooldown window (after which they no longer suppress anything) or for a dead pid, keeping the coordinator's footprint flat.

### 3. No-op `janitor_pass` event suppression
`run_janitor_pass` recorded a `janitor_pass` event on **every** tick, including the common `no_stale` no-op — steady unbounded growth of the `events` table with zero-signal rows that `brief()`/nudge queries scan. Consecutive no-op ticks now collapse into a single row; the first `no_stale` after activity still lands, so the dashboard keeps a heartbeat.

## Acceptance criteria
- ✅ Daemon sleeps are jittered; two same-host instances do not fire their `ps`/notify work in lockstep.
- ✅ `_last_notify_at` size stays bounded over a long-running coordinator.
- ✅ `events` does not accumulate a row per no-op janitor tick.

## Tests
New/updated unit tests for jitter bounds, notify-dict pruning, and no-op event suppression (`tests/test_helpers.py`, `tests/test_memory_guard.py`, `tests/test_thread_janitor.py`); updated the pre-existing `daemon_sleep` busy-spin-guard test to assert jittered bounds. Full suite: **836 passed, 0 failed, 1 skipped**.

## Docs
CHANGELOG, `docs/ROADMAP.md`, and `docs/ARCHITECTURE.md` updated.

Closes #86

🤖 Generated with [Claude Code](https://claude.com/claude-code)