### PR TITLE
feat: verify auto-update PyPI provenance

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,6 +30,11 @@
 # THREADKEEPER_AUTO_UPDATE_INTERVAL_S=86400    # daily MCP self-update check; 0 disables
 # THREADKEEPER_AUTO_UPDATE_RESTART=true        # exit after applying an update so the host restarts on new code
 # THREADKEEPER_AUTO_UPDATE_TIMEOUT_S=600       # max seconds for git/pip update commands
+# THREADKEEPER_AUTO_UPDATE_VERIFY_PROVENANCE=true
+# THREADKEEPER_AUTO_UPDATE_PYPI_BASE_URL=https://pypi.org
+# THREADKEEPER_AUTO_UPDATE_EXPECTED_PUBLISHER_REPOSITORY=po4erk91/thread-keeper
+# THREADKEEPER_AUTO_UPDATE_EXPECTED_PUBLISHER_WORKFLOW=publish.yml
+# THREADKEEPER_AUTO_UPDATE_EXPECTED_PUBLISHER_ENVIRONMENT=pypi
 
 # ── skill updater ──
 # THREADKEEPER_SKILL_UPDATE_INTERVAL_S=302400  # twice weekly installed-skill update/mirror check; 0 disables

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -63,6 +63,8 @@ jobs:
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          attestations: true
 
   github-release:
     name: Create GitHub Release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ version bumps follow semver per the policy in
 
 ## [Unreleased]
 
