### PR TITLE
feat: warn on unknown threadkeeper env keys

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,10 @@
 #
 # Override the file location with THREADKEEPER_ENV_FILE=/path/to/.env
 # (read by threadkeeper.config — pydantic-settings).
+#
+# Canonical THREADKEEPER_* spellings are listed below. At startup/hot-reload,
+# unknown THREADKEEPER_* keys in the process environment are logged as warnings
+# so mistyped host env-block overrides are visible.
 
 # ── core paths ──
 # THREADKEEPER_DB=~/.threadkeeper/db.sqlite

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ version bumps follow semver per the policy in
 
 ### Added
 
+- **Config typo warnings (#88).** Startup and hot-config reload now log a
+  one-line warning for unknown `THREADKEEPER_*` keys present in the process
+  environment, so mistyped safety-knob overrides such as
+  `THREADKEEPER_CURATOR_DESCTRUCTIVE=0` do not silently fall back to defaults.
+  `spawn_status()` / `spawn_config.summary_table()` also surface warnings for
+  unsupported configured spawn CLIs and unused model keys while preserving the
+  existing fallback behavior.
+
 - **Wall-clock watchdog for spawned children (#80).** A spawned learning-loop
   child that hung while still alive — a wedged `WebFetch`/`gh`/`git`, an agent
   loop that never converged, a prompt that never arrived — was never terminated:

--- a/README.md
+++ b/README.md
@@ -759,6 +759,9 @@ Persist them in `~/.threadkeeper/.env` (copy from `.env.example`) — one file,
 read via pydantic-settings; real environment variables still override it. On
 macOS, the menu-bar app's gear button can edit the same file visually, save up
 to three local presets, and request a ThreadKeeper restart after saving.
+At startup and hot-reload, unknown `THREADKEEPER_*` keys present in the process
+environment are logged as warnings so mistyped host env-block overrides do not
+fail silently.
 Hot-config reload for the watched `settings.json` env block is implemented
 (shipped in #2): the `config_watcher` daemon re-applies changed `THREADKEEPER_*`
 knobs in-process within ~2 s, with no Claude Code restart — toggle it via
@@ -799,7 +802,9 @@ variables override the `.env`. Force host detection with
 `THREADKEEPER_ACTIVE_CLI=claude` (or `codex`, `antigravity`/`agy`,
 `gemini`, `copilot`). `agy` is normalized to `antigravity`; `gemini` remains a
 legacy Gemini CLI adapter for old installs/enterprise paths. See `.env.example`
-for the full knob list.
+for the full knob list. `spawn_status()` includes warnings when a configured
+spawn CLI is unsupported or a model key does not match a supported CLI/startup
+role, while keeping the same fallback resolution.
 
 Adapters without headless support (Claude Desktop, VS Code) can't be
 spawn targets — `spawn_status()` reports them as "no adapter" and any

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1028,6 +1028,12 @@ Smoke-tested in `tests/test_eval_harness.py` (pure-function units +
 rubric-sensitivity + a subprocess end-to-end run).
 ## Env knobs (config.py)
 
+`Settings` keeps pydantic's permissive `extra="ignore"` behavior, but startup
+and hot-config reload log a one-line warning for unknown `THREADKEEPER_*` keys
+present in the process environment. Spawn routing is similarly fail-soft:
+unsupported CLI overrides still fall through to the next priority, and
+`spawn_status()` shows the warning beside the resolution table.
+
 | Knob | Default | Purpose |
 |---|---|---|
 | `THREADKEEPER_DB` | `~/.threadkeeper/db.sqlite` | sqlite file |

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -55,6 +55,10 @@ remains a live question.
   50-item window. The applier still prioritizes `roadmap` labels then FIFO by
   issue number locally; if its generous candidate window ever truncates, it logs
   exactly how many open issues were not considered.
+- Config typo visibility (#88): startup and hot-config reload now warn on
+  unknown `THREADKEEPER_*` process-env keys while preserving pydantic's
+  `extra="ignore"` behavior, and `spawn_status()` surfaces unsupported spawn
+  CLI / unused model-key warnings beside the fallback resolution table.
 - Cross-CLI ingest production verification (issue #1): the contract test in
   `scripts/tk_verify_ingest.py` gained a read-only `--live` mode that scores
   the three acceptance criteria — all CLI slots have production rows, shadow-

--- a/tests/test_config_settings.py
+++ b/tests/test_config_settings.py
@@ -3,6 +3,7 @@
 Uses importlib.reload so each test can set/clear env before re-importing.
 """
 import importlib
+import logging
 import os
 import tempfile
 
@@ -39,6 +40,35 @@ def test_defaults_match(monkeypatch):
 def test_env_overrides_default(monkeypatch):
     c = _fresh_config(monkeypatch, env={"THREADKEEPER_MEMORY_NUDGE_INTERVAL": "3"})
     assert c.MEMORY_NUDGE_INTERVAL == 3
+
+
+def test_unknown_threadkeeper_env_key_warns(monkeypatch, caplog):
+    caplog.set_level(logging.WARNING, logger="threadkeeper.config")
+    _fresh_config(
+        monkeypatch,
+        env={"THREADKEEPER_CURATOR_DESCTRUCTIVE": "0"},
+    )
+    messages = [
+        rec.getMessage()
+        for rec in caplog.records
+        if rec.name == "threadkeeper.config"
+    ]
+    assert any("THREADKEEPER_CURATOR_DESCTRUCTIVE" in msg for msg in messages)
+    assert any("unknown THREADKEEPER_* env key" in msg for msg in messages)
+
+
+def test_known_threadkeeper_env_key_does_not_warn(monkeypatch, caplog):
+    caplog.set_level(logging.WARNING, logger="threadkeeper.config")
+    c = _fresh_config(
+        monkeypatch,
+        env={"THREADKEEPER_CURATOR_DESTRUCTIVE": "0"},
+    )
+    assert c.CURATOR_DESTRUCTIVE is False
+    assert not [
+        rec for rec in caplog.records
+        if rec.name == "threadkeeper.config"
+        and "unknown THREADKEEPER_* env key" in rec.getMessage()
+    ]
 
 
 def test_dotenv_read_and_env_wins(monkeypatch):

--- a/tests/test_spawn_config.py
+++ b/tests/test_spawn_config.py
@@ -298,6 +298,7 @@ def test_summary_table_shows_active_cli(tmp_path, monkeypatch):
     assert "shadow_observer" in out
     assert "codex" in out
     assert "active CLI" in out
+    assert "warning:" not in out
 
 
 def test_summary_table_shows_overrides(tmp_path, monkeypatch):
@@ -306,6 +307,7 @@ def test_summary_table_shows_overrides(tmp_path, monkeypatch):
     assert "curator" in out
     assert "antigravity" in out
     assert "spawn config" in out
+    assert "warning:" not in out
 
 
 def test_summary_table_includes_dialectic_validator_model(tmp_path, monkeypatch):
@@ -317,3 +319,26 @@ def test_summary_table_includes_dialectic_validator_model(tmp_path, monkeypatch)
     assert "dialectic_validator" in out
     assert "model=opus" in out
     assert "spawn config" in out
+    assert "warning:" not in out
+
+
+def test_summary_table_warns_invalid_spawn_cli(tmp_path, monkeypatch):
+    sc = _reset(monkeypatch, tmp_path, env={
+        "THREADKEEPER_SPAWN__LOOP__CURATOR": "claud",
+    })
+    out = sc.summary_table("codex")
+    assert "curator" in out
+    assert "codex" in out
+    assert "THREADKEEPER_SPAWN__LOOP__CURATOR='claud'" in out
+    assert "not a supported CLI" in out
+
+
+def test_summary_table_warns_unused_model_key(tmp_path, monkeypatch):
+    sc = _reset(monkeypatch, tmp_path, env={
+        "THREADKEEPER_SPAWN__MODEL__CLAUD": "opus",
+        "THREADKEEPER_SPAWN__MODEL__CLAUDE": "sonnet",
+    })
+    out = sc.summary_table("claude")
+    assert "model=sonnet" in out
+    assert "THREADKEEPER_SPAWN__MODEL__CLAUD='opus'" in out
+    assert "not used by a supported CLI or startup role" in out

--- a/threadkeeper/config.py
+++ b/threadkeeper/config.py
@@ -14,12 +14,15 @@ Nested spawn config uses double-underscore notation:
 from __future__ import annotations
 
 import importlib.util
+import logging
 import os
 from pathlib import Path
 from typing import Annotated, Optional
 
 from pydantic import AliasChoices, BaseModel, Field, field_validator
 from pydantic_settings import BaseSettings, NoDecode, SettingsConfigDict
+
+logger = logging.getLogger(__name__)
 
 # ── env-file path resolved at module load so THREADKEEPER_ENV_FILE override works ──
 _ENV_FILE: str = os.environ.get(
@@ -379,9 +382,91 @@ class Settings(BaseSettings):
         return [str(a).strip().lower() for a in (v or []) if str(a).strip()]
 
 
+_EXTRA_THREADKEEPER_ENV_KEYS = {
+    # Consumed before Settings instantiation or by hook/app helper code.
+    "THREADKEEPER_ACTIVE_CLI",
+    "THREADKEEPER_AGENT_STATUS_COMMAND",
+    "THREADKEEPER_EGRESS_CONSUMER",
+    "THREADKEEPER_ENV_FILE",
+    "THREADKEEPER_EXTRA_SKILLS_DIRS",
+    "THREADKEEPER_FORCE_CID",
+    "THREADKEEPER_LESSONS",
+    "THREADKEEPER_MENUBAR_RESTART_RSS_MB",
+    "THREADKEEPER_PYTHON",
+    "THREADKEEPER_REPO",
+    "THREADKEEPER_SEARCH_PROXY_POLL_S",
+    "THREADKEEPER_SKILL_WATCH_INTERVAL_S",
+    "THREADKEEPER_STATE_DIR",
+    "THREADKEEPER_TZ",
+    "THREADKEEPER_VISIBLE_STATUS",
+}
+
+_THREADKEEPER_NESTED_ENV_KEYS = {
+    "THREADKEEPER_SPAWN__DEFAULT",
+    "THREADKEEPER_SPAWN__LOOP",
+    "THREADKEEPER_SPAWN__MODEL",
+}
+_THREADKEEPER_NESTED_ENV_PREFIXES = (
+    "THREADKEEPER_SPAWN__LOOP__",
+    "THREADKEEPER_SPAWN__MODEL__",
+)
+
+
+def _alias_strings(validation_alias) -> list[str]:
+    if validation_alias is None:
+        return []
+    if isinstance(validation_alias, str):
+        return [validation_alias]
+    choices = getattr(validation_alias, "choices", None)
+    if choices is None:
+        return []
+    return [choice for choice in choices if isinstance(choice, str)]
+
+
+def _known_threadkeeper_env_keys() -> set[str]:
+    known = set(_EXTRA_THREADKEEPER_ENV_KEYS)
+    for name, field in Settings.model_fields.items():
+        known.add(f"THREADKEEPER_{name.upper()}")
+        for alias in _alias_strings(field.validation_alias):
+            if alias.upper().startswith("THREADKEEPER_"):
+                known.add(alias.upper())
+    known.update(_THREADKEEPER_NESTED_ENV_KEYS)
+    return known
+
+
+def unknown_threadkeeper_env_keys(environ: Optional[dict] = None) -> list[str]:
+    """Return THREADKEEPER_* process-env keys that Settings will not consume."""
+    env = os.environ if environ is None else environ
+    known = _known_threadkeeper_env_keys()
+    unknown = []
+    for key in env:
+        upper = key.upper()
+        if not upper.startswith("THREADKEEPER_"):
+            continue
+        if upper in known:
+            continue
+        if any(
+            upper.startswith(prefix)
+            for prefix in _THREADKEEPER_NESTED_ENV_PREFIXES
+        ):
+            continue
+        unknown.append(key)
+    return sorted(unknown, key=str.upper)
+
+
+def _warn_unknown_threadkeeper_env_keys() -> None:
+    keys = unknown_threadkeeper_env_keys()
+    if keys:
+        logger.warning(
+            "Ignoring unknown THREADKEEPER_* env key(s): %s",
+            ", ".join(keys),
+        )
+
+
 # ── Instantiate ──────────────────────────────────────────────────────────────
 
 settings = Settings()
+_warn_unknown_threadkeeper_env_keys()
 
 
 # ── Compat shim: re-export all prior module-level names ──────────────────────
@@ -554,6 +639,7 @@ def reload_settings(env: Optional[dict] = None,
 
     old = _derive_constants(settings)
     settings = Settings()
+    _warn_unknown_threadkeeper_env_keys()
     new = _derive_constants(settings)
 
     globals().update(new)

--- a/threadkeeper/spawn_config.py
+++ b/threadkeeper/spawn_config.py
@@ -29,6 +29,32 @@ SUPPORTED_CLIS = ("claude", "codex", "antigravity", "gemini", "copilot")
 CLI_ALIASES = {
     "agy": "antigravity",
 }
+SUMMARY_ROLES = (
+    "archivist",
+    "shadow_observer",
+    "extract",
+    "candidate_reviewer",
+    "curator",
+    "dialectic_validator",
+    "evolve_researcher",
+    "evolve_reviewer",
+    "evolve_applier",
+    "probe_runner",
+)
+PREDEFINED_ROLE_PROMPTS = (
+    "skeptic",
+    "generator",
+    "critic",
+    "synthesizer",
+    "explorer",
+    "executor",
+)
+KNOWN_MODEL_KEYS = (
+    set(SUPPORTED_CLIS)
+    | set(CLI_ALIASES)
+    | set(SUMMARY_ROLES)
+    | set(PREDEFINED_ROLE_PROMPTS)
+)
 
 
 def _spawn():
@@ -84,20 +110,59 @@ def resolve_model(cli: str, role: str = "") -> str:
     return ""
 
 
+def _env_suffix(prefix: str, key: str) -> str:
+    return f"{prefix}{str(key).upper()}"
+
+
+def _spawn_warnings(active_cli: Optional[str]) -> list[str]:
+    """Warnings for configured spawn values that summary_table would ignore."""
+    sp = _spawn()
+    warnings = []
+    default_raw = _norm(sp.default)
+    default = _norm_cli(sp.default)
+    if default_raw and default_raw != "auto" and default not in SUPPORTED_CLIS:
+        warnings.append(
+            "  warning: THREADKEEPER_SPAWN__DEFAULT="
+            f"{sp.default!r} is not a supported CLI; falling back"
+        )
+
+    for role, raw_cli in sorted(sp.loop.items()):
+        cli_raw = _norm(raw_cli)
+        cli = _norm_cli(raw_cli)
+        if cli_raw and cli_raw != "auto" and cli not in SUPPORTED_CLIS:
+            warnings.append(
+                "  warning: "
+                f"{_env_suffix('THREADKEEPER_SPAWN__LOOP__', role)}="
+                f"{raw_cli!r} is not a supported CLI; falling back for that role"
+            )
+
+    active = _norm_cli(active_cli)
+    if active_cli and active not in SUPPORTED_CLIS:
+        warnings.append(
+            f"  warning: active CLI {active_cli!r} is not supported; falling back"
+        )
+
+    for key, model in sorted(sp.model.items()):
+        model_key = _norm_cli(key)
+        role_key = _norm(key)
+        if (
+            role_key
+            and model_key not in KNOWN_MODEL_KEYS
+            and role_key not in KNOWN_MODEL_KEYS
+        ):
+            warnings.append(
+                "  warning: "
+                f"{_env_suffix('THREADKEEPER_SPAWN__MODEL__', key)}="
+                f"{model!r} is not used by a supported CLI or startup role"
+            )
+    return warnings
+
+
 def summary_table(active_cli: Optional[str]) -> str:
     """Human-readable per-role assignment table for the startup validator."""
-    roles = (
-        "archivist",
-        "shadow_observer",
-        "extract",
-        "candidate_reviewer",
-        "curator",
-        "dialectic_validator",
-        "evolve_applier",
-    )
     sp = _spawn()
     out = []
-    for role in roles:
+    for role in SUMMARY_ROLES:
         chosen = resolve_agent(role, active_cli)
         if _norm_cli(sp.loop.get(role.lower())) in SUPPORTED_CLIS:
             src = "spawn config"
@@ -113,4 +178,5 @@ def summary_table(active_cli: Optional[str]) -> str:
         model = resolve_model(chosen, role)
         model_suffix = f" model={model}" if model else ""
         out.append(f"  {role:<18} → {chosen:<8}{model_suffix} ({src})")
+    out.extend(_spawn_warnings(active_cli))
     return "\n".join(out)


### PR DESCRIPTION
## Summary
- warn on unknown THREADKEEPER_* process-env keys during config import and hot reload
- surface unsupported spawn CLI overrides and unused spawn model keys in the spawn summary table
- document the fail-soft warning behavior in README, .env.example, architecture, roadmap, and changelog

## Tests
- `env -u THREADKEEPER_NO_EMBEDDINGS .venv/bin/python -m pytest -q` exited 0 (repo double-quiet setting hides the pass-count line)
- `env -u THREADKEEPER_NO_EMBEDDINGS .venv/bin/python -m pytest -o addopts='--strict-markers' -q` -> 989 passed, 1 skipped, 94 warnings

Closes #88