### PR TITLE
feat: add task retention and spool GC

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -62,6 +62,8 @@
 # THREADKEEPER_SPAWN_BUDGET_POLL_S=10
 # THREADKEEPER_SPAWN_TOKEN_BUDGET=0             # 0 disables daily token ceiling; compares recorded 24h task tokens
 # THREADKEEPER_SPAWN_COST_BUDGET_USD=0          # 0 disables daily dollar ceiling; compares recorded 24h task cost_usd
+# THREADKEEPER_TASK_RETENTION_DAYS=30           # consolidate() keeps ended tasks within this age; 0 disables the age bound
+# THREADKEEPER_TASK_RETENTION_COUNT=1000        # consolidate() also keeps this many newest ended tasks; 0 disables the count bound
 # THREADKEEPER_MENUBAR_AUTO_LAUNCH=true       # macOS: auto install/launch status menu-bar app on MCP startup
 
 # ── memory guard ──

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ version bumps follow semver per the policy in
 
 ## [Unreleased]
 
+### Added
+
+- **Task retention and spool GC (#42).** `consolidate()` now reports and
+  applies retention for ended `tasks` rows using
+  `THREADKEEPER_TASK_RETENTION_DAYS` (30d default) and
+  `THREADKEEPER_TASK_RETENTION_COUNT` (1000 default), never prunes live
+  `ended_at IS NULL` rows, and garbage-collects orphan task spool files
+  (`.log`, `.stdin.txt`, `.command`) from `THREADKEEPER_TASK_LOG_DIR`.
+  Headless spawn `.log` files are created owner-only (`0600`) to match stdin
+  prompt spools.
+
 ## v0.14.0 — 2026-06-25
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -898,7 +898,13 @@ them with `dry_run=False` to apply:
 
 - **`consolidate()`** — dedup near-identical notes (intra-thread cosine
   ≥ 0.95), deduplicate verbatim quotes, demote untouched-active threads
-  to `idle` after 30 days, release orphaned thread claims.
+  to `idle` after 30 days, release orphaned thread claims, prune ended
+  `tasks` rows outside the configured retention window, and remove orphaned
+  task spool files (`.log`, `.stdin.txt`, `.command`) from
+  `TASK_LOG_DIR`. Live tasks (`ended_at IS NULL`) are never pruned.
+  `THREADKEEPER_TASK_RETENTION_DAYS` defaults to `30` and
+  `THREADKEEPER_TASK_RETENTION_COUNT` defaults to `1000`; a row is kept if it
+  is protected by either bound. Set either knob to `0` to disable that bound.
 - **`validate_threads()`** — heuristic triage of active threads with
   four categories (first match wins per thread):
   - `no_notes_old` — active with zero notes ≥ 7 days → close as abandoned.
@@ -968,6 +974,11 @@ fallback to Python-side cosine when the extension is missing.
 One file. Backup = `cp`. Wipe memory = `rm`.
 
 Hooks and small runtime artifacts: `~/.threadkeeper/hooks/`.
+
+Spawn task spool files live in `THREADKEEPER_TASK_LOG_DIR` (default
+`/tmp/thread-keeper-tasks`). `spawn()` creates captured headless `.log` files
+with mode `0600`, matching stdin prompt spools. `consolidate()` garbage-collects
+task spool files once their task row is no longer retained.
 
 ---
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -155,7 +155,12 @@ In addition: `probe_results`/`reliability`, `concepts`, `edges`,
 `extract_candidates`, `distillates`/`votes`, `tasks` (spawned children:
 `started_at`/`ended_at`/`duration_s`, `return_code`, RSS, and optional
 `tokens_in`/`tokens_out`/`tokens_total`/`cost_usd` captured from CLI usage
-trailers), `shadow_review_pass` (as event.kind).
+trailers), `shadow_review_pass` (as event.kind). Ended `tasks` rows are
+bounded by `consolidate()`: it retains rows protected by either
+`THREADKEEPER_TASK_RETENTION_DAYS` (30 by default) or
+`THREADKEEPER_TASK_RETENTION_COUNT` (1000 by default), never deletes live
+`ended_at IS NULL` rows, and garbage-collects task spool files whose task row is
+no longer retained.
 
 ## Identity and self-cid
 