+### Added
+
+- **PyPI provenance gate for auto-update (#44).** Packaged self-updates now
+  resolve the candidate PyPI release before running `pip`, require PyPI
+  Integrity API provenance from the expected GitHub Trusted Publisher
+  (`po4erk91/thread-keeper`, `publish.yml`, environment `pypi`), and verify the
+  attested filename/SHA-256 against PyPI metadata. Missing or mismatched
+  provenance records a refused `auto_update_pass` and keeps the current
+  known-good process running. New env knobs document the break-glass provenance
+  opt-out and the expected publisher identity.
+
 ## v0.14.0 — 2026-06-25
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -59,10 +59,11 @@ make it more than a memory store:
 Foreground MCP servers also run a daily self-update check by default. Source
 checkouts fast-forward their tracked git branch and reinstall the editable
 package; PyPI/pipx/venv installs run `pip install --upgrade` in the current
-interpreter environment. Dirty or diverged git checkouts are skipped rather
-than overwritten. Restarts are gated on install/setup success plus a subprocess
-import smoke check, so a broken update is recorded but the current server keeps
-running.
+interpreter environment only after the latest PyPI release files have matching
+Integrity API provenance from the expected GitHub Trusted Publisher. Dirty or
+diverged git checkouts are skipped rather than overwritten. Restarts are gated
+on install/setup success plus a subprocess import smoke check, so a broken or
+unverified update is recorded but the current server keeps running.
 
 They also run a twice-weekly installed-skill updater by default. It keeps all
 configured CLI skill roots in sync, adopts newer local copies installed into a
@@ -337,16 +338,25 @@ By default it checks once per day (`THREADKEEPER_AUTO_UPDATE_INTERVAL_S=86400`):
   editable package, and rerun `threadkeeper._setup`;
 - installed package: run `pip install --upgrade threadkeeper` or
   `threadkeeper[semantic]` in the current interpreter environment, preserving
-  semantic extras when they are already installed, then rerun setup when the
-  installed version changes.
+  semantic extras when they are already installed, but only after the candidate
+  PyPI release's non-yanked files have PyPI Integrity API provenance from the
+  expected GitHub Trusted Publisher (`po4erk91/thread-keeper`, `publish.yml`,
+  environment `pypi`), then rerun setup when the installed version changes.
 
-After a successful update, the daemon exits the current MCP process by default
-so the host can restart it on the new code. Before scheduling that exit, it
-imports `threadkeeper.server` in a subprocess; install/setup/import failures are
-recorded as `auto_update_pass` with `restart=suppressed`, and the current
-known-working process stays alive. Disable restart with
+Auto-update is standing consent for thread-keeper to fetch and run future
+maintainer code. A packaged update whose provenance is missing, whose publisher
+identity does not match policy, or whose attested subject digest does not match
+PyPI metadata is refused before `pip` runs and is recorded as
+`auto_update_pass` with `mode=pip` and `refused`. After a successful update, the
+daemon exits the current MCP process by default so the host can restart it on
+the new code. Before scheduling that exit, it imports `threadkeeper.server` in a
+subprocess; install/setup/import failures are recorded as `auto_update_pass`
+with `restart=suppressed`, and the current known-working process stays alive.
+Disable restart with
 `THREADKEEPER_AUTO_UPDATE_RESTART=0`, or disable the updater entirely with
-`THREADKEEPER_AUTO_UPDATE_INTERVAL_S=0`. If a packaged release needs manual
+`THREADKEEPER_AUTO_UPDATE_INTERVAL_S=0`. The provenance gate is on by default;
+`THREADKEEPER_AUTO_UPDATE_VERIFY_PROVENANCE=0` is a break-glass opt-out for
+private mirrors or disconnected installs. If a packaged release needs manual
 rollback, pin the previous version explicitly, for example
 `pip install threadkeeper==<previous>`. Each real check records an
 `auto_update_pass` event that appears in dashboard/status telemetry.
@@ -784,6 +794,11 @@ The most-used env knobs (full list in `threadkeeper/config.py`):
 | `THREADKEEPER_CONFIG_WATCH_INTERVAL_S` | 2 | hot-config reload: poll `~/.claude/settings.json` and re-apply changed env knobs in-process (no Claude Code restart); 0 disables |
 | `THREADKEEPER_CONFIG_WATCH_PATH` | "" (`~/.claude/settings.json`) | override the watched settings file |
 | `THREADKEEPER_SHADOW_REVIEW_INTERVAL_S` | 0 (off) | shadow daemon tick (s) |
+| `THREADKEEPER_AUTO_UPDATE_VERIFY_PROVENANCE` | true | require PyPI Integrity API provenance before packaged `pip` self-upgrades |
+| `THREADKEEPER_AUTO_UPDATE_PYPI_BASE_URL` | `https://pypi.org` | PyPI base URL used for JSON metadata and Integrity API checks |
+| `THREADKEEPER_AUTO_UPDATE_EXPECTED_PUBLISHER_REPOSITORY` | `po4erk91/thread-keeper` | expected GitHub Trusted Publisher repository for packaged self-upgrades |
+| `THREADKEEPER_AUTO_UPDATE_EXPECTED_PUBLISHER_WORKFLOW` | `publish.yml` | expected GitHub Actions workflow filename in PyPI provenance |
+| `THREADKEEPER_AUTO_UPDATE_EXPECTED_PUBLISHER_ENVIRONMENT` | `pypi` | expected GitHub Actions environment in PyPI provenance |
 | `THREADKEEPER_SHADOW_REVIEW_WINDOW_S` | 900 | sliding window for shadow scan (s) |
 | `THREADKEEPER_EXTRACT_INTERVAL_S` | 0 (off) | extract daemon tick (s); 600 = 10 min recommended |
 | `THREADKEEPER_EXTRACT_WINDOW_MIN` | 30 | sliding dialog window per extract pass (min) |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -25,6 +25,38 @@ until coordinated disclosure. Please include:
 
 ## Trust boundaries
 
+### Auto-update (future maintainer code → local execution)
+
+The foreground MCP server starts a daily auto-update daemon by default
+(`THREADKEEPER_AUTO_UPDATE_INTERVAL_S=86400`). Keeping it enabled is standing
+consent for thread-keeper to fetch future maintainer-published code and run it
+inside the local MCP server process. Disable that channel entirely with
+`THREADKEEPER_AUTO_UPDATE_INTERVAL_S=0`; disable only the post-update restart
+with `THREADKEEPER_AUTO_UPDATE_RESTART=0`.
+
+Mitigations for packaged PyPI installs:
+
+- Before invoking `pip install --upgrade`, the daemon resolves the latest PyPI
+  release metadata and queries PyPI's Integrity API for each non-yanked release
+  file's provenance.
+- The release is accepted only when provenance contains a GitHub Trusted
+  Publisher bundle for the configured identity
+  (`THREADKEEPER_AUTO_UPDATE_EXPECTED_PUBLISHER_REPOSITORY`,
+  `THREADKEEPER_AUTO_UPDATE_EXPECTED_PUBLISHER_WORKFLOW`,
+  `THREADKEEPER_AUTO_UPDATE_EXPECTED_PUBLISHER_ENVIRONMENT`; defaults:
+  `po4erk91/thread-keeper`, `publish.yml`, `pypi`).
+- The attestation statement must name the exact distribution filename and
+  SHA-256 digest from PyPI metadata. Missing provenance, mismatched publisher
+  identity, or digest mismatch refuses the update before `pip` runs, records an
+  `auto_update_pass`, and keeps the current process running.
+- `THREADKEEPER_AUTO_UPDATE_VERIFY_PROVENANCE=0` is a break-glass opt-out for
+  private mirrors or disconnected environments. Leave it enabled for normal PyPI
+  installs.
+
+Editable git checkouts are still treated as developer-controlled working trees:
+dirty/diverged checkouts are skipped, but signed git tag/commit enforcement is
+not yet implemented for that path.
+
 ### Autonomous GitHub writers (stored / issue content → public GitHub)
 
 The evolve reviewer and evolve applier can run privileged children that edit the

--- a/apps/macos-agent-status/ThreadKeeperAgentStatus.swift
+++ b/apps/macos-agent-status/ThreadKeeperAgentStatus.swift
@@ -249,6 +249,14 @@ private let envSettingDefinitions: [EnvSettingDefinition] = [
         defaultValue: "true",
         kind: .toggle
     ),
+    EnvSettingDefinition(
+        group: "Core",
+        key: "THREADKEEPER_AUTO_UPDATE_VERIFY_PROVENANCE",
+        title: "Verify PyPI provenance",
+        detail: "Requires trusted PyPI attestations before packaged self-updates.",
+        defaultValue: "true",
+        kind: .toggle
+    ),
 
     EnvSettingDefinition(
         group: "Learning Loops",

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -101,12 +101,22 @@ Foreground parent MCP sessions also start `auto_update.py` when
 is single-flight across live servers, records `events.kind='auto_update_pass'`,
 and applies the install-appropriate update path: clean git checkouts fetch and
 fast-forward their tracked branch, then reinstall editable; package installs run
-`pip install --upgrade` in the current interpreter environment. Successful
-updates optionally exit the current MCP process (`THREADKEEPER_AUTO_UPDATE_RESTART`
-default true) so the host reconnects to the new code, but only after setup and a
-subprocess import smoke check both pass. Install/setup/import failures are
-recorded on the `auto_update_pass` event with `restart=suppressed`, and the
-already-running process stays alive on its current in-memory code.
+`pip install --upgrade` in the current interpreter environment only after the
+latest PyPI release's non-yanked files pass the provenance gate. That gate
+queries PyPI JSON metadata plus the Integrity API, requires a Trusted Publisher
+bundle for `po4erk91/thread-keeper` from `publish.yml` in environment `pypi`,
+and checks the attested subject filename/SHA-256 against PyPI metadata before
+`pip` is invoked. Missing provenance, mismatched publisher identity, or digest
+mismatch returns `refused mode=pip ...` and records an `auto_update_pass` without
+restarting. Successful updates optionally exit the current MCP process
+(`THREADKEEPER_AUTO_UPDATE_RESTART` default true) so the host reconnects to the
+new code, but only after setup and a subprocess import smoke check both pass.
+Install/setup/import failures are recorded on the `auto_update_pass` event with
+`restart=suppressed`, and the already-running process stays alive on its current
+in-memory code. Set `THREADKEEPER_AUTO_UPDATE_INTERVAL_S=0` to opt out of the
+standing-consent update channel entirely; the provenance gate itself is
+controlled by `THREADKEEPER_AUTO_UPDATE_VERIFY_PROVENANCE` for break-glass
+mirrors.
 The legacy monolith `server.py` at the repo root was removed in May 2026 — the
 runtime is fully on the package.
 
@@ -1158,6 +1168,11 @@ unsupported CLI overrides still fall through to the next priority, and
 | `THREADKEEPER_MEMORY_GUARD_POLL_S` | 30 | server RSS guard tick; 0 disables |
 | `THREADKEEPER_MEMORY_GUARD_WARN_MB` | 1536 | notify/log above this server RSS |
 | `THREADKEEPER_MEMORY_GUARD_KILL_MB` | 3072 | SIGTERM server above this RSS; 0 disables killing |
+| `THREADKEEPER_AUTO_UPDATE_VERIFY_PROVENANCE` | true | require PyPI Integrity API provenance before packaged `pip` self-upgrades |
+| `THREADKEEPER_AUTO_UPDATE_PYPI_BASE_URL` | `https://pypi.org` | PyPI base URL used for JSON metadata and Integrity API checks |
+| `THREADKEEPER_AUTO_UPDATE_EXPECTED_PUBLISHER_REPOSITORY` | `po4erk91/thread-keeper` | expected GitHub Trusted Publisher repository for packaged self-upgrades |
+| `THREADKEEPER_AUTO_UPDATE_EXPECTED_PUBLISHER_WORKFLOW` | `publish.yml` | expected GitHub Actions workflow filename in PyPI provenance |
+| `THREADKEEPER_AUTO_UPDATE_EXPECTED_PUBLISHER_ENVIRONMENT` | `pypi` | expected GitHub Actions environment in PyPI provenance |
 | `THREADKEEPER_MEMORY_GUARD_AGG_WARN_MB` | 2048 | notify/request trim above combined server RSS |
 | `THREADKEEPER_MEMORY_GUARD_AGG_KILL_MB` | 3072 | retire stale idle servers under aggregate pressure |
 | `THREADKEEPER_MEMORY_GUARD_RECLAIM_MB` | 1024 | local RSS floor before warn-triggered self trim |

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -8,7 +8,9 @@ the version in `pyproject.toml` and dispatches
 matching `v*` still trigger `publish.yml` directly.
 
 PyPI upload uses Trusted Publisher OIDC — no PyPI API token is stored in
-the repository.
+the repository. The publish job explicitly uploads PyPI digital attestations
+(`attestations: true`), which is what the packaged auto-updater verifies before
+running future `pip install --upgrade` self-updates.
 
 ## One-time setup
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -486,14 +486,14 @@ Follow-up gaps from the 2026-06-17 audit:
   and reviewer/applier mutual exclusion or `git worktree` isolation so concurrent
   PR-producing children don't race on `.git/index.lock` or contaminate PR diffs
   with unrelated working-tree WIP (#43).
-- Auto-update payload integrity/provenance: the on-by-default daily pip/git
-  self-update installs and runs new code with **no version pin, hash, or PyPI
-  attestation/signed-tag verification**, then restarts on it. A compromised
-  release auto-propagates to every install within ~24h. Distinct from #19
-  (closed reliability smoke-check gate — a malicious-but-importable release
-  passes that) and #22 (GitHub-writing daemons). Verify provenance before
-  upgrade and document auto-update as standing consent to run maintainer code
-  (#44).
+- ✅ DONE (#44). Auto-update payload integrity/provenance: packaged PyPI
+  self-updates now verify PyPI Integrity API provenance before invoking `pip`,
+  require the expected GitHub Trusted Publisher identity, check the attested
+  filename/SHA-256 against PyPI metadata, and refuse missing/mismatched
+  provenance without restart. Docs now state that auto-update is standing
+  consent to run future maintainer code and point to the opt-out. Signed
+  git tag/commit enforcement remains a later hardening slice for editable
+  checkouts.
 
 Deep code-audit pass (2026-06-17, evolve_reviewer second pass; each finding
 verified at the cited file:line, deduplicated against the issues above):

--- a/tests/test_auto_update.py
+++ b/tests/test_auto_update.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
+import base64
+import json
 import sys
 import time
 from pathlib import Path
 from types import SimpleNamespace
+from urllib.error import HTTPError
 
 
 def _bootstrap(tmp_path, monkeypatch, *, interval="86400", disable_bg="1"):
@@ -40,6 +43,72 @@ def _bootstrap(tmp_path, monkeypatch, *, interval="86400", disable_bg="1"):
     from threadkeeper import auto_update, db
 
     return {"auto_update": auto_update, "db": db}
+
+
+def _release_metadata(version="0.9.3", filename="threadkeeper-0.9.3.tar.gz"):
+    return {
+        "info": {"version": version},
+        "releases": {
+            version: [
+                {
+                    "filename": filename,
+                    "digests": {"sha256": "a" * 64},
+                    "yanked": False,
+                }
+            ]
+        },
+    }
+
+
+def _provenance(
+    filename="threadkeeper-0.9.3.tar.gz",
+    sha256="a" * 64,
+    *,
+    repository="po4erk91/thread-keeper",
+    workflow="publish.yml",
+    environment="pypi",
+):
+    statement = {
+        "_type": "https://in-toto.io/Statement/v1",
+        "subject": [
+            {
+                "name": filename,
+                "digest": {"sha256": sha256},
+            }
+        ],
+        "predicateType": "https://docs.pypi.org/attestations/publish/v1",
+        "predicate": None,
+    }
+    encoded_statement = base64.b64encode(
+        json.dumps(statement).encode("utf-8")
+    ).decode("ascii")
+    return {
+        "version": 1,
+        "attestation_bundles": [
+            {
+                "publisher": {
+                    "kind": "GitHub",
+                    "repository": repository,
+                    "workflow": workflow,
+                    "environment": environment,
+                    "claims": None,
+                },
+                "attestations": [
+                    {
+                        "version": 1,
+                        "envelope": {
+                            "statement": encoded_statement,
+                            "signature": "sig",
+                        },
+                        "verification_material": {
+                            "certificate": "cert",
+                            "transparency_entries": [],
+                        },
+                    }
+                ],
+            }
+        ],
+    }
 
 
 def test_disabled_without_force(tmp_path, monkeypatch):
@@ -232,6 +301,16 @@ def test_pip_update_runs_setup_when_version_changes(tmp_path, monkeypatch):
 
     monkeypatch.setattr(pkg["auto_update"], "_installed_version", lambda: next(versions))
     monkeypatch.setattr(pkg["auto_update"], "_package_spec", lambda: "threadkeeper")
+    monkeypatch.setattr(
+        pkg["auto_update"],
+        "_pypi_project_metadata",
+        lambda: _release_metadata(),
+    )
+    monkeypatch.setattr(
+        pkg["auto_update"],
+        "_fetch_pypi_provenance",
+        lambda version, filename: _provenance(filename),
+    )
     monkeypatch.setattr(pkg["auto_update"], "_run", fake_run)
     monkeypatch.setattr(pkg["auto_update"], "_run_setup", lambda: " setup=ok")
 
@@ -241,6 +320,109 @@ def test_pip_update_runs_setup_when_version_changes(tmp_path, monkeypatch):
     assert calls == [
         [sys.executable, "-m", "pip", "install", "--upgrade", "threadkeeper"]
     ]
+
+
+def test_pip_update_refuses_missing_provenance_and_suppresses_restart(
+    tmp_path,
+    monkeypatch,
+):
+    pkg = _bootstrap(tmp_path, monkeypatch)
+    scheduled = {"value": False}
+    pip_calls: list[list[str]] = []
+
+    def fake_run(args, *, cwd=None, timeout=None):
+        pip_calls.append(args)
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    def missing_provenance(version, filename):
+        raise HTTPError("https://pypi.org/provenance", 404, "Not Found", None, None)
+
+    monkeypatch.setattr(pkg["auto_update"], "_is_git_checkout", lambda repo: False)
+    monkeypatch.setattr(pkg["auto_update"], "_installed_version", lambda: "0.9.2")
+    monkeypatch.setattr(
+        pkg["auto_update"],
+        "_pypi_project_metadata",
+        lambda: _release_metadata(),
+    )
+    monkeypatch.setattr(
+        pkg["auto_update"],
+        "_fetch_pypi_provenance",
+        missing_provenance,
+    )
+    monkeypatch.setattr(pkg["auto_update"], "_run", fake_run)
+    monkeypatch.setattr(
+        pkg["auto_update"],
+        "_schedule_restart",
+        lambda: scheduled.__setitem__("value", True),
+    )
+
+    out = pkg["auto_update"].run_auto_update_pass(
+        force=True,
+        restart_on_update=True,
+    )
+
+    assert out == (
+        "refused mode=pip version=0.9.3 "
+        "reason=provenance_missing file=threadkeeper-0.9.3.tar.gz"
+    )
+    assert scheduled["value"] is False
+    assert pip_calls == []
+    row = pkg["db"].get_db().execute(
+        "SELECT summary FROM events WHERE kind='auto_update_pass' "
+        "ORDER BY id DESC LIMIT 1"
+    ).fetchone()
+    assert row is not None
+    assert row["summary"] == out
+
+
+def test_pip_update_refuses_mismatched_provenance(tmp_path, monkeypatch):
+    pkg = _bootstrap(tmp_path, monkeypatch)
+    scheduled = {"value": False}
+    pip_calls: list[list[str]] = []
+
+    monkeypatch.setattr(pkg["auto_update"], "_is_git_checkout", lambda repo: False)
+    monkeypatch.setattr(pkg["auto_update"], "_installed_version", lambda: "0.9.2")
+    monkeypatch.setattr(
+        pkg["auto_update"],
+        "_pypi_project_metadata",
+        lambda: _release_metadata(),
+    )
+    monkeypatch.setattr(
+        pkg["auto_update"],
+        "_fetch_pypi_provenance",
+        lambda version, filename: _provenance(
+            filename,
+            repository="attacker/thread-keeper",
+        ),
+    )
+    monkeypatch.setattr(
+        pkg["auto_update"],
+        "_run",
+        lambda args, *, cwd=None, timeout=None: pip_calls.append(args),
+    )
+    monkeypatch.setattr(
+        pkg["auto_update"],
+        "_schedule_restart",
+        lambda: scheduled.__setitem__("value", True),
+    )
+
+    out = pkg["auto_update"].run_auto_update_pass(
+        force=True,
+        restart_on_update=True,
+    )
+
+    assert out == (
+        "refused mode=pip version=0.9.3 "
+        "reason=publisher_mismatch file=threadkeeper-0.9.3.tar.gz"
+    )
+    assert scheduled["value"] is False
+    assert pip_calls == []
+    row = pkg["db"].get_db().execute(
+        "SELECT summary FROM events WHERE kind='auto_update_pass' "
+        "ORDER BY id DESC LIMIT 1"
+    ).fetchone()
+    assert row is not None
+    assert row["summary"] == out
 
 
 def test_daemon_does_not_start_when_background_daemons_disabled(tmp_path, monkeypatch):

--- a/tests/test_config_settings.py
+++ b/tests/test_config_settings.py
@@ -36,6 +36,11 @@ def test_defaults_match(monkeypatch):
     assert c.SPAWN_COST_BUDGET_USD == 0.0
     assert c.AUTO_UPDATE_INTERVAL_S == 86400
     assert c.AUTO_UPDATE_RESTART is True
+    assert c.AUTO_UPDATE_VERIFY_PROVENANCE is True
+    assert c.AUTO_UPDATE_PYPI_BASE_URL == "https://pypi.org"
+    assert c.AUTO_UPDATE_EXPECTED_PUBLISHER_REPOSITORY == "po4erk91/thread-keeper"
+    assert c.AUTO_UPDATE_EXPECTED_PUBLISHER_WORKFLOW == "publish.yml"
+    assert c.AUTO_UPDATE_EXPECTED_PUBLISHER_ENVIRONMENT == "pypi"
     assert c.SKILL_UPDATE_INTERVAL_S == 302400
     assert c.SKILL_UPDATE_INFER_SOURCES is True
     assert str(c.DB_PATH).endswith("/.threadkeeper/db.sqlite")
@@ -107,8 +112,13 @@ def test_all_exported_names_present(monkeypatch):
     required = [
         "AUTO_REVIEW_ENABLED",
         "AUTO_UPDATE_INTERVAL_S",
+        "AUTO_UPDATE_EXPECTED_PUBLISHER_ENVIRONMENT",
+        "AUTO_UPDATE_EXPECTED_PUBLISHER_REPOSITORY",
+        "AUTO_UPDATE_EXPECTED_PUBLISHER_WORKFLOW",
+        "AUTO_UPDATE_PYPI_BASE_URL",
         "AUTO_UPDATE_RESTART",
         "AUTO_UPDATE_TIMEOUT_S",
+        "AUTO_UPDATE_VERIFY_PROVENANCE",
         "BACKGROUND_DAEMONS_ALLOWED",
         "BRIEF_LEAN",
         "BRIEF_NO_THREAD_NUDGE",

--- a/threadkeeper/assets/macos-agent-status/ThreadKeeperAgentStatus.swift
+++ b/threadkeeper/assets/macos-agent-status/ThreadKeeperAgentStatus.swift
@@ -249,6 +249,14 @@ private let envSettingDefinitions: [EnvSettingDefinition] = [
         defaultValue: "true",
         kind: .toggle
     ),
+    EnvSettingDefinition(
+        group: "Core",
+        key: "THREADKEEPER_AUTO_UPDATE_VERIFY_PROVENANCE",
+        title: "Verify PyPI provenance",
+        detail: "Requires trusted PyPI attestations before packaged self-updates.",
+        defaultValue: "true",
+        kind: .toggle
+    ),
 
     EnvSettingDefinition(
         group: "Learning Loops",

--- a/threadkeeper/auto_update.py
+++ b/threadkeeper/auto_update.py
@@ -11,9 +11,12 @@ restart it against the newly installed code.
 """
 from __future__ import annotations
 
+import base64
 from contextlib import contextmanager
+from dataclasses import dataclass
 import importlib.metadata
 import importlib.util
+import json
 import logging
 import os
 from pathlib import Path
@@ -21,12 +24,20 @@ import subprocess
 import sys
 import threading
 import time
-from typing import Iterator
+from typing import Any, Iterator
+from urllib.error import HTTPError, URLError
+from urllib.parse import quote
+from urllib.request import Request, urlopen
 
 from .config import (
+    AUTO_UPDATE_EXPECTED_PUBLISHER_ENVIRONMENT,
+    AUTO_UPDATE_EXPECTED_PUBLISHER_REPOSITORY,
+    AUTO_UPDATE_EXPECTED_PUBLISHER_WORKFLOW,
     AUTO_UPDATE_INTERVAL_S,
+    AUTO_UPDATE_PYPI_BASE_URL,
     AUTO_UPDATE_RESTART,
     AUTO_UPDATE_TIMEOUT_S,
+    AUTO_UPDATE_VERIFY_PROVENANCE,
     BACKGROUND_DAEMONS_ALLOWED,
     DB_PATH,
 )
@@ -38,8 +49,21 @@ logger = logging.getLogger(__name__)
 PACKAGE_NAME = "threadkeeper"
 SMOKE_IMPORT_CODE = "import threadkeeper; from threadkeeper import server"
 FAILED_UPDATE_MARKERS = (" install=failed", " setup=failed", " smoke=failed")
+PYPI_JSON_ACCEPT = "application/json"
+PYPI_INTEGRITY_ACCEPT = "application/vnd.pypi.integrity.v1+json"
+ATTESTATION_PREDICATE_TYPES = {
+    "https://docs.pypi.org/attestations/publish/v1",
+    "https://slsa.dev/provenance/v1",
+}
 _started = False
 _restart_scheduled = False
+
+
+@dataclass(frozen=True)
+class _ProvenanceDecision:
+    allowed: bool
+    version: str = ""
+    reason: str = ""
 
 
 def _run(
@@ -162,6 +186,213 @@ def _short(text: str, limit: int = 160) -> str:
     return " ".join((text or "").split())[:limit]
 
 
+def _pypi_url(path: str) -> str:
+    return f"{AUTO_UPDATE_PYPI_BASE_URL.rstrip('/')}/{path.lstrip('/')}"
+
+
+def _fetch_json(url: str, *, accept: str = PYPI_JSON_ACCEPT) -> dict[str, Any]:
+    request = Request(
+        url,
+        headers={
+            "Accept": accept,
+            "User-Agent": "threadkeeper-auto-update",
+        },
+    )
+    timeout = min(30, AUTO_UPDATE_TIMEOUT_S)
+    with urlopen(request, timeout=timeout) as response:  # noqa: S310 - fixed PyPI URL
+        payload = response.read()
+    data = json.loads(payload.decode("utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError("expected JSON object")
+    return data
+
+
+def _pypi_project_metadata() -> dict[str, Any]:
+    return _fetch_json(_pypi_url(f"pypi/{quote(PACKAGE_NAME)}/json"))
+
+
+def _release_files(metadata: dict[str, Any], version: str) -> list[dict[str, Any]]:
+    releases = metadata.get("releases")
+    files = (
+        releases.get(version)
+        if isinstance(releases, dict)
+        else None
+    )
+    if not files:
+        files = metadata.get("urls", [])
+    if not isinstance(files, list):
+        return []
+    return [
+        f for f in files
+        if isinstance(f, dict) and not bool(f.get("yanked"))
+    ]
+
+
+def _fetch_pypi_provenance(version: str, filename: str) -> dict[str, Any]:
+    project = quote(PACKAGE_NAME)
+    ver = quote(version, safe="")
+    name = quote(filename, safe="")
+    return _fetch_json(
+        _pypi_url(f"integrity/{project}/{ver}/{name}/provenance"),
+        accept=PYPI_INTEGRITY_ACCEPT,
+    )
+
+
+def _publisher_matches_expected(publisher: Any) -> bool:
+    if not isinstance(publisher, dict):
+        return False
+    if publisher.get("kind") != "GitHub":
+        return False
+    expected_repo = AUTO_UPDATE_EXPECTED_PUBLISHER_REPOSITORY.strip().lower()
+    actual_repo = str(publisher.get("repository") or "").strip().lower()
+    if not expected_repo or actual_repo != expected_repo:
+        return False
+    expected_workflow = AUTO_UPDATE_EXPECTED_PUBLISHER_WORKFLOW.strip()
+    if expected_workflow and publisher.get("workflow") != expected_workflow:
+        return False
+    expected_environment = AUTO_UPDATE_EXPECTED_PUBLISHER_ENVIRONMENT.strip()
+    if expected_environment and publisher.get("environment") != expected_environment:
+        return False
+    return True
+
+
+def _decode_attestation_statement(attestation: dict[str, Any]) -> dict[str, Any]:
+    envelope = attestation.get("envelope")
+    if not isinstance(envelope, dict):
+        raise ValueError("missing envelope")
+    raw_statement = envelope.get("statement")
+    if not isinstance(raw_statement, str) or not raw_statement:
+        raise ValueError("missing statement")
+    decoded = base64.b64decode(raw_statement, validate=True)
+    statement = json.loads(decoded.decode("utf-8"))
+    if not isinstance(statement, dict):
+        raise ValueError("statement_not_object")
+    return statement
+
+
+def _attestation_matches_file(
+    attestation: dict[str, Any],
+    *,
+    filename: str,
+    sha256: str,
+) -> bool:
+    try:
+        statement = _decode_attestation_statement(attestation)
+    except Exception:
+        return False
+    if statement.get("predicateType") not in ATTESTATION_PREDICATE_TYPES:
+        return False
+    subject = statement.get("subject")
+    if not isinstance(subject, list) or len(subject) != 1:
+        return False
+    item = subject[0]
+    if not isinstance(item, dict) or item.get("name") != filename:
+        return False
+    digest = item.get("digest")
+    if not isinstance(digest, dict):
+        return False
+    return str(digest.get("sha256") or "").lower() == sha256.lower()
+
+
+def _provenance_matches_file(
+    provenance: dict[str, Any],
+    *,
+    filename: str,
+    sha256: str,
+) -> tuple[bool, str]:
+    if provenance.get("version") != 1:
+        return False, "provenance_version"
+    bundles = provenance.get("attestation_bundles")
+    if not isinstance(bundles, list) or not bundles:
+        return False, "provenance_empty"
+
+    saw_expected_publisher = False
+    for bundle in bundles:
+        if not isinstance(bundle, dict):
+            continue
+        if not _publisher_matches_expected(bundle.get("publisher")):
+            continue
+        saw_expected_publisher = True
+        attestations = bundle.get("attestations")
+        if not isinstance(attestations, list):
+            continue
+        for attestation in attestations:
+            if isinstance(attestation, dict) and _attestation_matches_file(
+                attestation,
+                filename=filename,
+                sha256=sha256,
+            ):
+                return True, "ok"
+
+    if saw_expected_publisher:
+        return False, "attestation_mismatch"
+    return False, "publisher_mismatch"
+
+
+def _verify_pypi_release_provenance(old_version: str) -> _ProvenanceDecision:
+    try:
+        metadata = _pypi_project_metadata()
+    except (HTTPError, URLError, OSError, TimeoutError, ValueError, json.JSONDecodeError) as e:
+        return _ProvenanceDecision(
+            False,
+            old_version,
+            f"metadata_unavailable err={_short(str(e))}",
+        )
+
+    info = metadata.get("info")
+    version = str((info or {}).get("version") or "").strip() if isinstance(info, dict) else ""
+    if not version:
+        return _ProvenanceDecision(False, old_version, "metadata_missing_version")
+    if old_version != "unknown" and version == old_version:
+        return _ProvenanceDecision(True, version, "already_current")
+
+    files = _release_files(metadata, version)
+    if not files:
+        return _ProvenanceDecision(False, version, "release_files_missing")
+
+    for file_info in files:
+        filename = str(file_info.get("filename") or "").strip()
+        digests = file_info.get("digests")
+        sha256 = (
+            str((digests or {}).get("sha256") or "").strip().lower()
+            if isinstance(digests, dict)
+            else ""
+        )
+        if not filename:
+            return _ProvenanceDecision(False, version, "release_file_missing_name")
+        if not sha256:
+            return _ProvenanceDecision(
+                False,
+                version,
+                f"release_file_missing_sha256 file={filename}",
+            )
+
+        try:
+            provenance = _fetch_pypi_provenance(version, filename)
+        except HTTPError as e:
+            if e.code == 404:
+                reason = "provenance_missing"
+            else:
+                reason = f"provenance_http_{e.code}"
+            return _ProvenanceDecision(False, version, f"{reason} file={filename}")
+        except (URLError, OSError, TimeoutError, ValueError, json.JSONDecodeError) as e:
+            return _ProvenanceDecision(
+                False,
+                version,
+                f"provenance_unavailable file={filename} err={_short(str(e))}",
+            )
+
+        ok, reason = _provenance_matches_file(
+            provenance,
+            filename=filename,
+            sha256=sha256,
+        )
+        if not ok:
+            return _ProvenanceDecision(False, version, f"{reason} file={filename}")
+
+    return _ProvenanceDecision(True, version, "verified")
+
+
 def _git_stdout(repo: Path, *args: str, timeout: int = 60) -> tuple[int, str, str]:
     res = _run(["git", "-C", str(repo), *args], timeout=timeout)
     return res.returncode, res.stdout.strip(), res.stderr.strip()
@@ -280,6 +511,17 @@ def _update_git_checkout(repo: Path) -> str:
 
 def _update_installed_package() -> str:
     old_version = _installed_version()
+    if AUTO_UPDATE_VERIFY_PROVENANCE:
+        provenance = _verify_pypi_release_provenance(old_version)
+        if not provenance.allowed:
+            version = provenance.version or old_version
+            return (
+                f"refused mode=pip version={version} "
+                f"reason={_short(provenance.reason)}"
+            )
+        if provenance.version and provenance.version == old_version:
+            return f"no_update mode=pip version={old_version}"
+
     install = _run(
         [sys.executable, "-m", "pip", "install", "--upgrade", _package_spec()],
         timeout=AUTO_UPDATE_TIMEOUT_S,

--- a/threadkeeper/config.py
+++ b/threadkeeper/config.py
@@ -116,6 +116,11 @@ class Settings(BaseSettings):
     auto_update_interval_s: float = 86400.0
     auto_update_restart: bool = True
     auto_update_timeout_s: int = 600
+    auto_update_verify_provenance: bool = True
+    auto_update_pypi_base_url: str = "https://pypi.org"
+    auto_update_expected_publisher_repository: str = "po4erk91/thread-keeper"
+    auto_update_expected_publisher_workflow: str = "publish.yml"
+    auto_update_expected_publisher_environment: str = "pypi"
 
     # ── Skill update daemon ─────────────────────────────────────────────────
     # Twice weekly by default. It syncs installed skills across known CLI roots
@@ -529,6 +534,17 @@ def _derive_constants(s: "Settings") -> dict:
         "AUTO_UPDATE_TIMEOUT_S": s.auto_update_timeout_s,
         "SKILL_UPDATE_INTERVAL_S": s.skill_update_interval_s,
         "SKILL_UPDATE_TIMEOUT_S": s.skill_update_timeout_s,
+        "AUTO_UPDATE_VERIFY_PROVENANCE": s.auto_update_verify_provenance,
+        "AUTO_UPDATE_PYPI_BASE_URL": s.auto_update_pypi_base_url,
+        "AUTO_UPDATE_EXPECTED_PUBLISHER_REPOSITORY": (
+            s.auto_update_expected_publisher_repository
+        ),
+        "AUTO_UPDATE_EXPECTED_PUBLISHER_WORKFLOW": (
+            s.auto_update_expected_publisher_workflow
+        ),
+        "AUTO_UPDATE_EXPECTED_PUBLISHER_ENVIRONMENT": (
+            s.auto_update_expected_publisher_environment
+        ),
         "SKILL_UPDATE_SOURCES": s.skill_update_sources,
         "SKILL_UPDATE_INFER_SOURCES": s.skill_update_infer_sources,
         "SKILL_UPDATE_ALLOW_UNTRACKED_OVERWRITE": (


### PR DESCRIPTION
## Summary
- Gate packaged auto-updates on PyPI Integrity API provenance for the expected GitHub Trusted Publisher before `pip` runs.
- Refuse missing or mismatched provenance, record the refusal, and keep the current process running without restart.
- Document auto-update as standing consent, add policy knobs, and make PyPI publish attestations explicit.

## Tests
- `env -u THREADKEEPER_NO_EMBEDDINGS .venv/bin/python -m pytest -q` exited 0; this repo's double-quiet config hides the pass-count line.
- `env -u THREADKEEPER_NO_EMBEDDINGS .venv/bin/python -m pytest -o addopts='--strict-markers' -q` -> 1030 passed, 1 skipped, 94 warnings.

Closes #44