### PR TITLE
feat(spawn): wall-clock watchdog for hung-but-alive spawned children (#80)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ version bumps follow semver per the policy in
 
 ## [Unreleased]
 
+### Added
+
+- **Wall-clock watchdog for spawned children (#80).** A spawned learning-loop
+  child that hung while still alive — a wedged `WebFetch`/`gh`/`git`, an agent
+  loop that never converged, a prompt that never arrived — was never terminated:
+  it stalled its loop's single-flight slot (`_running_*_children` =
+  `ended_at IS NULL AND alive(pid)`) and burned model tokens forever, because
+  every existing reaper keyed off something other than age (dead pid, orphaned
+  parent, RSS threshold). The budget sweep (`spawn_budget._refresh_all_running`,
+  already running every ~10 s) is now also an age-based watchdog: a `pid>0` row
+  older than `THREADKEEPER_SPAWN_MAX_RUNTIME_S` (1 h default; `0` disables, so
+  there are no surprise kills on upgrade) is `SIGTERM`'d, then `SIGKILL`'d on its
+  process group after `THREADKEEPER_SPAWN_KILL_GRACE_S` (10 s), and its row is
+  closed with `return_code` 124 (the `timeout(1)` convention) so the loop's
+  single-flight releases and the next tick can retry. The daemon now also runs
+  when the RSS budget is disabled but the watchdog is on. Timed-out children are
+  surfaced as `tasks_timed_out` in `mp_dashboard` and `timed_out` in
+  `agent_status`. Complements #25 (aggregate cost, no kill), #66 (kill-path
+  liveness correctness), and #64 (visible/pid=0 RSS measurement).
+
 ### Changed
 
 - **Background daemon resource hygiene (#86).** Three low-grade resource gaps in

--- a/README.md
+++ b/README.md
@@ -247,6 +247,16 @@ live process is reaped once it outlives `THREADKEEPER_SPAWN_VISIBLE_TTL_S`
 (1 h default; 0 disables), so an unresolvable row can't pin budget
 capacity forever.
 
+The same daemon is also a **wall-clock watchdog**: a child that hangs while
+still alive — a wedged `WebFetch`/`gh`/`git`, an agent loop that never
+converges, a prompt that never arrives — would otherwise stall its loop's
+single-flight slot and burn tokens forever. Any child whose row outlives
+`THREADKEEPER_SPAWN_MAX_RUNTIME_S` (1 h default; 0 disables) is `SIGTERM`'d,
+then `SIGKILL`'d after `THREADKEEPER_SPAWN_KILL_GRACE_S` (10 s), and its row
+is closed with the timeout `return_code` 124 so the loop's single-flight
+releases and the next tick can retry. Timed-out children are surfaced as
+`tasks_timed_out` in `mp_dashboard` and `timed_out` in `agent_status`.
+
 `tk-agent-status` exposes autonomous learning loop status as structured JSON
 or compact text for external monitors:
 
@@ -702,6 +712,8 @@ The most-used env knobs (full list in `threadkeeper/config.py`):
 | `THREADKEEPER_PROBE_INTERVAL_S` | 0 (off) | probe daemon tick (s); 1800 = 30 min recommended so finished probe answers are graded promptly |
 | `THREADKEEPER_PROBE_COOLDOWN_S` | 604800 | per-category probe cooldown; 86400 = 1d recommended for active reliability tracking |
 | `THREADKEEPER_SPAWN_BUDGET_MB` | 3072 | combined child RSS cap (MB); 0 disables |
+| `THREADKEEPER_SPAWN_MAX_RUNTIME_S` | 3600 | wall-clock lifetime cap (s) for a spawned child; over-cap live children are SIGTERM→SIGKILL'd and closed with `return_code` 124; 0 disables |
+| `THREADKEEPER_SPAWN_KILL_GRACE_S` | 10 | grace between SIGTERM and SIGKILL when the watchdog kills a timed-out child |
 | `THREADKEEPER_MENUBAR_AUTO_LAUNCH` | true | macOS: auto install/launch status menu-bar app on MCP startup |
 | `THREADKEEPER_MENUBAR_RESTART_RSS_MB` | 1024 | macOS widget self-restart RSS threshold; 0 disables |
 | `THREADKEEPER_MEMORY_GUARD_POLL_S` | 30 | server RSS guard tick (s); 0 disables |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -175,7 +175,12 @@ All daemon threads are cheap (ticks 0.5–30 s), no-op when env-knobs disable th
   signals (see below).
 - **spawn_budget** — once per `SPAWN_BUDGET_POLL_S` (default 10 s) walks
   the subtree of each `running` task via `ps`, updates `tasks.rss_kb` and
-  closes dead ones.
+  closes dead ones. The same sweep is the **wall-clock watchdog** (#80): a
+  pid>0 child whose row outlives `SPAWN_MAX_RUNTIME_S` (1 h default; 0
+  disables) is `SIGTERM`'d, then `SIGKILL`'d after `SPAWN_KILL_GRACE_S`, and
+  its row is closed with `return_code` 124 so the spawning loop's single-flight
+  (`_running_*_children`) releases. (When the RSS budget is disabled but the
+  watchdog is on, the daemon still runs.)
 - **memory_guard** — once per `MEMORY_GUARD_POLL_S` (default 30 s) scans
   all `threadkeeper.server` processes; warns above `MEMORY_GUARD_WARN_MB`
   and sends SIGTERM above `MEMORY_GUARD_KILL_MB` after logging/notifying.
@@ -433,6 +438,16 @@ children** (the parent itself is not counted). Default 3 GB.
   the same subtree RSS, so they contribute real memory, not the estimate. A
   visible row whose cid never resolves to a live process is reaped past
   `SPAWN_VISIBLE_TTL_S` (1 h default) so it can't pin budget capacity forever.
+- Wall-clock watchdog (#80): a pid>0 child whose row outlives
+  `SPAWN_MAX_RUNTIME_S` (1 h default; 0 disables) is killed
+  (`SIGTERM`→`SPAWN_KILL_GRACE_S`→`SIGKILL` on its process group) and its row is
+  closed with `return_code` `SPAWN_TIMEOUT_RETURN_CODE` (124, the `timeout(1)`
+  convention). This frees the spawning loop's single-flight slot and the pinned
+  budget share that a hung-but-alive child would otherwise hold forever. The
+  kill is idempotent (the `ended_at IS NULL` guard) and observable:
+  `mp_dashboard` reports `tasks_timed_out` and `agent_status` reports
+  `timed_out`. Complementary to #64 (visible/pid=0 RSS) and #66 (kill-path
+  liveness correctness).
 
 Tools: `spawn_budget_status()` (cap/used/free/per-task), `spawn_budget_set(MB)`
 (runtime override, not persisted).
@@ -899,6 +914,7 @@ tests/
 ├── test_threads.py            lifecycle: open → note → close → idle revival
 ├── test_core_memory.py        Letta-tier: set/get/list/remove + brief surfacing
 ├── test_spawn_budget.py       admission control + daemon polling
+├── test_spawn_watchdog.py     wall-clock kill + single-flight release (#80)
 ├── test_search_proxy.py       request/response signal roundtrip
 ├── test_dialectic.py          smoothed-ratio confidence
 ├── test_skills.py             skill_manage frontmatter validation + curator
@@ -1027,6 +1043,8 @@ rubric-sensitivity + a subprocess end-to-end run).
 | `THREADKEEPER_SPAWN_ESTIMATE_FULL_MB` | 1500 | initial full child RSS guess |
 | `THREADKEEPER_SPAWN_BUDGET_POLL_S` | 10 | budget daemon tick; 0 disables |
 | `THREADKEEPER_SPAWN_VISIBLE_TTL_S` | 3600 | reap a visible (pid=0) row whose cid never resolves to a live process; 0 disables |
+| `THREADKEEPER_SPAWN_MAX_RUNTIME_S` | 3600 | wall-clock lifetime cap (s) for a spawned child; over-cap live children are SIGTERM→SIGKILL'd and closed with `return_code` 124; 0 disables |
+| `THREADKEEPER_SPAWN_KILL_GRACE_S` | 10 | grace between SIGTERM and SIGKILL when the watchdog kills a timed-out child |
 | `THREADKEEPER_MENUBAR_AUTO_LAUNCH` | true | macOS: auto install/launch agent-status menu-bar app on MCP startup |
 | `THREADKEEPER_MENUBAR_RESTART_RSS_MB` | 1024 | macOS widget self-restart RSS threshold; 0 disables |
 | `THREADKEEPER_MEMORY_GUARD_POLL_S` | 30 | server RSS guard tick; 0 disables |

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -492,6 +492,21 @@ verified at the cited file:line, deduplicated against the issues above):
   `SPAWN_VISIBLE_TTL_S` (1 h default) wall-clock backstop reaps any `pid<=0` row
   whose cid never resolves to a live process so it can't pin capacity forever.
   (The admission-time check-then-spawn TOCTOU is #58; kill-path safety is #66.)
+- ✅ DONE (#80). No **wall-clock watchdog** for spawned learning-loop children:
+  a child that hung while still alive (wedged `WebFetch`/`gh`/`git`, an agent
+  loop that never converged, a prompt that never arrived) was never terminated —
+  it stalled its loop's single-flight slot (`_running_*_children` =
+  `ended_at IS NULL AND alive(pid)`) and burned tokens forever, since every
+  reaper keyed off something other than age (dead pid, orphaned parent, RSS).
+  Now the budget sweep (`spawn_budget._refresh_all_running`) is also an age
+  watchdog: a `pid>0` row older than `SPAWN_MAX_RUNTIME_S` (1 h default; 0
+  disables — no surprise kills on upgrade) is `SIGTERM`'d, then `SIGKILL`'d on
+  its process group after `SPAWN_KILL_GRACE_S`, and closed with `return_code`
+  124 (`timeout(1)` convention) so the single-flight releases and the next tick
+  retries. The daemon now also runs when the RSS budget is off but the watchdog
+  is on. Timed-out children are surfaced (`tasks_timed_out` in `mp_dashboard`,
+  `timed_out` in `agent_status`). Complements #25 (aggregate cost, no kill), #66
+  (kill-path liveness correctness), and #64 (visible/pid=0 RSS measurement).
 - ✅ DONE (#68). Spawn **slim MCP config** was written world-readable with no
   `chmod` and embedded the host server `env` block, while the stdin prompt file
   is correctly `0600` and the `.command` script was `0755`. Now: slim config

--- a/tests/test_spawn_watchdog.py
+++ b/tests/test_spawn_watchdog.py
@@ -1,0 +1,275 @@
+"""Wall-clock watchdog for spawned children (#80).
+
+A child that hangs while still alive stalls its loop's single-flight slot and
+burns tokens forever. The budget daemon's sweep (`_refresh_all_running`) reaps
+any pid>0 row that has outlived `SPAWN_MAX_RUNTIME_S`: SIGTERM → grace →
+SIGKILL, then `ended_at` + the timeout sentinel `return_code` so the loop's
+single-flight releases.
+
+The real-kill test launches a genuinely detached sleeper (double-fork +
+setsid, re-parented to init) so the watchdog's `os.waitpid`-based `alive()`
+check can't reap it out from under the test, then asserts the sweep actually
+kills it. The remaining cases mock the kill (using this process's own live
+pid) to exercise the single-flight release / idempotency / disable semantics
+without process-management flakiness.
+"""
+from __future__ import annotations
+
+import os
+import signal
+import subprocess
+import sys
+import time
+
+import pytest
+
+
+_FAKE_CID = "33334444-5555-6666-7777-888899990000"
+
+
+def _tool(pkg, name):
+    return pkg["mcp"]._tool_manager._tools[name].fn
+
+
+def _txt(res):
+    if isinstance(res, str):
+        return res
+    return "\n".join(
+        c.text for c in res.content if getattr(c, "type", None) == "text"
+    )
+
+
+def _insert_running(pkg, task_id, pid, started_at, prompt="test"):
+    """Insert a running (ended_at NULL) task with an explicit pid + age."""
+    conn = pkg["db"].get_db()
+    conn.execute(
+        "INSERT INTO tasks (id, pid, parent_cid, spawned_cid, cwd, prompt, "
+        "started_at, ended_at, rss_kb, rss_updated_at) "
+        "VALUES (?,?,?,?,?,?,?,?,?,?)",
+        (task_id, pid, _FAKE_CID, f"child-{task_id}", "/tmp", prompt,
+         started_at, None, None, started_at),
+    )
+    conn.commit()
+    return conn
+
+
+def _spawn_detached_sleeper() -> int:
+    """Start a long-lived sleeper that is NOT this process's waitable child.
+
+    A launcher forks a setsid'd sleeper, prints its pid, then exits — so the
+    sleeper re-parents to init/launchd and `alive()`'s opportunistic
+    `os.waitpid` never reaps it. Returns the sleeper's pid."""
+    code = (
+        "import os,sys,time\n"
+        "r=os.fork()\n"
+        "if r>0:\n"
+        "    sys.stdout.write(str(r)); sys.stdout.flush(); os._exit(0)\n"
+        "os.setsid()\n"
+        "os.close(0); os.close(1); os.close(2)\n"
+        "time.sleep(300)\n"
+    )
+    out = subprocess.check_output([sys.executable, "-c", code], text=True)
+    return int(out.strip())
+
+
+def _wait_dead(pid: int, timeout: float = 10.0) -> bool:
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        try:
+            os.kill(pid, 0)
+        except ProcessLookupError:
+            return True
+        except OSError:
+            return True
+        time.sleep(0.2)
+    return False
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Real kill path — seed an old running row with a live pid, run the sweep.
+# ─────────────────────────────────────────────────────────────────────
+
+def test_watchdog_kills_overcap_child(mp_with_cid, monkeypatch):
+    monkeypatch.setenv("THREADKEEPER_SPAWN_BUDGET_MB", "3072")
+    monkeypatch.setenv("THREADKEEPER_SPAWN_MAX_RUNTIME_S", "60")
+    monkeypatch.setenv("THREADKEEPER_SPAWN_KILL_GRACE_S", "5")
+    pkg = mp_with_cid(_FAKE_CID)
+
+    import threadkeeper.spawn_budget as sb
+
+    pid = _spawn_detached_sleeper()
+    try:
+        old = int(time.time()) - 200  # older than the 60s cap
+        conn = _insert_running(pkg, "tk_hung", pid, old)
+
+        sb._refresh_all_running(conn)
+
+        row = conn.execute(
+            "SELECT ended_at, return_code FROM tasks WHERE id='tk_hung'"
+        ).fetchone()
+        assert row["ended_at"] is not None
+        assert row["return_code"] == sb.SPAWN_TIMEOUT_RETURN_CODE
+        # Single-flight releases: an ended row no longer counts as running.
+        assert sb._running_tasks_rss(conn) == 0
+        assert _wait_dead(pid), "watchdog did not actually kill the child"
+    finally:
+        try:
+            os.kill(pid, signal.SIGKILL)
+        except (ProcessLookupError, OSError):
+            pass
+
+
+def test_watchdog_releases_applier_single_flight(mp_with_cid, monkeypatch):
+    """A timed-out applier child stops being reported by the applier
+    single-flight check, so the loop can spawn again."""
+    monkeypatch.setenv("THREADKEEPER_SPAWN_BUDGET_MB", "3072")
+    monkeypatch.setenv("THREADKEEPER_SPAWN_MAX_RUNTIME_S", "60")
+    pkg = mp_with_cid(_FAKE_CID)
+
+    import threadkeeper.spawn_budget as sb
+    from threadkeeper.evolve_applier import (
+        _running_applier_children,
+        EVOLVE_APPLY_PROMPT_PREFIX,
+    )
+
+    # Don't actually signal — pid is THIS test process (guaranteed alive).
+    killed: list[int] = []
+    monkeypatch.setattr(sb, "_terminate_tree",
+                        lambda pid, grace: killed.append(pid))
+
+    old = int(time.time()) - 200
+    conn = _insert_running(
+        pkg, "tk_appl", os.getpid(), old,
+        prompt=EVOLVE_APPLY_PROMPT_PREFIX + " ISSUE #999 ...",
+    )
+
+    # Before the sweep the hung child pins the applier single-flight slot.
+    assert "tk_appl" in _running_applier_children(conn)
+
+    sb._refresh_all_running(conn)
+
+    # After: killed, closed, and the slot is free.
+    assert killed == [os.getpid()]
+    row = conn.execute(
+        "SELECT ended_at, return_code FROM tasks WHERE id='tk_appl'"
+    ).fetchone()
+    assert row["ended_at"] is not None
+    assert row["return_code"] == sb.SPAWN_TIMEOUT_RETURN_CODE
+    assert "tk_appl" not in _running_applier_children(conn)
+
+
+def test_watchdog_is_idempotent(mp_with_cid, monkeypatch):
+    """A second sweep over an already-reaped row neither re-kills nor
+    rewrites the row."""
+    monkeypatch.setenv("THREADKEEPER_SPAWN_MAX_RUNTIME_S", "60")
+    pkg = mp_with_cid(_FAKE_CID)
+
+    import threadkeeper.spawn_budget as sb
+    killed: list[int] = []
+    monkeypatch.setattr(sb, "_terminate_tree",
+                        lambda pid, grace: killed.append(pid))
+
+    old = int(time.time()) - 200
+    conn = _insert_running(pkg, "tk_once", os.getpid(), old)
+
+    sb._refresh_all_running(conn)
+    first = conn.execute(
+        "SELECT ended_at, return_code FROM tasks WHERE id='tk_once'"
+    ).fetchone()
+    assert first["ended_at"] is not None
+
+    sb._refresh_all_running(conn)  # already ended → not re-selected
+    second = conn.execute(
+        "SELECT ended_at, return_code FROM tasks WHERE id='tk_once'"
+    ).fetchone()
+    assert second["ended_at"] == first["ended_at"]
+    assert len(killed) == 1  # killed exactly once
+
+
+def test_watchdog_disabled_when_zero(mp_with_cid, monkeypatch):
+    """Cap=0 disables the watchdog — an old running child is left untouched
+    (no surprise kills on upgrade)."""
+    monkeypatch.setenv("THREADKEEPER_SPAWN_BUDGET_MB", "3072")
+    monkeypatch.setenv("THREADKEEPER_SPAWN_MAX_RUNTIME_S", "0")
+    pkg = mp_with_cid(_FAKE_CID)
+
+    import threadkeeper.spawn_budget as sb
+    killed: list[int] = []
+    monkeypatch.setattr(sb, "_terminate_tree",
+                        lambda pid, grace: killed.append(pid))
+
+    old = int(time.time()) - 100_000  # ancient
+    conn = _insert_running(pkg, "tk_keep", os.getpid(), old)
+
+    sb._refresh_all_running(conn)
+
+    row = conn.execute(
+        "SELECT ended_at, return_code FROM tasks WHERE id='tk_keep'"
+    ).fetchone()
+    assert row["ended_at"] is None
+    assert killed == []
+
+
+def test_young_child_not_reaped(mp_with_cid, monkeypatch):
+    """A child within the cap is never killed."""
+    monkeypatch.setenv("THREADKEEPER_SPAWN_MAX_RUNTIME_S", "3600")
+    pkg = mp_with_cid(_FAKE_CID)
+
+    import threadkeeper.spawn_budget as sb
+    killed: list[int] = []
+    monkeypatch.setattr(sb, "_terminate_tree",
+                        lambda pid, grace: killed.append(pid))
+
+    young = int(time.time()) - 30
+    conn = _insert_running(pkg, "tk_young", os.getpid(), young)
+
+    sb._refresh_all_running(conn)
+
+    row = conn.execute(
+        "SELECT ended_at FROM tasks WHERE id='tk_young'"
+    ).fetchone()
+    assert row["ended_at"] is None
+    assert killed == []
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Observability — timed-out children are surfaced, not silent.
+# ─────────────────────────────────────────────────────────────────────
+
+def test_dashboard_reports_timed_out_tasks(mp_with_cid, monkeypatch):
+    pkg = mp_with_cid(_FAKE_CID)
+    import threadkeeper.spawn_budget as sb
+    conn = pkg["db"].get_db()
+    now = int(time.time())
+    conn.execute(
+        "INSERT INTO tasks (id, pid, parent_cid, spawned_cid, cwd, prompt, "
+        "started_at, ended_at, return_code) VALUES (?,?,?,?,?,?,?,?,?)",
+        ("tk_to", 0, _FAKE_CID, "c", "/tmp", "test",
+         now - 5000, now - 100, sb.SPAWN_TIMEOUT_RETURN_CODE),
+    )
+    conn.commit()
+
+    txt = _txt(_tool(pkg, "mp_dashboard")())
+    assert "tasks_timed_out=1" in txt
+
+
+def test_agent_status_reports_timed_out(mp_with_cid, monkeypatch):
+    pkg = mp_with_cid(_FAKE_CID)
+    import threadkeeper.spawn_budget as sb
+    from threadkeeper.agent_status import (
+        agent_status_snapshot,
+        format_agent_status,
+    )
+    conn = pkg["db"].get_db()
+    now = int(time.time())
+    conn.execute(
+        "INSERT INTO tasks (id, pid, parent_cid, spawned_cid, cwd, prompt, "
+        "started_at, ended_at, return_code) VALUES (?,?,?,?,?,?,?,?,?)",
+        ("tk_to2", 0, _FAKE_CID, "c", "/tmp", "test",
+         now - 5000, now - 100, sb.SPAWN_TIMEOUT_RETURN_CODE),
+    )
+    conn.commit()
+
+    snap = agent_status_snapshot(refresh=False)
+    assert snap["timed_out_count"] == 1
+    assert "timed_out=1" in format_agent_status(snap)

--- a/threadkeeper/agent_status.py
+++ b/threadkeeper/agent_status.py
@@ -687,6 +687,24 @@ def _recent_results(conn, now: int, limit: int = 10) -> list[dict[str, Any]]:
     return results
 
 
+def _timed_out_count(conn, now: int) -> int:
+    """Children the wall-clock watchdog killed in the recent window (#80).
+
+    The watchdog stamps `return_code = SPAWN_TIMEOUT_RETURN_CODE` (124) on a
+    child it kills for running past `SPAWN_MAX_RUNTIME_S`. Counting them here
+    makes a runtime kill observable in the status surface instead of silent."""
+    from .spawn_budget import SPAWN_TIMEOUT_RETURN_CODE
+    try:
+        row = conn.execute(
+            "SELECT COUNT(*) FROM tasks "
+            "WHERE return_code=? AND ended_at>=?",
+            (SPAWN_TIMEOUT_RETURN_CODE, now - _RESULT_WINDOW_S),
+        ).fetchone()
+    except Exception:
+        return 0
+    return int(row[0] or 0) if row else 0
+
+
 def memory_cleanup(dry_run: bool = False, force: bool = False) -> dict[str, Any]:
     """Run the safe ThreadKeeper memory cleanup path.
 
@@ -798,16 +816,19 @@ def agent_status_snapshot(refresh: bool = True, limit: int = 50) -> dict[str, An
         "ready_loop_count": sum(1 for loop in loops if loop["status"] == "ready"),
         "loops": loops,
         "recent_results": _recent_results(conn, now),
+        "timed_out_count": _timed_out_count(conn, now),
         "agents": agents,
     }
 
 
 def format_agent_status(snapshot: dict[str, Any]) -> str:
+    timed_out = snapshot.get("timed_out_count", 0)
+    timed_out_disp = f" timed_out={timed_out}" if timed_out else ""
     lines = [
         f"loops enabled={snapshot.get('enabled_loop_count', 0)} "
         f"running={snapshot.get('running_loop_count', 0)} "
         f"ready={snapshot.get('ready_loop_count', 0)} "
-        f"child_rss={snapshot['total_rss_mb']}MB"
+        f"child_rss={snapshot['total_rss_mb']}MB{timed_out_disp}"
     ]
     for loop in snapshot.get("loops", []):
         backlog = ""

--- a/threadkeeper/config.py
+++ b/threadkeeper/config.py
@@ -157,6 +157,18 @@ class Settings(BaseSettings):
     # outlives this, so an unresolvable row can't pin budget capacity forever
     # (#64). 0 disables the reaper.
     spawn_visible_ttl_s: float = 3600.0
+    # Wall-clock lifetime cap for any spawned child (#80). A child that hangs
+    # while still alive — a wedged WebFetch/gh/git, an agent loop that never
+    # converges, a prompt that never arrives — would otherwise stall its loop's
+    # single-flight slot and burn tokens forever. The budget daemon SIGTERMs a
+    # pid>0 child whose row has outlived this, then SIGKILLs it after
+    # SPAWN_KILL_GRACE_S, and marks the row ended with return_code 124 (the
+    # timeout(1) convention) so the loop's single-flight releases. Generous
+    # default so legitimate long runs aren't cut; 0 disables (no surprise kills
+    # on upgrade).
+    spawn_max_runtime_s: float = 3600.0
+    # Grace between the SIGTERM and the SIGKILL of a timed-out child (#80).
+    spawn_kill_grace_s: float = 10.0
 
     # ── Memory guard ─────────────────────────────────────────────────────────
     memory_guard_poll_s: float = 30.0
@@ -430,6 +442,8 @@ def _derive_constants(s: "Settings") -> dict:
         "SPAWN_ESTIMATE_FULL_MB": s.spawn_estimate_full_mb,
         "SPAWN_BUDGET_POLL_S": s.spawn_budget_poll_s,
         "SPAWN_VISIBLE_TTL_S": s.spawn_visible_ttl_s,
+        "SPAWN_MAX_RUNTIME_S": s.spawn_max_runtime_s,
+        "SPAWN_KILL_GRACE_S": s.spawn_kill_grace_s,
         "MEMORY_GUARD_POLL_S": s.memory_guard_poll_s,
         "MEMORY_GUARD_WARN_MB": s.memory_guard_warn_mb,
         "MEMORY_GUARD_KILL_MB": s.memory_guard_kill_mb,

--- a/threadkeeper/spawn_budget.py
+++ b/threadkeeper/spawn_budget.py
@@ -43,6 +43,8 @@ from .config import (
     SPAWN_ESTIMATE_FULL_MB,
     SPAWN_BUDGET_POLL_S,
     SPAWN_VISIBLE_TTL_S,
+    SPAWN_MAX_RUNTIME_S,
+    SPAWN_KILL_GRACE_S,
 )
 from .helpers import daemon_sleep
 from .db import get_db
@@ -51,6 +53,12 @@ from .helpers import alive
 logger = logging.getLogger(__name__)
 
 _started = False
+
+# return_code stamped on a child the wall-clock watchdog kills (#80). 124 is
+# the GNU `timeout(1)` convention for "command timed out", so it reads as a
+# timeout marker rather than a normal exit (0-255) or a signal-kill (negative).
+# Surfaced by agent_status / mp_dashboard so a runtime kill is observable.
+SPAWN_TIMEOUT_RETURN_CODE = 124
 
 
 # ─────────────────────────────────────────────────────────────────────
@@ -248,6 +256,79 @@ def _measure_visible(conn, row, now: int) -> int:
     return 0
 
 
+def _terminate_tree(pid: int, grace_s: float) -> None:
+    """Kill a timed-out child: SIGTERM the process group, wait up to `grace_s`,
+    then SIGKILL whatever is left (#80).
+
+    Spawned children start in their own session (`start_new_session=True`), so
+    the tracked pid is the session/group leader and signalling the whole group
+    reaches both the `_spawn_wrap` recorder and the real CLI underneath it —
+    SIGTERM is forwarded by the wrapper, and the SIGKILL fallback reaps any
+    child that ignored it without leaving an orphan. Falls back to a bare
+    per-pid signal when the group can't be resolved."""
+    import signal as _sig
+
+    def _send(sig) -> None:
+        try:
+            os.killpg(os.getpgid(pid), sig)
+            return
+        except (ProcessLookupError, PermissionError, OSError):
+            pass
+        try:
+            os.kill(pid, sig)
+        except (ProcessLookupError, PermissionError, OSError):
+            pass
+
+    _send(_sig.SIGTERM)
+    deadline = time.time() + max(0.0, float(grace_s or 0.0))
+    while time.time() < deadline:
+        if not alive(pid):
+            return
+        time.sleep(0.2)
+    if alive(pid):
+        _send(_sig.SIGKILL)
+
+
+def _over_runtime_cap(row, now: int) -> bool:
+    """True when this running row has outlived SPAWN_MAX_RUNTIME_S (#80).
+    Cap of 0 disables the watchdog entirely."""
+    if SPAWN_MAX_RUNTIME_S <= 0:
+        return False
+    started = row["started_at"] or 0
+    return bool(started) and (now - started) >= SPAWN_MAX_RUNTIME_S
+
+
+def _reap_timed_out(conn, row, now: int) -> bool:
+    """Kill a child that has run past the wall-clock cap and close its row so
+    the spawning loop's single-flight slot releases (#80).
+
+    SIGTERM→grace→SIGKILL the process tree, then stamp ended_at + the timeout
+    return_code. The ended_at guard keeps it idempotent: a second sweep over an
+    already-reaped row is a no-op. Returns True when this call closed the row."""
+    pid = int(row["pid"] or 0)
+    if pid > 0:
+        _terminate_tree(pid, SPAWN_KILL_GRACE_S)
+    cur = conn.execute(
+        "UPDATE tasks SET ended_at=?, return_code=? "
+        "WHERE id=? AND ended_at IS NULL",
+        (now, SPAWN_TIMEOUT_RETURN_CODE, row["id"]),
+    )
+    closed = cur.rowcount > 0
+    if closed:
+        age = now - (row["started_at"] or now)
+        logger.warning(
+            "spawn watchdog: killed task %s after %ss (cap=%ss)",
+            row["id"], age, SPAWN_MAX_RUNTIME_S,
+        )
+        try:
+            from .identity import _emit
+            _emit(conn, "spawn_timeout", target=row["id"],
+                  summary=f"runtime {age}s exceeded cap {SPAWN_MAX_RUNTIME_S}s")
+        except Exception:
+            pass
+    return closed
+
+
 def _refresh_all_running(conn) -> int:
     """Sweep running tasks, update rss_kb with real measurement.
 
@@ -279,6 +360,12 @@ def _refresh_all_running(conn) -> int:
                 (now, r["id"]),
             )
             changed = True
+            continue
+        if _over_runtime_cap(r, now):
+            # Alive but hung past the wall-clock cap — kill it and close the
+            # row so the loop's single-flight releases (#80).
+            if _reap_timed_out(conn, r, now):
+                changed = True
             continue
         rss = measure_tree_rss_kb(pid)
         if rss is None:
@@ -317,8 +404,8 @@ def start_budget_daemon() -> None:
         return
     if SPAWN_BUDGET_POLL_S <= 0:
         return
-    if SPAWN_BUDGET_MB <= 0:
-        return  # budget disabled, no need to track
+    if SPAWN_BUDGET_MB <= 0 and SPAWN_MAX_RUNTIME_S <= 0:
+        return  # both RSS budget and wall-clock watchdog (#80) off — nothing to do
     t = threading.Thread(
         target=_daemon_loop, name="spawn_budget", daemon=True,
     )

--- a/threadkeeper/tool_schemas.py
+++ b/threadkeeper/tool_schemas.py
@@ -108,4 +108,5 @@ class AgentStatusSnapshot(_Lenient):
     ready_loop_count: int = 0
     loops: list[dict[str, Any]] = Field(default_factory=list)
     recent_results: list[dict[str, Any]] = Field(default_factory=list)
+    timed_out_count: int = 0
     agents: list[dict[str, Any]] = Field(default_factory=list)

--- a/threadkeeper/tools/dashboard.py
+++ b/threadkeeper/tools/dashboard.py
@@ -150,12 +150,21 @@ def mp_dashboard(window_days: int = 7) -> str:
                f"{_fmt_group(cand, ('pending','accepted','rejected'))}")
     out.append(f"  evolve: "
                f"{_fmt_group(evolve, ('pending','promoted','dismissed'))}")
+    # tasks_timed_out: children the wall-clock watchdog killed for running past
+    # SPAWN_MAX_RUNTIME_S (#80), keyed off the timeout sentinel return_code so a
+    # runtime kill is observable here rather than silent.
+    from ..spawn_budget import SPAWN_TIMEOUT_RETURN_CODE
+    timed_out = _scalar(
+        conn, "SELECT COUNT(*) FROM tasks WHERE return_code=?",
+        (SPAWN_TIMEOUT_RETURN_CODE,),
+    )
     out.append(
         f"  probes={_scalar(conn, 'SELECT COUNT(*) FROM probes')} "
         f"probe_results={_scalar(conn, 'SELECT COUNT(*) FROM probe_results')} "
         f"tasks_running="
         f"{_scalar(conn, 'SELECT COUNT(*) FROM tasks WHERE ended_at IS NULL')} "
-        f"tasks_total={_scalar(conn, 'SELECT COUNT(*) FROM tasks')}"
+        f"tasks_total={_scalar(conn, 'SELECT COUNT(*) FROM tasks')} "
+        f"tasks_timed_out={timed_out}"
     )
 
     # ── loops ─────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Adds a configurable **wall-clock watchdog** for spawned learning-loop children. A child that hangs while still alive — a wedged `WebFetch`/`gh`/`git`, an agent loop that never converges, a prompt that never arrives — was previously never terminated: it stalled its loop's single-flight slot and burned model tokens forever, because every existing reaper keyed off something *other* than wall-clock age (dead pid → `spawn_budget`, orphaned parent → `process_health`, RSS → `memory_guard`).

## What changed

- **New knobs** (`config.py`, with `0`-disable semantics):
  - `THREADKEEPER_SPAWN_MAX_RUNTIME_S` (default `3600`) — per-child lifetime cap; `0` disables (no surprise kills on upgrade).
  - `THREADKEEPER_SPAWN_KILL_GRACE_S` (default `10`) — SIGTERM→SIGKILL grace.
- **Enforcement** in the sweep that already iterates running tasks every ~10 s (`spawn_budget._refresh_all_running`): a `pid>0` row older than the cap is `SIGTERM`'d on its process group, then `SIGKILL`'d after the grace, and closed with `ended_at` + the sentinel `return_code` 124 (the `timeout(1)` convention). This releases the loop's single-flight slot (`_running_*_children`) so the next tick retries. Idempotent via the `ended_at IS NULL` guard.
- The budget daemon now **also starts when the RSS budget is disabled but the watchdog is on**.
- **Observability**: timed-out children surface as `tasks_timed_out` in `mp_dashboard` and `timed_out` in `agent_status` (+ `timed_out_count` in the structured snapshot).

## Tests

`tests/test_spawn_watchdog.py` (7 cases): real-kill path (a genuinely detached sleeper, double-fork + `setsid`, so `alive()`'s `os.waitpid` can't reap it from under the test) asserting the sweep kills it + sets `ended_at`/`return_code`; applier single-flight release; idempotency (killed exactly once); `0`-disable; young-child untouched; and both observability surfaces.

Full suite: `env -u THREADKEEPER_NO_EMBEDDINGS .venv/bin/python -m pytest -q` → exit 0 (983 tests).

## Docs

README (Spawn section + Configuration table), `docs/ARCHITECTURE.md` (daemon list + spawn-budget section + config table + test list), `docs/ROADMAP.md` (DONE entry), `CHANGELOG.md`.

Relationship to neighbors: complements #25 (aggregate cost, no kill), #66 (kill-path liveness correctness), #64 (visible/pid=0 RSS measurement).

Closes #80