### PR TITLE
feat: skip human-gated roadmap issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ version bumps follow semver per the policy in
 
 ## [Unreleased]
 
+### Added
+
+- **Evolve applier skip-label gate (#50).** Autonomous roadmap issue pickup now
+  excludes GitHub issues carrying labels in
+  `THREADKEEPER_EVOLVE_APPLY_SKIP_LABELS` (default
+  `blocked,needs-design,wontfix,question,discussion,help wanted`) before claim
+  or spawn. Exact-number apply returns `skipped: label X` for a denylisted issue
+  instead of silently switching tasks, and skip telemetry is visible through
+  `evolve_apply_status()` plus the `roadmap_issue_skipped` dashboard outcome.
+
 ## v0.14.0 — 2026-06-25
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -632,11 +632,12 @@ shell/`bypassPermissions` to the same child:
 A full research → audit cycle therefore spans two due passes.
 
 The Evolve applier is the downstream implementer. `evolve_apply_roadmap_issue()`
-picks one open GitHub issue at a time (`roadmap` label first, then FIFO), skips
-issues with an active Evolve claim comment, posts its own claim comment before
-spawning, and advances to the next issue when an issue-local dispatch failure
-prevents startup. The child implements exactly that issue, runs the full suite,
-opens a PR whose body includes `Closes #N`, and only then calls
+picks one open GitHub issue at a time (`roadmap` label first, then FIFO),
+skips issues carrying denylisted human-gate labels, skips issues with an active
+Evolve claim comment, posts its own claim comment before spawning, and advances
+to the next issue when an issue-local dispatch failure prevents startup. The
+child implements exactly that issue, runs the full suite, opens a PR whose body
+includes `Closes #N`, and only then calls
 `evolve_mark_roadmap_issue_applied(issue_number, pr_url)`. It never commits or
 pushes to `main`, and it never marks an issue applied without a real PR URL. A
 manual `evolve_apply_roadmap_issue(issue_number=N)` remains exact: it reports
@@ -645,6 +646,16 @@ The queue fetch uses paginated GitHub REST reads in oldest-created order, then
 applies the documented roadmap/FIFO sort locally. A generous local candidate
 window is retained as a runaway guard; if it ever truncates, the applier logs
 how many open issues were outside the window.
+
+**Skip-label gate.** Autonomous issue pickup refuses issues with labels listed
+in `THREADKEEPER_EVOLVE_APPLY_SKIP_LABELS` (default
+`blocked,needs-design,wontfix,question,discussion,help wanted`). These labels
+mean the issue needs human design, discussion, or intervention before a
+permission-bypassing implementer should try it. Queue mode excludes those
+issues and records `roadmap_issue_skipped` telemetry; exact mode returns
+`skipped: label X` for the named issue rather than selecting a different one.
+Set the knob to another comma-separated list, or to `off`, to override the
+default.
 
 **Author-trust gate (this repo is public).** Any GitHub account can open an
 issue, and an open issue's body is injected into the permission-bypassing
@@ -828,9 +839,10 @@ The most-used env knobs (full list in `threadkeeper/config.py`):
 | `THREADKEEPER_EVOLVE_AUTO_CLONE` | true | auto-provision (git clone + `.venv` with `[semantic,dev]`) a managed checkout when installed without a source tree (PyPI/site-packages), so the evolve loops work by default. Set `0`/`false` to disable — then a non-checkout install requires an editable install or an explicit `EVOLVE_REPO_ROOT`, otherwise the loops return `ERR evolve_repo_unavailable` |
 | `THREADKEEPER_EVOLVE_REPO_URL` | upstream repo | git URL the managed checkout is cloned from |
 | `THREADKEEPER_EVOLVE_REPO_BRANCH` | `main` | branch the managed checkout tracks |
+| `THREADKEEPER_EVOLVE_APPLY_SKIP_LABELS` | `blocked,needs-design,wontfix,question,discussion,help wanted` | comma-separated labels that exclude GitHub issues from autonomous Evolve applier pickup. Exact-number apply returns `skipped: label X`; set to `off` to clear |
 | `THREADKEEPER_EVOLVE_TRUSTED_AUTHOR_ASSOCIATIONS` | `OWNER,MEMBER,COLLABORATOR` | comma-separated GitHub author associations eligible for **autonomous** issue pickup on this public repo; issues from other authors are skipped unless promoted (trust label or exact-number invocation) |
 | `THREADKEEPER_EVOLVE_TRUST_LABELS` | (empty) | comma-separated labels that promote an untrusted-author issue into the autonomous queue; on a public repo only collaborators can apply labels, so a trust label is a maintainer endorsement |
-| `THREADKEEPER_ROADMAP_ISSUE_MAX_ATTEMPTS` | 3 | poison-issue dead-letter cap: after this many implementer spawns for a roadmap issue with no resulting PR, the issue gets a `blocked` label + one summary comment and is excluded from the auto-drain until a human intervenes. A manual `evolve_apply_roadmap_issue(issue_number=N)` still force-retries it |
+| `THREADKEEPER_ROADMAP_ISSUE_MAX_ATTEMPTS` | 3 | poison-issue dead-letter cap: after this many implementer spawns for a roadmap issue with no resulting PR, the issue gets a `blocked` label + one summary comment and is excluded from the auto-drain until a human intervenes. A manual `evolve_apply_roadmap_issue(issue_number=N)` bypasses the cap, but the default skip-label gate still refuses the `blocked` label until it is removed or reconfigured |
 | `THREADKEEPER_ROADMAP_ISSUE_BACKOFF_BASE_S` | 172800 (2d) | base failure-backoff window for a roadmap issue; doubles per attempt (`base * 2^(attempts-1)`, capped at 30d). Defers re-selection of a repeatedly-aborting issue beyond the fixed 24h claim TTL |
 | `THREADKEEPER_DIALECTIC_MAX_NEW_CLAIMS` | 3 | max new dialectic claims the validator may create per pass |
 
@@ -930,8 +942,9 @@ them with `dry_run=False` to apply:
   **outcomes** (what those loops actually produced — skills materialized,
   tier promotions, candidate accept-vs-reject rate, plus knowledge-store
   mutation counts: `lesson_append` / `lesson_remove`,
-  `curator_report_applied`, `roadmap_issue_applied`, `evolve_applied`,
-  `dialectic_claim` / `dialectic_supersede`). A `curator_net_change
+  `curator_report_applied`, `roadmap_issue_applied`,
+  `roadmap_issue_skipped`, `evolve_applied`, `dialectic_claim` /
+  `dialectic_supersede`). A `curator_net_change
   added/removed/patched/net` line makes a loop silently shrinking the
   lessons store visible at a glance. Surfaces the gaps the point-tools
   can't: a loop firing constantly while its outcomes stay flat, or a

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -285,8 +285,17 @@ All daemon threads are cheap (ticks 0.5–30 s), no-op when env-knobs disable th
   itself an endorsement). Untrusted issues are skipped until promoted; naming
   the exact number (`evolve_apply_roadmap_issue(issue_number=N)`) bypasses the
   gate as explicit human promotion. This removes the untrusted input at the
-  boundary and complements the in-prompt data-fencing of #22/#76. Before
-  spawning, the parent runs five multi-host conflict guards in order: (1) skip
+  boundary and complements the in-prompt data-fencing of #22/#76.
+  **Skip-label gate (#50):** before claim/spawn work, `_open_roadmap_issues()`
+  also excludes issues whose labels match `EVOLVE_APPLY_SKIP_LABELS` (default
+  `blocked,needs-design,wontfix,question,discussion,help wanted`). These are
+  human-gated backlog items: blocked, discussion/design, rejected, or reserved
+  for contributors rather than an unsupervised `bypassPermissions` child. Queue
+  mode records `roadmap_issue_skipped` telemetry and continues with clean
+  candidates; exact mode returns `skipped: label X` for the named issue instead
+  of switching tasks. The skip count/reasons show in `evolve_apply_status()`;
+  `mp_dashboard()` counts the skip outcome.
+  Before spawning, the parent runs five multi-host conflict guards in order: (1) skip
   if an active `<!-- thread-keeper:evolve-applier-claim -->` comment already
   exists; (2) skip if `gh pr list --search "in:body Closes #N"` shows an open
   PR already closing the issue; (3) post the parent's own claim comment (body
@@ -312,7 +321,8 @@ All daemon threads are cheap (ticks 0.5–30 s), no-op when env-knobs disable th
   signals. A successful child writes `roadmap_issue_applied` (checked first
   everywhere), so only genuinely-failing issues accrue attempts. An exact
   `evolve_apply_roadmap_issue(issue_number=N)` override bypasses the cooldown
-  and the cap so a human can force a retry; per-issue attempt counts/states
+  and the cap, but the default skip-label gate still refuses the `blocked`
+  label until it is removed or reconfigured; per-issue attempt counts/states
   surface in `evolve_apply_status()` and stuck/dead-letter counts in
   `mp_dashboard()`. In queue mode, issue-local dispatch
   failures advance to the next issue; exact

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -61,6 +61,11 @@ remains a live question.
   50-item window. The applier still prioritizes `roadmap` labels then FIFO by
   issue number locally; if its generous candidate window ever truncates, it logs
   exactly how many open issues were not considered.
+- Evolve applier skip-label gate (#50): autonomous roadmap issue pickup now
+  refuses labels in `THREADKEEPER_EVOLVE_APPLY_SKIP_LABELS` (default
+  `blocked,needs-design,wontfix,question,discussion,help wanted`), reports
+  exact-mode skips as `skipped: label X`, and surfaces skip telemetry in
+  `evolve_apply_status()` / `mp_dashboard()`.
 - Config typo visibility (#88): startup and hot-config reload now warn on
   unknown `THREADKEEPER_*` process-env keys while preserving pydantic's
   `extra="ignore"` behavior, and `spawn_status()` surfaces unsupported spawn
@@ -721,13 +726,13 @@ A reviewer pass over the autonomous roadmap-automation surface (evolve
 reviewer/applier, curator) surfaced three concrete gaps not covered by the
 existing backlog. Each is tracked as a GitHub issue.
 
-**Evolve applier never refuses inappropriate issues.** `_open_roadmap_issues()`
-treats every open issue as backlog (`roadmap` label first, then FIFO) and only
-skips already-applied / actively-claimed ones — there is no opt-out. The child
-runs `bypassPermissions` + `Bash/Edit/Write`, so it can auto-attempt human-gated
-work (design/discussion questions, the XL multi-user item, the security
-hardening issues #21/#22, `good-first-issue`s). Add a configurable skip-label
-denylist (and optional opt-in posture). (#50) Scope: S.
+**Evolve applier skip-label gate (done, #50).** `_open_roadmap_issues()` now
+refuses issues carrying labels in `THREADKEEPER_EVOLVE_APPLY_SKIP_LABELS`
+(default `blocked,needs-design,wontfix,question,discussion,help wanted`) before
+candidate claim/spawn. Exact `evolve_apply_roadmap_issue(issue_number=N)` calls
+return `skipped: label X` for a denylisted issue rather than switching to
+another issue. Skip telemetry is recorded as `roadmap_issue_skipped` and
+surfaced in `evolve_apply_status()` / `mp_dashboard()`. Scope was S.
 
 **Closed-unmerged applier PR strands its issue.** The child records a permanent
 `roadmap_issue_applied` marker once it opens a PR; if a human closes that PR

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -110,6 +110,25 @@ def _outcome_all(out: str, label: str) -> int:
     return int(m.group(1)) if m else 0
 
 
+def test_dashboard_counts_roadmap_issue_skips(fresh_mp):
+    conn = fresh_mp["db"].get_db()
+    now = int(time.time())
+    dash = _tool(fresh_mp, "mp_dashboard")
+    before = dash(window_days=7)
+    skip0 = _outcome_all(before, "roadmap_issue_skipped")
+    conn.execute(
+        "INSERT INTO events (session_id, kind, target, summary, created_at) "
+        "VALUES ('s', 'roadmap_issue_skipped', '50', "
+        "'skipped: label blocked', ?)",
+        (now,),
+    )
+    conn.commit()
+
+    after = dash(window_days=7)
+
+    assert _outcome_all(after, "roadmap_issue_skipped") - skip0 == 1, after
+
+
 def _net_field(out: str, field: str) -> int:
     m = re.search(rf"curator_net_change [^\n]*\b{field}=(\d+)", out)
     return int(m.group(1)) if m else 0

--- a/tests/test_evolve_applier.py
+++ b/tests/test_evolve_applier.py
@@ -516,6 +516,54 @@ def test_open_roadmap_issues_exact_mode_bypasses_author_gate(
     assert [int(i["number"]) for i in promoted] == [7]
 
 
+def test_open_roadmap_issues_skips_denylisted_labels(tmp_path, monkeypatch):
+    pkg = _bootstrap(tmp_path, monkeypatch)
+    conn = pkg["db"].get_db()
+    monkeypatch.setattr(
+        pkg["ea"], "_fetch_open_issues",
+        lambda repo_root=None: (
+            [
+                _issue(1, "human discussion", labels=("roadmap", "discussion")),
+                _issue(2, "blocked work", labels=("roadmap", "blocked")),
+                _issue(3, "ready work", labels=("enhancement",)),
+                _issue(4, "human reserved", labels=("Help Wanted",)),
+            ],
+            "",
+        ),
+    )
+
+    issues, err = pkg["ea"]._open_roadmap_issues(conn)
+
+    assert err == ""
+    assert [int(i["number"]) for i in issues] == [3]
+
+
+def test_apply_roadmap_issue_exact_reports_denylisted_label(
+    tmp_path, monkeypatch,
+):
+    pkg = _bootstrap(tmp_path, monkeypatch)
+    monkeypatch.setattr(
+        pkg["ea"], "_fetch_open_issues",
+        lambda repo_root=None: (
+            [
+                _issue(1, "human discussion", labels=("roadmap", "discussion")),
+                _issue(2, "ready work"),
+            ],
+            "",
+        ),
+    )
+
+    def _boom(**kw):
+        raise AssertionError("denylisted exact issue must not spawn")
+
+    import threadkeeper.tools.spawn as spawn_mod
+    monkeypatch.setattr(spawn_mod, "spawn", _boom)
+
+    out = pkg["ea"].apply_roadmap_issue(issue_number=1)
+
+    assert out == "ERR roadmap_issue_skipped=1: skipped: label discussion"
+
+
 def test_fetch_open_issues_maps_rest_payload_and_filters_prs(
     tmp_path, monkeypatch,
 ):

--- a/threadkeeper/config.py
+++ b/threadkeeper/config.py
@@ -319,6 +319,15 @@ class Settings(BaseSettings):
     # itself a maintainer endorsement. Empty by default — association is the
     # sole gate. CSV string or list.
     evolve_trust_labels: Annotated[list[str], NoDecode] = []
+    # Label denylist for autonomous roadmap-issue pickup (#50). These labels
+    # mean "not safe/suitable for an unsupervised permission-bypassing
+    # implementer" even when the issue otherwise sorts into the roadmap queue.
+    # Exact issue-number invocation still reports the label skip instead of
+    # silently switching tasks. CSV string or list; set to "off" to clear.
+    evolve_apply_skip_labels: Annotated[list[str], NoDecode] = [
+        "blocked", "needs-design", "wontfix", "question", "discussion",
+        "help wanted",
+    ]
     # Poison-issue guard for the evolve applier. After an implementer child is
     # spawned for a roadmap issue but no PR results, the issue stays selectable
     # once its 24h claim TTL lapses. Without a cap that re-spawns a costly
@@ -399,6 +408,17 @@ class Settings(BaseSettings):
     def _parse_trust_labels(cls, v):
         """Accept CSV string or list; normalize to lower (case-insensitive)."""
         if isinstance(v, str):
+            v = [a for a in v.split(",")]
+        return [str(a).strip().lower() for a in (v or []) if str(a).strip()]
+
+    @field_validator("evolve_apply_skip_labels", mode="before")
+    @classmethod
+    def _parse_apply_skip_labels(cls, v):
+        """Accept CSV string or list; normalize to lower (case-insensitive)."""
+        if isinstance(v, str):
+            raw = v.strip().lower()
+            if raw in {"0", "false", "none", "off"}:
+                return []
             v = [a for a in v.split(",")]
         return [str(a).strip().lower() for a in (v or []) if str(a).strip()]
 
@@ -601,6 +621,7 @@ def _derive_constants(s: "Settings") -> dict:
             s.evolve_trusted_author_associations
         ),
         "EVOLVE_TRUST_LABELS": s.evolve_trust_labels,
+        "EVOLVE_APPLY_SKIP_LABELS": s.evolve_apply_skip_labels,
         "ROADMAP_ISSUE_MAX_ATTEMPTS": s.roadmap_issue_max_attempts,
         "ROADMAP_ISSUE_BACKOFF_BASE_S": s.roadmap_issue_backoff_base_s,
         "THREAD_JANITOR_INTERVAL_S": s.thread_janitor_interval_s,

--- a/threadkeeper/evolve_applier.py
+++ b/threadkeeper/evolve_applier.py
@@ -48,6 +48,7 @@ from .config import (
     DB_PATH,
     EVOLVE_APPLY_INTERVAL_S,
     EVOLVE_AUTO_CLONE,
+    EVOLVE_APPLY_SKIP_LABELS,
     EVOLVE_REPO_BRANCH,
     EVOLVE_REPO_ROOT,
     EVOLVE_REPO_URL,
@@ -170,6 +171,7 @@ ROADMAP_ISSUE_CLAIM_HOST_KIND = "roadmap_issue_claim_host"
 # written when an issue crosses the attempt cap and is flagged for a human.
 ROADMAP_ISSUE_ATTEMPT_KIND = "roadmap_issue_attempt"
 ROADMAP_ISSUE_DEAD_LETTER_KIND = "roadmap_issue_dead_letter"
+ROADMAP_ISSUE_SKIPPED_KIND = "roadmap_issue_skipped"
 # Label applied to a dead-lettered issue so it is visibly excluded from the
 # auto-drain and surfaced for a human (composes with the #50 skip-label gate).
 ROADMAP_ISSUE_BLOCKED_LABEL = "blocked"
@@ -651,6 +653,57 @@ def _issue_author_trusted(issue: dict) -> bool:
     if label_set and {name.lower() for name in _issue_labels(issue)} & label_set:
         return True
     return False
+
+
+def _roadmap_issue_skip_label(issue: dict) -> str:
+    """Return the denylisted label that excludes this issue, if any."""
+    deny = {str(label).strip().lower() for label in EVOLVE_APPLY_SKIP_LABELS
+            if str(label).strip()}
+    if not deny:
+        return ""
+    for label in _issue_labels(issue):
+        normalized = str(label).strip().lower()
+        if normalized in deny:
+            return normalized
+    return ""
+
+
+def _format_label_skip(skipped: list[tuple[int, str]], limit: int = 6) -> str:
+    if not skipped:
+        return ""
+    head = ", ".join(f"#{num} label {label}" for num, label in skipped[:limit])
+    more = len(skipped) - limit
+    if more > 0:
+        head += f", +{more} more"
+    return f"roadmap_issue_skipped_label: skipped: {head}"
+
+
+def _record_roadmap_issue_skipped(
+    conn: sqlite3.Connection,
+    skipped: list[tuple[int, str]],
+) -> None:
+    """Persist visible telemetry for human-gated issues skipped by label."""
+    now = int(time.time())
+    for num, label in skipped:
+        try:
+            conn.execute(
+                "INSERT INTO events (session_id, kind, target, summary, "
+                "created_at) VALUES (?, ?, ?, ?, ?)",
+                (
+                    identity._session_id or "",
+                    ROADMAP_ISSUE_SKIPPED_KIND,
+                    str(int(num)),
+                    f"skipped: label {label}"[:300],
+                    now,
+                ),
+            )
+        except sqlite3.OperationalError:
+            logger.debug(
+                "evolve_applier: failed to record roadmap issue skip",
+                exc_info=True,
+            )
+            return
+    conn.commit()
 
 
 def _fetch_open_issues(repo_root: Optional[Path] = None) -> tuple[list[dict], str]:
@@ -1250,8 +1303,9 @@ def _roadmap_issue_dead_letter_body(issue: dict, attempts: int) -> str:
         "bypassPermissions implementer child every cycle with no progress. A "
         f"human should unblock it (remove the `{ROADMAP_ISSUE_BLOCKED_LABEL}` "
         "label, then split/clarify the issue) before it is retried. A manual "
-        f"`evolve_apply_roadmap_issue(issue_number={num})` still force-retries "
-        "it regardless of this dead-letter state."
+        f"`evolve_apply_roadmap_issue(issue_number={num})` bypasses the "
+        "dead-letter attempt cap, but label-denylisted issues remain skipped "
+        "until the label gate is cleared or reconfigured."
     )
 
 
@@ -1376,6 +1430,25 @@ def _open_roadmap_issues(
     skip_backoff: bool = True,
     flag_dead_letter: bool = False,
 ) -> tuple[list[dict], str]:
+    issues, err, _ = _open_roadmap_issue_candidates(
+        conn, repo_root,
+        skip_claimed=skip_claimed,
+        enforce_author_trust=enforce_author_trust,
+        skip_backoff=skip_backoff,
+        flag_dead_letter=flag_dead_letter,
+    )
+    return issues, err
+
+
+def _open_roadmap_issue_candidates(
+    conn: sqlite3.Connection,
+    repo_root: Optional[Path] = None,
+    *,
+    skip_claimed: bool = True,
+    enforce_author_trust: bool = True,
+    skip_backoff: bool = True,
+    flag_dead_letter: bool = False,
+) -> tuple[list[dict], str, list[tuple[int, str]]]:
     """Open GitHub issues not already handed off by evolve_applier.
 
     The user treats all open issues as roadmap backlog; issues with the
@@ -1397,13 +1470,17 @@ def _open_roadmap_issues(
     `flag_dead_letter` is set, a dead-lettered issue is flagged once (a
     `blocked` label + one summary comment) as it is excluded — only the real
     drain paths pass this so the read-only status view never writes to GitHub.
+    Issues carrying a label from `EVOLVE_APPLY_SKIP_LABELS` are excluded before
+    claim/spawn work. Exact issue mode reads the returned skipped list so it can
+    report the human-gated label instead of falling through to "not open."
     """
     issues, err = _fetch_open_issues(repo_root)
     if err:
-        return [], err
+        return [], err, []
     out: list[dict] = []
     claim_errors: list[str] = []
     untrusted: list[int] = []
+    label_skipped: list[tuple[int, str]] = []
     now_t = time.time()
     for issue in issues:
         try:
@@ -1411,6 +1488,10 @@ def _open_roadmap_issues(
         except (TypeError, ValueError):
             continue
         if _roadmap_issue_applied(conn, num):
+            continue
+        skip_label = _roadmap_issue_skip_label(issue)
+        if skip_label:
+            label_skipped.append((num, skip_label))
             continue
         if enforce_author_trust and not _issue_author_trusted(issue):
             untrusted.append(num)
@@ -1449,8 +1530,8 @@ def _open_roadmap_issues(
     if not out and claim_errors:
         return [], "roadmap_issue_claim_check_failed: " + "; ".join(
             claim_errors
-        )[:240]
-    return out, ""
+        )[:240], label_skipped
+    return out, "", label_skipped
 
 
 def build_apply_prompt(evolve_id: int, suggestion: str,
@@ -1803,7 +1884,9 @@ def apply_roadmap_issue(issue_number: int = 0) -> str:
         exact = bool(issue_number)
         # Queue mode honours the backoff/dead-letter gate and flags poison
         # issues; exact mode is a deliberate human override that ignores it.
-        issues, err = _open_roadmap_issues(
+        # Label-denylisted issues are skipped in both modes; exact mode reports
+        # that skip explicitly instead of switching tasks.
+        issues, err, label_skipped = _open_roadmap_issue_candidates(
             conn, repo_root,
             skip_claimed=not exact,
             enforce_author_trust=not exact,
@@ -1820,16 +1903,31 @@ def apply_roadmap_issue(issue_number: int = 0) -> str:
                 None,
             )
             if issue is None:
+                skipped = [
+                    (num, label) for num, label in label_skipped
+                    if num == int(issue_number)
+                ]
+                if skipped:
+                    _record_roadmap_issue_skipped(conn, skipped)
+                    return (
+                        f"ERR roadmap_issue_skipped={int(issue_number)}: "
+                        f"skipped: label {skipped[0][1]}"
+                    )
                 return f"ERR roadmap_issue_not_open={int(issue_number)}"
             candidates = [issue]
         else:
             if not issues:
+                if label_skipped:
+                    _record_roadmap_issue_skipped(conn, label_skipped)
+                    return "no_roadmap_issue " + _format_label_skip(label_skipped)
                 return "no_roadmap_issue"
             candidates = issues
 
         running = _running_applier_children(conn)
         if running:
             return f"applier_running n={len(running)} (single-flight)"
+        if label_skipped:
+            _record_roadmap_issue_skipped(conn, label_skipped)
 
         failures: list[str] = []
         for issue in candidates:
@@ -1839,6 +1937,8 @@ def apply_roadmap_issue(issue_number: int = 0) -> str:
             if started:
                 if failures:
                     return f"{status} after_skipping={len(failures)}"
+                if label_skipped:
+                    return f"{status} skipped_labels={len(label_skipped)}"
                 return status
             failures.append(status)
             if exact or not _roadmap_dispatch_can_try_next(status):
@@ -2066,10 +2166,15 @@ def run_evolve_apply_pass(force: bool = False) -> str:
     _, repo_err = _ensure_repo_ready()
     # flag_dead_letter=True so a poison issue is flagged (label + one comment)
     # and dropped even on a pass where it is the only open issue left.
-    issues, issue_err = (
-        ([], repo_err) if repo_err
-        else _open_roadmap_issues(conn, flag_dead_letter=True)
-    )
+    label_skipped: list[tuple[int, str]] = []
+    if repo_err:
+        issues, issue_err = [], repo_err
+    else:
+        issues, issue_err, label_skipped = _open_roadmap_issue_candidates(
+            conn, flag_dead_letter=True
+        )
+        if label_skipped and not issues:
+            _record_roadmap_issue_skipped(conn, label_skipped)
     if issues:
         out = apply_roadmap_issue()
         if out.startswith("spawned roadmap_issue=") or out.startswith(
@@ -2088,8 +2193,15 @@ def run_evolve_apply_pass(force: bool = False) -> str:
 
     pending = _promoted_unapplied(conn)
     if not pending:
+        if label_skipped and not issue_err:
+            out = _format_label_skip(label_skipped)
+            _record_apply_pass(conn, now_t, out)
+            return out
         if issue_err:
-            out = f"roadmap_issue_fetch_error: {issue_err}"
+            if issue_err.startswith("roadmap_issue_skipped_label"):
+                out = issue_err
+            else:
+                out = f"roadmap_issue_fetch_error: {issue_err}"
             _record_apply_pass(conn, now_t, out)
             return out
         if not force and not _pass_due(conn, now_t):

--- a/threadkeeper/tools/dashboard.py
+++ b/threadkeeper/tools/dashboard.py
@@ -187,6 +187,7 @@ _LOOP_TASK_PREFIXES: dict[str, str] = {
 #   lesson_append / lesson_remove   — curator + shadow lesson writes/prunes
 #   curator_report_applied          — evolve_applier applied a curator report
 #   roadmap_issue_applied           — evolve_applier opened a roadmap-issue PR
+#   roadmap_issue_skipped           — evolve_applier refused human-gated issue
 #   evolve_applied                  — evolve_applier marked a suggestion done
 #   dialectic_claim / _supersede    — user-model claim mutations
 _OUTCOME_KINDS = (
@@ -199,6 +200,7 @@ _OUTCOME_KINDS = (
     ("lesson_remove", "lesson_remove"),
     ("curator_report_applied", "curator_report_applied"),
     ("roadmap_issue_applied", "roadmap_issue_applied"),
+    ("roadmap_issue_skipped", "roadmap_issue_skipped"),
     ("evolve_applied", "evolve_applied"),
     ("dialectic_claim", "dialectic_claim"),
     ("dialectic_supersede", "dialectic_supersede"),

--- a/threadkeeper/tools/evolve_applier.py
+++ b/threadkeeper/tools/evolve_applier.py
@@ -44,7 +44,8 @@ from ..evolve_applier import (
     mark_applied,
     mark_roadmap_issue_applied,
     roadmap_attempt_ledger,
-    _open_roadmap_issues,
+    _format_label_skip,
+    _open_roadmap_issue_candidates,
     _pending_curator_reports,
     _promoted_unapplied,
     _running_applier_children,
@@ -154,7 +155,7 @@ def evolve_apply_status() -> str:
     _ensure_session(conn)
     reports = _pending_curator_reports(conn)
     pending = _promoted_unapplied(conn)
-    issues, issue_err = _open_roadmap_issues(conn)
+    issues, issue_err, label_skipped = _open_roadmap_issue_candidates(conn)
     ledger = roadmap_attempt_ledger(conn)
     backoff = [e for e in ledger if e["state"] == "backoff"]
     dead = [e for e in ledger if e["state"] == "dead_letter"]
@@ -165,6 +166,7 @@ def evolve_apply_status() -> str:
     lines = [
         f"interval_s={EVOLVE_APPLY_INTERVAL_S:.0f} "
         f"roadmap_issues={len(issues)} "
+        f"roadmap_label_skipped={len(label_skipped)} "
         f"roadmap_backoff={len(backoff)} "
         f"roadmap_dead_letter={len(dead)} "
         f"curator_reports={len(reports)} "
@@ -175,6 +177,8 @@ def evolve_apply_status() -> str:
     ]
     if issue_err:
         lines.append(f"roadmap_issue_fetch_error={issue_err}")
+    if label_skipped:
+        lines.append(f"roadmap_issue_label_skips={_format_label_skip(label_skipped)}")
     if issues:
         lines.append("")
         lines.append("roadmap issues (next first):")


### PR DESCRIPTION
## Summary

- add THREADKEEPER_EVOLVE_APPLY_SKIP_LABELS as a configurable denylist for autonomous roadmap issue pickup
- exclude denylisted labels from queue and exact issue selection, with exact mode returning `skipped: label X`
- surface skip telemetry in evolve apply status and mp_dashboard, plus README/architecture/roadmap/changelog docs

## Tests

- `env -u THREADKEEPER_NO_EMBEDDINGS -u THREADKEEPER_GH_WRAPPER_DIR -u THREADKEEPER_REAL_GH .venv/bin/python -m pytest -q` (PYTEST_EXIT=0; full run completed at 100%)

Closes #50