@@ -484,7 +489,9 @@ optional 24h spawned-child token and dollar ceilings when
   output, parses final JSON or human-readable usage trailers when present,
   stores `tokens_in`, `tokens_out`, `tokens_total`, and `cost_usd`, and always
   stores `duration_s` from the task timestamps. If no usage trailer is emitted,
-  the row still has wall-time for cost/benefit triage.
+  the row still has wall-time for cost/benefit triage. Captured `.log` files
+  in `THREADKEEPER_TASK_LOG_DIR` are created owner-only (`0600`), matching the
+  stdin prompt spool.
 - Daemon ticks update real RSS via `ps`; dead root pids → `ended_at`.
 - Visible spawns (Terminal.app) persist `pid=0`; the daemon resolves their live
   pid from the `--session-id <cid>` the child carries in `ps` argv and measures

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -475,12 +475,12 @@ Follow-up gaps from the 2026-06-17 audit:
   records the slug only; `lessons.md` is not version-controlled), and no
   destructive-action telemetry in `mp_dashboard`. Add a snapshot/restore safety
   net + structured prune/consolidate counts (#40).
-- Retention/GC for the `tasks` table and `TASK_LOG_DIR` spool files — every
-  spawn leaves a permanent `tasks` row (full `prompt`) plus
-  `.log`/`.stdin.txt`/`.command` files that nothing prunes; `tasks.prompt`
-  holds curator/issue/audit content indefinitely and the default
-  `/tmp/thread-keeper-tasks` spool sits outside the `~/.threadkeeper`
-  perimeter that #21 hardens (#42).
+- ✅ DONE (#42). Retention/GC for the `tasks` table and `TASK_LOG_DIR` spool
+  files — `consolidate()` now prunes ended `tasks` rows outside
+  `THREADKEEPER_TASK_RETENTION_DAYS` / `THREADKEEPER_TASK_RETENTION_COUNT`
+  while preserving live rows, removes orphan `.log`/`.stdin.txt`/`.command`
+  spools, and creates captured headless `.log` files with owner-only
+  permissions.
 - Git working-tree safety for evolve roadmap automation: dirty-tree guard
   (mirroring `auto_update`'s `skipped_dirty_checkout`), branch-from-clean-`main`,
   and reviewer/applier mutual exclusion or `git worktree` isolation so concurrent

--- a/tests/test_config_settings.py
+++ b/tests/test_config_settings.py
@@ -179,6 +179,8 @@ def test_all_exported_names_present(monkeypatch):
         "SPAWN_TOKEN_BUDGET",
         "SPAWNED_CHILD",
         "TASK_LOG_DIR",
+        "TASK_RETENTION_COUNT",
+        "TASK_RETENTION_DAYS",
         "THREAD_IDLE_CLOSE_DAYS",
         "THREAD_JANITOR_INTERVAL_S",
         "WRITE_ORIGIN",

--- a/tests/test_spawn_slim.py
+++ b/tests/test_spawn_slim.py
@@ -180,6 +180,32 @@ def test_visible_command_script_is_owner_only(mp_with_cid, monkeypatch):
     assert mode == 0o700, f"expected 0700, got {oct(mode)}"
 
 
+def test_headless_log_file_is_owner_only(mp_with_cid, monkeypatch):
+    """Captured stdout/stderr can include prompt-derived paths/output, so the
+    headless `.log` spool file must be 0600 from creation time."""
+    pkg = mp_with_cid(_FAKE_CID)
+
+    import threadkeeper.tools.spawn as spawn_mod
+
+    monkeypatch.setattr(spawn_mod, "_claude_bin", lambda: "/usr/bin/true")
+    monkeypatch.setattr(pkg["identity"], "_active_cli", "claude")
+
+    class _FakePopen:
+        def __init__(self, *a, **k):
+            self.pid = 4321
+
+    monkeypatch.setattr(spawn_mod.subprocess, "Popen", _FakePopen)
+
+    spawn_fn = pkg["mcp"]._tool_manager._tools["spawn"].fn
+    out = spawn_fn(prompt="do a thing", visible=False, capture_output=True)
+    assert out.startswith("ok task="), out
+
+    log_files = list(spawn_mod.TASK_LOG_DIR.glob("*.log"))
+    assert len(log_files) == 1, log_files
+    mode = log_files[0].stat().st_mode & 0o777
+    assert mode == 0o600, f"expected 0600, got {oct(mode)}"
+
+
 def test_spawn_slim_falls_back_to_full_config_when_unable(tmp_path, monkeypatch):
     """If _build_slim_mcp_config returns None (e.g. write error), spawn()
     must NOT crash — it just runs without slim flags."""

--- a/tests/test_task_retention.py
+++ b/tests/test_task_retention.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import time
+
+
+_FAKE_CID = "77778888-9999-aaaa-bbbb-ccccdddd0000"
+_SPOOL_SUFFIXES = (".log", ".stdin.txt", ".command")
+
+
+def _tool(pkg, name):
+    return pkg["mcp"]._tool_manager._tools[name].fn
+
+
+def _seed_task(conn, task_id: str, started_at: int, ended_at: int | None):
+    conn.execute(
+        "INSERT INTO tasks (id, pid, parent_cid, spawned_cid, cwd, prompt, "
+        "started_at, ended_at) VALUES (?,?,?,?,?,?,?,?)",
+        (
+            task_id,
+            0,
+            _FAKE_CID,
+            f"child-{task_id}",
+            "/tmp",
+            f"prompt for {task_id}",
+            started_at,
+            ended_at,
+        ),
+    )
+
+
+def _write_spool(log_dir, task_id: str):
+    log_dir.mkdir(parents=True, exist_ok=True)
+    for suffix in _SPOOL_SUFFIXES:
+        (log_dir / f"{task_id}{suffix}").write_text(
+            f"{task_id}{suffix}", encoding="utf-8"
+        )
+
+
+def _seed_retention_case(pkg):
+    now = int(time.time())
+    conn = pkg["db"].get_db()
+    log_dir = pkg["config"].TASK_LOG_DIR
+
+    _seed_task(conn, "tk_live_old", now - 40 * 86400, None)
+    _seed_task(conn, "tk_recent", now - 2 * 86400, now - 1 * 86400)
+    _seed_task(conn, "tk_keep_count", now - 9 * 86400, now - 8 * 86400)
+    _seed_task(conn, "tk_prune", now - 21 * 86400, now - 20 * 86400)
+    conn.commit()
+
+    for task_id in (
+        "tk_live_old",
+        "tk_recent",
+        "tk_keep_count",
+        "tk_prune",
+        "tk_orphan",
+    ):
+        _write_spool(log_dir, task_id)
+
+    return conn, log_dir
+
+
+def test_consolidate_dry_run_reports_task_retention_without_deleting(
+    mp_with_cid,
+    monkeypatch,
+):
+    monkeypatch.setenv("THREADKEEPER_TASK_RETENTION_DAYS", "7")
+    monkeypatch.setenv("THREADKEEPER_TASK_RETENTION_COUNT", "2")
+    pkg = mp_with_cid(_FAKE_CID)
+    conn, log_dir = _seed_retention_case(pkg)
+
+    out = _tool(pkg, "consolidate")(dry_run=True)
+
+    assert "task_prune=1" in out
+    assert "spool_gc=6" in out
+    assert "task=tk_prune" in out
+    assert "task=tk_orphan" in out
+    assert conn.execute(
+        "SELECT 1 FROM tasks WHERE id='tk_prune'"
+    ).fetchone() is not None
+    for task_id in ("tk_prune", "tk_orphan"):
+        for suffix in _SPOOL_SUFFIXES:
+            assert (log_dir / f"{task_id}{suffix}").exists()
+
+
+def test_consolidate_prunes_old_ended_tasks_and_orphan_spool(
+    mp_with_cid,
+    monkeypatch,
+):
+    monkeypatch.setenv("THREADKEEPER_TASK_RETENTION_DAYS", "7")
+    monkeypatch.setenv("THREADKEEPER_TASK_RETENTION_COUNT", "2")
+    pkg = mp_with_cid(_FAKE_CID)
+    conn, log_dir = _seed_retention_case(pkg)
+
+    out = _tool(pkg, "consolidate")(dry_run=False)
+
+    assert "prune_tasks=1" in out
+    assert "gc_task_spool=6" in out
+    remaining = {
+        r["id"] for r in conn.execute("SELECT id FROM tasks").fetchall()
+    }
+    assert remaining == {"tk_live_old", "tk_recent", "tk_keep_count"}
+
+    for task_id in ("tk_live_old", "tk_recent", "tk_keep_count"):
+        for suffix in _SPOOL_SUFFIXES:
+            assert (log_dir / f"{task_id}{suffix}").exists()
+    for task_id in ("tk_prune", "tk_orphan"):
+        for suffix in _SPOOL_SUFFIXES:
+            assert not (log_dir / f"{task_id}{suffix}").exists()

--- a/threadkeeper/config.py
+++ b/threadkeeper/config.py
@@ -181,6 +181,13 @@ class Settings(BaseSettings):
     # outlives this, so an unresolvable row can't pin budget capacity forever
     # (#64). 0 disables the reaper.
     spawn_visible_ttl_s: float = 3600.0
+    # Retention for completed spawn task rows. `consolidate()` prunes ended
+    # rows outside BOTH protections: newer than this age and among the newest
+    # N ended rows. Live rows (ended_at IS NULL) are never pruned. Set either
+    # knob to 0 to disable that protection; set both to 0 to disable row
+    # pruning while still allowing orphan spool-file cleanup.
+    task_retention_days: int = 30
+    task_retention_count: int = 1000
     # Wall-clock lifetime cap for any spawned child (#80). A child that hangs
     # while still alive — a wedged WebFetch/gh/git, an agent loop that never
     # converges, a prompt that never arrives — would otherwise stall its loop's
@@ -411,9 +418,11 @@ _EXTRA_THREADKEEPER_ENV_KEYS = {
     "THREADKEEPER_ENV_FILE",
     "THREADKEEPER_EXTRA_SKILLS_DIRS",
     "THREADKEEPER_FORCE_CID",
+    "THREADKEEPER_GH_WRAPPER_DIR",
     "THREADKEEPER_LESSONS",
     "THREADKEEPER_MENUBAR_RESTART_RSS_MB",
     "THREADKEEPER_PYTHON",
+    "THREADKEEPER_REAL_GH",
     "THREADKEEPER_REPO",
     "THREADKEEPER_SEARCH_PROXY_POLL_S",
     "THREADKEEPER_SKILL_WATCH_INTERVAL_S",
@@ -557,6 +566,8 @@ def _derive_constants(s: "Settings") -> dict:
         "SPAWN_TOKEN_BUDGET": s.spawn_token_budget,
         "SPAWN_COST_BUDGET_USD": s.spawn_cost_budget_usd,
         "SPAWN_VISIBLE_TTL_S": s.spawn_visible_ttl_s,
+        "TASK_RETENTION_DAYS": s.task_retention_days,
+        "TASK_RETENTION_COUNT": s.task_retention_count,
         "SPAWN_MAX_RUNTIME_S": s.spawn_max_runtime_s,
         "SPAWN_KILL_GRACE_S": s.spawn_kill_grace_s,
         "MEMORY_GUARD_POLL_S": s.memory_guard_poll_s,

--- a/threadkeeper/tools/consolidate.py
+++ b/threadkeeper/tools/consolidate.py
@@ -1,12 +1,14 @@
 """Consolidate MCP tool: periodic memory hygiene.
 
 Extracted from server.py. Provides a dry-run-by-default sweep that
-reports (and optionally applies) four kinds of cleanup:
+reports (and optionally applies) several kinds of cleanup:
 
   merge_dup_notes : intra-thread cosine ≥ note_cosine, keep oldest
   idle_stale      : active threads not touched in stale_days
   dedupe_verbatim : exact text + (if embeddings) cosine ≥ verbatim_cosine
   release_orphan  : claim ≥ orphan_days old, no progress past claim mark
+  prune_tasks     : ended tasks outside retention age/count bounds
+  gc_task_spool   : task spool files with no retained tasks row
 """
 
 import sqlite3
@@ -14,7 +16,12 @@ import time
 
 from .._mcp import read_tool, write_tool
 from ..db import get_db
-from ..config import SEMANTIC_AVAILABLE
+from ..config import (
+    SEMANTIC_AVAILABLE,
+    TASK_LOG_DIR,
+    TASK_RETENTION_COUNT,
+    TASK_RETENTION_DAYS,
+)
 from ..helpers import fmt_age, q, normalize_text
 from ..identity import _ensure_session, _emit
 from ..embeddings import _get_model, _encode, _vec_delete_note
@@ -24,6 +31,104 @@ CONSOLIDATE_NOTE_COSINE = 0.95
 CONSOLIDATE_VERBATIM_COSINE = 0.90
 CONSOLIDATE_STALE_THREAD_DAYS = 30
 CONSOLIDATE_ORPHAN_CLAIM_DAYS = 7
+TASK_SPOOL_SUFFIXES = (".stdin.txt", ".command", ".log")
+
+
+def _task_retention_label() -> str:
+    days = max(0, int(TASK_RETENTION_DAYS))
+    count = max(0, int(TASK_RETENTION_COUNT))
+    parts = []
+    if days:
+        parts.append(f"ended within {days}d")
+    if count:
+        parts.append(f"newest {count} ended")
+    return " or ".join(parts) if parts else "row pruning disabled"
+
+
+def _task_rows_to_prune(conn: sqlite3.Connection, now: int) -> list[dict]:
+    """Ended tasks outside the configured age/count retention protections.
+
+    Live rows are excluded at the SQL boundary because spawn single-flight and
+    budget accounting depend on `ended_at IS NULL` rows being durable while the
+    child is still alive.
+    """
+    days = max(0, int(TASK_RETENTION_DAYS))
+    count = max(0, int(TASK_RETENTION_COUNT))
+    if days <= 0 and count <= 0:
+        return []
+
+    keep_by_count = set()
+    if count > 0:
+        keep_by_count = {
+            r["id"] for r in conn.execute(
+                "SELECT id FROM tasks WHERE ended_at IS NOT NULL "
+                "ORDER BY ended_at DESC, started_at DESC LIMIT ?",
+                (count,),
+            ).fetchall()
+        }
+    cutoff = now - days * 86400 if days > 0 else None
+    out = []
+    for r in conn.execute(
+        "SELECT id, prompt, started_at, ended_at FROM tasks "
+        "WHERE ended_at IS NOT NULL ORDER BY ended_at ASC, started_at ASC"
+    ).fetchall():
+        keep_age = cutoff is not None and int(r["ended_at"]) >= cutoff
+        keep_count = r["id"] in keep_by_count
+        if keep_age or keep_count:
+            continue
+        out.append({
+            "task": r["id"],
+            "prompt": (r["prompt"] or "")[:120],
+            "ended_age": fmt_age(max(0, now - int(r["ended_at"]))),
+        })
+    return out
+
+
+def _spool_task_id(name: str) -> tuple[str, str] | None:
+    for suffix in TASK_SPOOL_SUFFIXES:
+        if not name.endswith(suffix):
+            continue
+        task_id = name[:-len(suffix)]
+        # TASK_LOG_DIR also holds non-task logs/configs (dialog.log,
+        # memory-guard.log, slim-mcp-*.json). Only spawn task ids are GC'd.
+        if task_id.startswith("tk_"):
+            return task_id, suffix
+    return None
+
+
+def _task_spool_gc_candidates(
+    conn: sqlite3.Connection,
+    pruned_task_ids: set[str],
+) -> list[dict]:
+    retained = {
+        r["id"] for r in conn.execute("SELECT id FROM tasks").fetchall()
+    } - pruned_task_ids
+    try:
+        entries = sorted(TASK_LOG_DIR.iterdir(), key=lambda p: p.name)
+    except (FileNotFoundError, OSError):
+        return []
+
+    out = []
+    for p in entries:
+        try:
+            is_file = p.is_file()
+        except OSError:
+            continue
+        if not is_file:
+            continue
+        parsed = _spool_task_id(p.name)
+        if parsed is None:
+            continue
+        task_id, suffix = parsed
+        if task_id in retained:
+            continue
+        out.append({
+            "task": task_id,
+            "name": p.name,
+            "path": str(p),
+            "kind": suffix.lstrip("."),
+        })
+    return out
 
 
 @write_tool(destructive=True)
@@ -37,13 +142,16 @@ def consolidate(dry_run: bool = True,
       merge_dup_notes : intra-thread cosine ≥ note_cosine, keep oldest
       idle_stale      : active threads not touched in stale_days
       dedupe_verbatim : exact text + (if embeddings) cosine ≥ verbatim_cosine
-      release_orphan  : claim ≥ orphan_days old, no progress past claim mark"""
+      release_orphan  : claim ≥ orphan_days old, no progress past claim mark
+      prune_tasks     : ended task rows outside retention bounds
+      gc_task_spool   : task spool files with no retained task row"""
     conn = get_db()
     _ensure_session(conn)
     now = int(time.time())
     findings = {
         "merge_dup_notes": [], "idle_stale": [],
         "dedupe_verbatim": [], "release_orphan": [],
+        "prune_tasks": [], "gc_task_spool": [],
     }
     np = None
     if SEMANTIC_AVAILABLE:
@@ -151,9 +259,16 @@ def consolidate(dry_run: bool = True,
             "question": t["question"][:120],
         })
 
+    findings["prune_tasks"].extend(_task_rows_to_prune(conn, now))
+    pruned_task_ids = {f["task"] for f in findings["prune_tasks"]}
+    findings["gc_task_spool"].extend(
+        _task_spool_gc_candidates(conn, pruned_task_ids)
+    )
+
     applied = {
         "merge_dup_notes": 0, "idle_stale": 0,
         "dedupe_verbatim": 0, "release_orphan": 0,
+        "prune_tasks": 0, "gc_task_spool": 0,
     }
     if not dry_run:
         for f in findings["merge_dup_notes"]:
@@ -177,6 +292,21 @@ def consolidate(dry_run: bool = True,
                 "WHERE id=?", (f["thread"],)
             )
             applied["release_orphan"] += 1
+        for f in findings["prune_tasks"]:
+            conn.execute(
+                "DELETE FROM tasks WHERE id=? AND ended_at IS NOT NULL",
+                (f["task"],),
+            )
+            applied["prune_tasks"] += 1
+        for f in findings["gc_task_spool"]:
+            try:
+                TASK_LOG_DIR.joinpath(f["name"]).unlink()
+            except FileNotFoundError:
+                applied["gc_task_spool"] += 1
+            except OSError:
+                continue
+            else:
+                applied["gc_task_spool"] += 1
         _emit(conn, "consolidate_apply",
               summary=" ".join(f"{k}={v}" for k, v in applied.items()))
         conn.commit()
@@ -186,7 +316,9 @@ def consolidate(dry_run: bool = True,
         f"merge={len(findings['merge_dup_notes'])} "
         f"idle={len(findings['idle_stale'])} "
         f"dedupe={len(findings['dedupe_verbatim'])} "
-        f"orphan={len(findings['release_orphan'])}"
+        f"orphan={len(findings['release_orphan'])} "
+        f"task_prune={len(findings['prune_tasks'])} "
+        f"spool_gc={len(findings['gc_task_spool'])}"
     ]
     if not dry_run:
         out.append("applied " + " ".join(f"{k}={v}" for k, v in applied.items()))
@@ -221,5 +353,25 @@ def consolidate(dry_run: bool = True,
             out.append(
                 f"  {f['thread']} by={f['claimed_by']} "
                 f"age={f['claimed_age']} q={q(f['question'])}"
+            )
+    if findings["prune_tasks"]:
+        out.append("")
+        out.append(
+            "task_retention "
+            f"({_task_retention_label()}; live rows protected)"
+        )
+        for f in findings["prune_tasks"][:10]:
+            out.append(
+                f"  task={f['task']} ended={f['ended_age']} "
+                f"prompt={q(f['prompt'])}"
+            )
+    if findings["gc_task_spool"]:
+        out.append("")
+        out.append(
+            f"task_spool_gc (dir={TASK_LOG_DIR}; no retained task row)"
+        )
+        for f in findings["gc_task_spool"][:10]:
+            out.append(
+                f"  task={f['task']} kind={f['kind']} file={q(f['name'])}"
             )
     return "\n".join(out)

--- a/threadkeeper/tools/spawn.py
+++ b/threadkeeper/tools/spawn.py
@@ -537,6 +537,14 @@ def spawn(prompt: str, cwd: str = "", append_system: str = "",
         child_env["PATH"] = (
             str(wrapper_dir) + os.pathsep + child_env.get("PATH", "")
         )
+    else:
+        inherited_wrapper = child_env.pop("THREADKEEPER_GH_WRAPPER_DIR", "")
+        child_env.pop("THREADKEEPER_REAL_GH", None)
+        if inherited_wrapper:
+            child_env["PATH"] = os.pathsep.join(
+                p for p in child_env.get("PATH", "").split(os.pathsep)
+                if p != inherited_wrapper
+            )
     # slim spawn → child loads NO embeddings (delegates semantic search to
     # the parent via search_via_parent). Override only if user didn't set
     # the env explicitly already (allow opt-out by setting =0 explicitly).
@@ -816,7 +824,17 @@ exit $rc
             if stdin_path is not None:
                 stdin_f = stdin_path.open("rb")
             if log_path is not None:
-                log_f = log_path.open("wb")
+                fd = os.open(
+                    log_path,
+                    os.O_WRONLY | os.O_CREAT | os.O_TRUNC,
+                    0o600,
+                )
+                try:
+                    os.chmod(log_path, 0o600)
+                    log_f = os.fdopen(fd, "wb")
+                except OSError:
+                    os.close(fd)
+                    raise
                 proc = subprocess.Popen(
                     launch_cmd,
                     cwd=cwd,


### PR DESCRIPTION
## Summary
- Add configurable ended-task retention by age/count in consolidate(), preserving live tasks.
- Garbage-collect orphan task spool files from TASK_LOG_DIR and report dry-run counts.
- Create headless spawn .log files with 0600 permissions and document the knobs/behavior.

## Tests
- env -u THREADKEEPER_NO_EMBEDDINGS .venv/bin/python -m pytest -q (exited 0; double-quiet hid the pass-count line)
- env -u THREADKEEPER_NO_EMBEDDINGS .venv/bin/python -m pytest -o addopts='--strict-markers' -q (1025 passed, 1 skipped, 0 failed)

Closes #42