### PR TITLE
fix: paginate roadmap issue pickup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,16 @@ version bumps follow semver per the policy in
 
 ### Changed
 
+- **Roadmap issue drain pagination (#81).** The evolve applier no longer asks
+  GitHub for a single newest-first 50-issue window before applying its
+  `roadmap`-label/FIFO sort. `_fetch_open_issues()` now uses paginated,
+  oldest-first REST reads (`gh api --paginate --slurp` with
+  `sort=created&direction=asc`), filters pull requests, and only then applies a
+  generous local candidate window with an explicit warning if any open issues
+  are left outside it. The evolve reviewer prompt now uses the same paginated
+  open-issue view for duplicate checks, so old backlog items do not disappear
+  from reviewer dedup once the queue grows.
+
 - **Background daemon resource hygiene (#86).** Three low-grade resource gaps in
   the background daemon family are closed:
   - **Wake-up jitter.** Every daemon sleep is now scaled by ±15% random jitter

--- a/README.md
+++ b/README.md
@@ -550,6 +550,9 @@ with problem statement, proposed direction, acceptance criteria, test/docs
 impact, and research sources when applicable. Legacy `evolve_format(...)`
 suggestions are still included as audit input, but durable implementation work
 should become GitHub issues.
+Before filing new issues, the privileged audit phase checks the open backlog via
+the same paginated, oldest-first GitHub REST issue view used by the applier, so
+deduplication is not limited to the newest 50 open issues.
 
 To avoid completing the **lethal trifecta** — private-data access + untrusted
 web content + exfiltration — inside one privileged child (#79), the reviewer
@@ -579,6 +582,10 @@ opens a PR whose body includes `Closes #N`, and only then calls
 pushes to `main`, and it never marks an issue applied without a real PR URL. A
 manual `evolve_apply_roadmap_issue(issue_number=N)` remains exact: it reports
 why that issue cannot start instead of silently switching to another issue.
+The queue fetch uses paginated GitHub REST reads in oldest-created order, then
+applies the documented roadmap/FIFO sort locally. A generous local candidate
+window is retained as a runaway guard; if it ever truncates, the applier logs
+how many open issues were outside the window.
 
 **Author-trust gate (this repo is public).** Any GitHub account can open an
 issue, and an open issue's body is injected into the permission-bypassing

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -238,6 +238,9 @@ All daemon threads are cheap (ticks 0.5–30 s), no-op when env-knobs disable th
   `Bash,Edit,Write` but **no** `WebSearch`/`WebFetch`) that audits the repo and
   does the GitHub/ROADMAP writes, consuming the digest inside an explicit
   `<<<EVOLVE_RESEARCH_DATA … EVOLVE_RESEARCH_DATA` fence it must treat as data.
+  Its duplicate-issue check uses a paginated oldest-first REST issue listing,
+  not a newest-first 50-item `gh issue list` window, so older open issues remain
+  visible as the backlog grows.
   Both phase prompts open with the same `"You are an EVOLVE REVIEWER"` line, so
   the existing single-flight (`_running_evolve_children`) and shadow/extract
   exclusion cover both. A full research → audit cycle spans two due passes.
@@ -245,8 +248,13 @@ All daemon threads are cheap (ticks 0.5–30 s), no-op when env-knobs disable th
   `EVOLVE_APPLY_INTERVAL_S` (default 0 = off) fetches open GitHub issues via the
   REST API (`gh api repos/{owner}/{repo}/issues` — needed because `gh issue
   list --json` cannot return `author_association`; pull requests in the
-  response are filtered out), prioritizes `roadmap`-labeled issues then FIFO,
-  and spawns one `evolve_applier` child to implement exactly one issue.
+  response are filtered out). The fetch is explicit `--paginate --slurp`,
+  `sort=created&direction=asc`, so the subsequent local priority
+  (`roadmap`-labeled issues first, then FIFO by issue number) applies across
+  the open backlog rather than only the newest page. A generous local candidate
+  window is retained as a runaway guard; if exceeded, a warning logs the number
+  of open issues outside the window. The applier then spawns one
+  `evolve_applier` child to implement exactly one issue.
   **Author-trust gate (#63):** the repo is public, so any account can open an
   issue whose body is injected into the permission-bypassing child. Autonomous
   pickup is therefore limited to issues whose `authorAssociation` is in

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -50,6 +50,11 @@ remains a live question.
   time behind a visible GitHub issue claim comment and PR, advances past
   unstartable issues, and falls back to Curator reports and legacy
   `evolve_format` suggestions when no issue is startable.
+- Evolve roadmap issue pagination (#81): reviewer dedup and applier pickup use
+  paginated, oldest-first GitHub REST issue reads instead of a newest-first
+  50-item window. The applier still prioritizes `roadmap` labels then FIFO by
+  issue number locally; if its generous candidate window ever truncates, it logs
+  exactly how many open issues were not considered.
 - Cross-CLI ingest production verification (issue #1): the contract test in
   `scripts/tk_verify_ingest.py` gained a read-only `--live` mode that scores
   the three acceptance criteria — all CLI slots have production rows, shadow-

--- a/tests/test_evolve_applier.py
+++ b/tests/test_evolve_applier.py
@@ -8,6 +8,8 @@ separately by actually running the role.
 """
 from __future__ import annotations
 
+import json
+import logging
 import sys
 import time
 from pathlib import Path
@@ -151,6 +153,26 @@ def _issue(number, title, labels=("roadmap",), body="Issue body",
         "url": f"https://github.com/o/r/issues/{number}",
         "authorAssociation": author_association,
     }
+
+
+def _rest_issue(number, title=None, labels=("roadmap",),
+                author_association="OWNER", pull_request=False):
+    item = {
+        "number": number,
+        "title": title or f"issue {number}",
+        "labels": [{"name": name} for name in labels],
+        "body": f"body {number}",
+        "html_url": f"https://github.com/o/r/issues/{number}",
+        "url": f"https://api.github.com/repos/o/r/issues/{number}",
+        "author_association": author_association,
+        "user": {"login": "po4erk91"},
+    }
+    if pull_request:
+        item["html_url"] = f"https://github.com/o/r/pull/{number}"
+        item["pull_request"] = {
+            "url": f"https://api.github.com/repos/o/r/pulls/{number}"
+        }
+    return item
 
 
 def _claim_comment(created_at="2026-06-14T12:00:00Z"):
@@ -498,34 +520,21 @@ def test_fetch_open_issues_maps_rest_payload_and_filters_prs(
     # author_association). Verify the shape mapping and that PRs are dropped.
     pkg = _bootstrap(tmp_path, monkeypatch)
     rest_payload = [
-        {
-            "number": 10,
-            "title": "real issue",
-            "labels": [{"name": "roadmap"}],
-            "body": "do the thing",
-            "html_url": "https://github.com/o/r/issues/10",
-            "url": "https://api.github.com/repos/o/r/issues/10",
-            "author_association": "OWNER",
-            "user": {"login": "po4erk91"},
-        },
-        {
-            "number": 11,
-            "title": "a pull request",
-            "labels": [],
-            "body": "",
-            "html_url": "https://github.com/o/r/pull/11",
-            "author_association": "NONE",
-            "user": {"login": "outsider"},
-            "pull_request": {"url": "https://api.github.com/.../pulls/11"},
-        },
+        _rest_issue(10, "real issue"),
+        _rest_issue(11, "a pull request", labels=(), pull_request=True),
     ]
+    calls = []
 
     class _Proc:
         returncode = 0
-        stdout = __import__("json").dumps(rest_payload)
+        stdout = json.dumps([rest_payload])
         stderr = ""
 
-    monkeypatch.setattr(pkg["ea"].subprocess, "run", lambda *a, **k: _Proc())
+    def _run(cmd, **kwargs):
+        calls.append(cmd)
+        return _Proc()
+
+    monkeypatch.setattr(pkg["ea"].subprocess, "run", _run)
 
     issues, err = pkg["orig"]["_fetch_open_issues"]()
 
@@ -536,6 +545,70 @@ def test_fetch_open_issues_maps_rest_payload_and_filters_prs(
     assert only["authorAssociation"] == "OWNER"
     assert only["authorLogin"] == "po4erk91"
     assert pkg["ea"]._issue_labels(only) == ["roadmap"]
+    assert "--paginate" in calls[0]
+    assert "--slurp" in calls[0]
+    endpoint = calls[0][-1]
+    assert "sort=created" in endpoint
+    assert "direction=asc" in endpoint
+    assert "per_page=100" in endpoint
+
+
+def test_open_roadmap_issues_fetches_past_old_50_window_and_keeps_fifo(
+    tmp_path, monkeypatch,
+):
+    pkg = _bootstrap(tmp_path, monkeypatch)
+    conn = pkg["db"].get_db()
+    monkeypatch.setattr(
+        pkg["ea"], "_fetch_open_issues", pkg["orig"]["_fetch_open_issues"],
+    )
+    # Simulate two REST pages so the candidate set crosses the historical
+    # 50-item gh issue-list window. The first startable candidate must still be
+    # the oldest issue number, not the newest issue from the first page.
+    rest_payload = [
+        [_rest_issue(n) for n in range(1, 51)],
+        [_rest_issue(n) for n in range(51, 56)],
+    ]
+
+    class _Proc:
+        returncode = 0
+        stdout = json.dumps(rest_payload)
+        stderr = ""
+
+    monkeypatch.setattr(pkg["ea"].subprocess, "run", lambda *a, **k: _Proc())
+
+    issues, err = pkg["ea"]._open_roadmap_issues(conn)
+
+    assert err == ""
+    assert len(issues) == 55
+    assert [int(i["number"]) for i in issues[:5]] == [1, 2, 3, 4, 5]
+
+
+def test_fetch_open_issues_warns_when_candidate_window_truncates(
+    tmp_path, monkeypatch, caplog,
+):
+    pkg = _bootstrap(tmp_path, monkeypatch)
+    monkeypatch.setattr(pkg["ea"], "ROADMAP_ISSUE_FETCH_LIMIT", 50)
+    rest_payload = [[_rest_issue(n) for n in range(1, 56)]]
+
+    class _Proc:
+        returncode = 0
+        stdout = json.dumps(rest_payload)
+        stderr = ""
+
+    monkeypatch.setattr(pkg["ea"].subprocess, "run", lambda *a, **k: _Proc())
+
+    with caplog.at_level(logging.WARNING, logger="threadkeeper.evolve_applier"):
+        issues, err = pkg["orig"]["_fetch_open_issues"]()
+
+    assert err == ""
+    assert len(issues) == 50
+    assert [int(i["number"]) for i in issues[:3]] == [1, 2, 3]
+    messages = [record.getMessage() for record in caplog.records]
+    assert any(
+        "55 open GitHub issues exceeds roadmap issue fetch window 50" in msg
+        and "5 newest issue(s) not considered" in msg
+        for msg in messages
+    )
 
 
 def test_apply_roadmap_issue_builds_evolve_applier_spawn(

--- a/tests/test_evolve_daemon.py
+++ b/tests/test_evolve_daemon.py
@@ -80,6 +80,17 @@ def _seed_research(pkg, conn, text="- idea: adopt Y\n  sources: https://ex.com\n
     return f, text
 
 
+def test_audit_prompt_uses_paginated_issue_dedup(tmp_path, monkeypatch):
+    pkg = _bootstrap(tmp_path, monkeypatch)
+    prompt = pkg["ed"].EVOLVE_AUDIT_PROMPT
+
+    assert "gh issue list --state open --limit 50" not in prompt
+    assert "gh api --paginate --slurp" in prompt
+    assert "sort=created" in prompt
+    assert "direction=asc" in prompt
+    assert "pull_request" in prompt
+
+
 # ── pending selection ──────────────────────────────────────────────────
 
 def test_pending_excludes_applied_and_decided(tmp_path, monkeypatch):

--- a/threadkeeper/evolve_applier.py
+++ b/threadkeeper/evolve_applier.py
@@ -166,7 +166,8 @@ ROADMAP_ISSUE_DEAD_LETTER_KIND = "roadmap_issue_dead_letter"
 ROADMAP_ISSUE_BLOCKED_LABEL = "blocked"
 # Upper bound on the escalating backoff window regardless of attempt count.
 ROADMAP_ISSUE_BACKOFF_CAP_S = 30 * 24 * 60 * 60
-ROADMAP_ISSUE_FETCH_LIMIT = 50
+ROADMAP_ISSUE_FETCH_LIMIT = 1000
+ROADMAP_ISSUE_FETCH_PAGE_SIZE = 100
 ROADMAP_ISSUE_CLAIM_MARKER = "<!-- thread-keeper:evolve-applier-claim -->"
 ROADMAP_ISSUE_CLAIM_TTL_S = 24 * 60 * 60
 
@@ -633,17 +634,24 @@ def _fetch_open_issues(repo_root: Optional[Path] = None) -> tuple[list[dict], st
     (OWNER/MEMBER/COLLABORATOR/…), which the `gh issue list --json` field set
     does not expose. The REST `/issues` endpoint also returns pull requests (a
     PR is an issue in GitHub's data model); those are filtered out so the
-    applier never treats a PR as backlog. Returned dicts keep the prior
-    internal shape (`number/title/labels/body/url`) plus the new
-    `authorAssociation`/`authorLogin` fields the gate reads.
+    applier never treats a PR as backlog.
+
+    Pagination is explicit and oldest-first (`sort=created&direction=asc`) so
+    the downstream roadmap/FIFO drain sees the oldest open issues even when the
+    backlog grows past one GitHub page. A generous local window is retained only
+    as a runaway guard; if it truncates, a warning records the exact overflow so
+    an operator does not mistake a cap for an empty/startable-free queue.
+    Returned dicts keep the prior internal shape (`number/title/labels/body/url`)
+    plus the `authorAssociation`/`authorLogin` fields the gate reads.
     """
     repo = str(repo_root or _repo_root())
     cmd = [
-        "gh", "api",
+        "gh", "api", "--paginate", "--slurp",
         "-H", "Accept: application/vnd.github+json",
         (
             "repos/{owner}/{repo}/issues"
-            f"?state=open&per_page={ROADMAP_ISSUE_FETCH_LIMIT}"
+            "?state=open&sort=created&direction=asc"
+            f"&per_page={ROADMAP_ISSUE_FETCH_PAGE_SIZE}"
         ),
     ]
     try:
@@ -671,13 +679,33 @@ def _fetch_open_issues(repo_root: Optional[Path] = None) -> tuple[list[dict], st
         return [], f"gh_issue_list_bad_json: {e}"
     if not isinstance(data, list):
         return [], "gh_issue_list_bad_shape"
+    if data and all(isinstance(page, list) for page in data):
+        items = [
+            item
+            for page in data
+            for item in page
+            if isinstance(item, dict)
+        ]
+    else:
+        # Defensive fallback for tests/older gh behavior without --slurp.
+        items = [item for item in data if isinstance(item, dict)]
+    open_issues = [
+        item for item in items
+        if not item.get("pull_request")
+    ]
+    total_open = len(open_issues)
+    if total_open > ROADMAP_ISSUE_FETCH_LIMIT:
+        skipped = total_open - ROADMAP_ISSUE_FETCH_LIMIT
+        logger.warning(
+            "evolve_applier: %d open GitHub issues exceeds roadmap issue fetch "
+            "window %d; %d newest issue(s) not considered",
+            total_open,
+            ROADMAP_ISSUE_FETCH_LIMIT,
+            skipped,
+        )
+        open_issues = open_issues[:ROADMAP_ISSUE_FETCH_LIMIT]
     out: list[dict] = []
-    for item in data:
-        if not isinstance(item, dict):
-            continue
-        if item.get("pull_request"):
-            # REST /issues includes PRs; the applier only drains real issues.
-            continue
+    for item in open_issues:
         user = item.get("user")
         login = user.get("login") if isinstance(user, dict) else ""
         out.append({
@@ -1316,7 +1344,9 @@ def _open_roadmap_issues(
     The user treats all open issues as roadmap backlog; issues with the
     explicit `roadmap` label are prioritized first, then FIFO by number. Active
     issue-claim comments are skipped so multiple appliers do not start the same
-    item in parallel.
+    item in parallel. The upstream issue fetch is paginated oldest-first before
+    this sort, so FIFO applies across the whole visible backlog rather than a
+    newest-first GitHub CLI window.
 
     When `enforce_author_trust` is set (the autonomous-drain default), issues
     whose author is not trusted (`_issue_author_trusted`) are skipped — this

--- a/threadkeeper/evolve_daemon.py
+++ b/threadkeeper/evolve_daemon.py
@@ -123,7 +123,11 @@ Run from the repo root:
   - Read README.md, docs/ARCHITECTURE.md, docs/ROADMAP.md, CHANGELOG.md.
   - Inspect threadkeeper/evolve_daemon.py, threadkeeper/evolve_applier.py,
     threadkeeper/agent_status.py, threadkeeper/curator.py, and relevant tests.
-  - Run `gh issue list --state open --limit 50` and avoid duplicate issues.
+  - Inspect all open issues before filing duplicates, oldest-first and without
+    the old 50-item window. Use a paginated REST read, for example:
+    `repo=$(gh repo view --json nameWithOwner -q .nameWithOwner)` then
+    `gh api --paginate --slurp "repos/$repo/issues?state=open&sort=created&direction=asc&per_page=100"`;
+    filter out entries with `pull_request`.
   - Review pending legacy evolve suggestions below. For each clear suggestion,
     create or link a GitHub issue; then call evolve_decide(promote|dismiss) only
     when that helps keep the legacy queue honest.


### PR DESCRIPTION
## Summary
- paginate open roadmap issue fetches oldest-first with gh api --paginate --slurp
- keep a generous local candidate window and log exact overflow when it truncates
- update reviewer dedup instructions plus README/architecture/roadmap/changelog docs

## Tests
- .venv/bin/python -m pytest tests/test_evolve_applier.py tests/test_evolve_daemon.py -q
- env -u THREADKEEPER_NO_EMBEDDINGS .venv/bin/python -m pytest -q

Closes #81