### PR TITLE
feat: add active-active cross-machine sync

### DIFF
--- a/docs/sync.md
+++ b/docs/sync.md
@@ -44,9 +44,10 @@ the wire and recomputed locally (every node has the model).
   dialectic_evidence, dialectic_observations, edges, skill_usage, reliability,
   probes, probe_results, evolve, style.
 - **Node-local** (never synced): sessions, presence, cursors, ingest_state,
-  resource_controls, events, signals, tasks, extract_candidates. Keeping
-  `events` local means its autoincrement id (the live-channel cursor) never
-  collides across machines.
+  resource_controls, events, signals, tasks, extract_candidates, daemon_state.
+  Keeping `events` local means its autoincrement id (the live-channel cursor)
+  never collides across machines; `daemon_state` is per-machine background
+  cadence (single-flight claim timestamps) — meaningless to replicate.
 - **Derived** (rebuilt locally): notes_fts, dialog_fts, notes_vec, dialog_vec,
   and the *_vec_map sidecars.
 
@@ -78,11 +79,27 @@ POST /sync/pull  {vv}       -> {vv, changes}   rows the caller is missing
 POST /sync/push  {changes}  -> {applied}        merge the caller's changes
 ```
 
-Bearer-token auth (`THREADKEEPER_SYNC_TOKEN`). Transport is plain HTTP intended
-to run over an already-encrypted private network (WireGuard/OpenVPN/Tailscale
-or LAN); TLS can be fronted or added later without protocol changes. NAT'd
-peers need a relay/rendezvous (future). Self-healing: an unreachable peer just
-retries next tick.
+Bearer-token auth (`THREADKEEPER_SYNC_TOKEN`), compared in constant time.
+Transport is plain HTTP intended to run over an already-encrypted private
+network (WireGuard/OpenVPN/Tailscale or LAN); TLS can be fronted or added later
+without protocol changes. NAT'd peers need a relay/rendezvous (future).
+Self-healing: an unreachable peer just retries next tick.
+
+## Trust model
+
+**Every peer is equal-trust.** There are no per-table or per-row ACLs: any peer
+that holds the shared token can write **any** replicated row (LWW by HLC means a
+peer can also overwrite or tombstone rows another node authored). The mesh
+assumes all machines belong to the same user. Guard the token accordingly and
+run only over a private/encrypted network.
+
+Because the DB replicates full private transcripts (`dialog_messages`), the
+server **refuses to bind a wildcard or public address by default** — `0.0.0.0`,
+`::`, a public IP, or an unresolvable hostname are rejected; only loopback and
+private/link-local addresses are allowed. Bind an explicit private/VPN address
+(e.g. your LAN or `10.8.0.x` VPN IP), or set
+`THREADKEEPER_SYNC_ALLOW_PUBLIC_BIND=1` to override — only behind your own
+network controls.
 
 ## Configuration (all OFF by default)
 
@@ -92,28 +109,42 @@ retries next tick.
 | `THREADKEEPER_SYNC_PEERS` | CSV of peer base URLs (`http://host:port`) |
 | `THREADKEEPER_SYNC_LISTEN` | local `host:port` to serve; empty = no server |
 | `THREADKEEPER_SYNC_TOKEN` | shared bearer token for peer auth |
+| `THREADKEEPER_SYNC_ALLOW_PUBLIC_BIND` | allow binding a wildcard/public listen address (default off) |
 
 Tools: `sync_status`, `sync_peers`, `sync_now`.
 
 ## Migration (opt-in, one-time, destructive)
 
-The feature is dormant until `PRAGMA user_version >= SYNC_SCHEMA_VERSION`. The
-additive schema (sync columns + tables) is applied automatically and is safe.
-The **re-id** (INTEGER PKs → global TEXT ids, references rewritten in lockstep,
-derived indexes rebuilt) is a separate opt-in script and is **never auto-run**:
+The feature is dormant until `sync_state.sync_schema_version >=
+SYNC_SCHEMA_VERSION`. (The gate deliberately lives in `sync_state`, not
+`PRAGMA user_version` — the core DB owns `user_version` as its own
+schema-migration counter.) The additive schema (sync columns + tables) rides the
+core schema versioning and is applied automatically and safely. The **re-id**
+(INTEGER PKs → global TEXT ids, references rewritten in lockstep, derived indexes
+rebuilt) is a separate opt-in script and is **never auto-run**:
 
 ```
 tk-sync-migrate            # dry-run: shows the plan, writes nothing
-tk-sync-migrate --apply    # backs up db.sqlite, then migrates; bumps user_version
+tk-sync-migrate --apply    # snapshots db.sqlite, then migrates; sets the sync gate
 ```
 
-`--apply` auto-backs-up `db.sqlite`, runs in a transaction, and is idempotent.
-Run it with a fresh backup; installing the feature without migrating leaves an
-existing user completely unaffected (sync stays off).
+`--apply` first writes a **consistent single-file snapshot** (`VACUUM INTO`,
+which reads through a live connection so WAL-resident committed pages are
+captured — a plain file copy could miss them), then migrates in a transaction,
+and is idempotent. Installing the feature without migrating leaves an existing
+user completely unaffected (sync stays off).
 
 ## Status / follow-ups
 
+- **Learning-loop double-processing.** Once `dialog_messages` replicates, each
+  machine's shadow_review / extract / dialectic miners will independently
+  process the *same* synced rows → the same lessons/claims minted on every node
+  (N machines ≈ N× LLM spend on one window; write-time dedup soaks some of it).
+  Planned fix: scope those loops to locally-ingested rows (`origin_node = self`),
+  or replicate the loop cursors/claims so work is done once. The cursor/claim
+  bookkeeping already lives in node-local tables, so this is additive.
 - Counter columns (`skill_usage.*_count`) merge by LWW for now (an increment on
-  the losing side is dropped); a per-node partial-count CRDT is a follow-up.
+  the losing side is dropped); a per-node partial-count CRDT summed at read
+  (G-Counter style) fits the schema as a follow-up.
 - TLS termination in-process, mDNS/reachability-triggered sync, and a relay for
   NAT'd peers are follow-ups; the current MVP relies on a private network.

--- a/docs/sync.md
+++ b/docs/sync.md
@@ -189,7 +189,9 @@ reset is the required path.
   (G-Counter style) fits the schema as a follow-up.
 - Synced rows arrive without embeddings (never shipped). `/sync/push` re-embeds
   only a bounded slice per request so it can't blow the client timeout on a large
-  initial corpus; the background ingester drains the remainder in bounded ticks.
+  initial corpus; the background ingester drains the remainder in bounded ticks
+  under `applying_guard`. All migrated-DB embedding backfills are derived-only:
+  they preserve the row's `origin_node`/HLC and never append to the sync oplog.
   NULL embeddings are a valid eventual state until then.
 - TLS termination in-process, mDNS/reachability-triggered sync, and a relay for
   NAT'd peers are follow-ups; the current MVP relies on a private network.

--- a/docs/sync.md
+++ b/docs/sync.md
@@ -64,10 +64,19 @@ are already global and merge by key.
 
 On a migrated DB, per-table triggers stamp `origin_node`/`hlc` on local writes
 and append to `sync_oplog`. The HLC is advanced in pure SQL off the
-`sync_state` singleton. Triggers are suppressed while `sync_state.applying=1`
-(set by `applying_guard` during a merge) so applying a peer's rows does not get
-re-captured as a local write — this preserves the relayed row's origin/hlc and
-keeps reconcile idempotent.
+`sync_state` singleton. During a merge the triggers are suppressed by
+`applying_guard`, which creates a **connection-local `TEMP` table**
+(`_tk_sync_applying`) that the triggers probe via `pragma_table_list` — so
+applying a peer's rows does not get re-captured as a local write (preserving the
+relayed row's origin/hlc and keeping reconcile idempotent), while a concurrent
+local write on *another* connection is still captured normally. Suppression is
+deliberately not a shared `sync_state` flag: a shared row would leak through an
+inner commit and silently drop unrelated concurrent writes.
+
+The receive path also absorbs the highest HLC it applies into the local clock
+(`identity.hlc_absorb`, inside the same guarded transaction) so a subsequent
+local edit is stamped from a clock that dominates everything just received —
+otherwise a local edit after a clock-ahead remote row would lose under LWW.
 
 ## Transport
 
@@ -134,6 +143,38 @@ captured — a plain file copy could miss them), then migrates in a transaction,
 and is idempotent. Installing the feature without migrating leaves an existing
 user completely unaffected (sync stays off).
 
+## Cloning a DB / replica identity
+
+The `node_id` lives inside the DB (`sync_state`), so **copying a migrated
+`db.sqlite` — or the whole `~/.threadkeeper` state directory — onto a second
+active machine duplicates the sync identity.** Because the version vector is
+`MAX(hlc)` per `origin_node`, two independent HLC streams under the same origin
+are indistinguishable: once a peer sees the higher stream it assumes every lower
+timestamp for that origin is already known, and a valid change from the other
+machine can be dropped **forever** (data loss, not an LWW collision on one row).
+
+The distinction that matters:
+
+- **Restoring a backup as a replacement** for the same writer (old machine gone)
+  may keep the identity — there is still only one live writer for it.
+- **Creating a second, simultaneously-writable replica** from a DB/state-dir
+  copy **must reset the clone's identity before it accepts any local write or
+  sync**:
+
+```
+tk-sync-reset-node            # dry-run: prints old/new node id + HLC high-water
+tk-sync-reset-node --apply    # assigns a fresh node_id on THIS (clone) DB
+```
+
+`--apply` runs in one exclusive transaction: it preserves the DB's existing HLC
+high-water mark (so a post-reset local write still dominates anything already
+observed, including a future-skewed remote HLC), changes only
+`sync_state.node_id`, clears seen-cursor state (`sync_peer_vv`), and atomically
+replaces the `node.id` mirror. Historical rows keep their `origin_node` — that
+history is already present in the copied DB. An identity file/DB mismatch check
+is defense-in-depth but cannot detect a full state-dir copy, so this explicit
+reset is the required path.
+
 ## Status / follow-ups
 
 - **Learning-loop double-processing.** Once `dialog_messages` replicates, each
@@ -146,5 +187,9 @@ user completely unaffected (sync stays off).
 - Counter columns (`skill_usage.*_count`) merge by LWW for now (an increment on
   the losing side is dropped); a per-node partial-count CRDT summed at read
   (G-Counter style) fits the schema as a follow-up.
+- Synced rows arrive without embeddings (never shipped). `/sync/push` re-embeds
+  only a bounded slice per request so it can't blow the client timeout on a large
+  initial corpus; the background ingester drains the remainder in bounded ticks.
+  NULL embeddings are a valid eventual state until then.
 - TLS termination in-process, mDNS/reachability-triggered sync, and a relay for
   NAT'd peers are follow-ups; the current MVP relies on a private network.

--- a/docs/sync.md
+++ b/docs/sync.md
@@ -1,0 +1,119 @@
+# Cross-machine sync (active-active P2P)
+
+Thread-keeper stores memory in one local SQLite file. This feature keeps that
+memory synchronized across a user's machines (e.g. an always-on desktop + a
+laptop), **active-active**: every machine writes autonomously — including
+offline, with several agents at once — and the end state on every node is the
+**union** of all write-sets, with concurrent edits resolved deterministically.
+
+Topology is a **decentralized P2P mesh, no hub**: each instance holds a peer
+list and reconciles with those peers. Peer lists may be partial/asymmetric —
+because replication is transitive (below), any *connected* graph converges.
+Adding a machine = add its address on some node; remove one and the rest keep
+working.
+
+> Postgres / a central server were rejected: TK is one process per machine, so
+> there is no local write concurrency to solve, and a central server breaks the
+> offline case (a laptop off-network would have no memory at all).
+
+## Model
+
+Each replicated row carries three sync columns (added additively, safe on any
+DB): `origin_node` (who first wrote it), `hlc` (a Hybrid Logical Clock
+timestamp), and `deleted` (tombstone). Rows are globally identified by a TEXT
+id (the primary key).
+
+- **HLC** (`phys_ms:counter:node_id`, zero-padded → lexically sortable) gives a
+  total order that stays causally correct even when machines' wall clocks drift.
+- **Version vector** = the highest HLC each node has seen *per origin*.
+- **Anti-entropy**: peers exchange version vectors; each sends the other every
+  row/tombstone whose HLC exceeds what the peer knows for that origin. Merge is
+  **last-writer-wins by HLC**; deletes propagate as tombstones so a peer that
+  still holds a row cannot resurrect it.
+- **Transitive relay**: a row carries its *origin's* HLC, not the sender's — so
+  B forwards A's rows to C with no direct A–C link. A connected graph converges.
+
+Derived indexes (FTS5, sqlite-vec) are **never shipped** — each node rebuilds
+them locally from the base rows after a merge. Embedding BLOBs are omitted from
+the wire and recomputed locally (every node has the model).
+
+### Table classes
+
+- **Replicated** (memory): threads, notes, verbatim, dialog_messages,
+  core_memory, concepts, distill, distill_votes, user_dialectic,
+  dialectic_evidence, dialectic_observations, edges, skill_usage, reliability,
+  probes, probe_results, evolve, style.
+- **Node-local** (never synced): sessions, presence, cursors, ingest_state,
+  resource_controls, events, signals, tasks, extract_candidates. Keeping
+  `events` local means its autoincrement id (the live-channel cursor) never
+  collides across machines.
+- **Derived** (rebuilt locally): notes_fts, dialog_fts, notes_vec, dialog_vec,
+  and the *_vec_map sidecars.
+
+## Global ids
+
+Replicated ids must be globally unique without coordination. Generated ids use
+a **ULID** (`helpers.gen_global_id`, 48-bit ms + 80 random bits, time-sortable);
+tables rebuilt from INTEGER PKs get a random-hex `DEFAULT` so inserts that omit
+an id still get a global one. `dialog_messages.uuid` and natural keys
+(`core_memory.key`, `style.key`, `skill_usage.name`, `reliability.category`)
+are already global and merge by key.
+
+## Capture
+
+On a migrated DB, per-table triggers stamp `origin_node`/`hlc` on local writes
+and append to `sync_oplog`. The HLC is advanced in pure SQL off the
+`sync_state` singleton. Triggers are suppressed while `sync_state.applying=1`
+(set by `applying_guard` during a merge) so applying a peer's rows does not get
+re-captured as a local write — this preserves the relayed row's origin/hlc and
+keeps reconcile idempotent.
+
+## Transport
+
+Each instance runs a client daemon (`sync/daemon.py`) and an HTTP server
+(`sync/server.py`), symmetric:
+
+```
+POST /sync/pull  {vv}       -> {vv, changes}   rows the caller is missing
+POST /sync/push  {changes}  -> {applied}        merge the caller's changes
+```
+
+Bearer-token auth (`THREADKEEPER_SYNC_TOKEN`). Transport is plain HTTP intended
+to run over an already-encrypted private network (WireGuard/OpenVPN/Tailscale
+or LAN); TLS can be fronted or added later without protocol changes. NAT'd
+peers need a relay/rendezvous (future). Self-healing: an unreachable peer just
+retries next tick.
+
+## Configuration (all OFF by default)
+
+| env | meaning |
+|---|---|
+| `THREADKEEPER_SYNC_INTERVAL_S` | client reconcile tick; 0 = daemon off |
+| `THREADKEEPER_SYNC_PEERS` | CSV of peer base URLs (`http://host:port`) |
+| `THREADKEEPER_SYNC_LISTEN` | local `host:port` to serve; empty = no server |
+| `THREADKEEPER_SYNC_TOKEN` | shared bearer token for peer auth |
+
+Tools: `sync_status`, `sync_peers`, `sync_now`.
+
+## Migration (opt-in, one-time, destructive)
+
+The feature is dormant until `PRAGMA user_version >= SYNC_SCHEMA_VERSION`. The
+additive schema (sync columns + tables) is applied automatically and is safe.
+The **re-id** (INTEGER PKs → global TEXT ids, references rewritten in lockstep,
+derived indexes rebuilt) is a separate opt-in script and is **never auto-run**:
+
+```
+tk-sync-migrate            # dry-run: shows the plan, writes nothing
+tk-sync-migrate --apply    # backs up db.sqlite, then migrates; bumps user_version
+```
+
+`--apply` auto-backs-up `db.sqlite`, runs in a transaction, and is idempotent.
+Run it with a fresh backup; installing the feature without migrating leaves an
+existing user completely unaffected (sync stays off).
+
+## Status / follow-ups
+
+- Counter columns (`skill_usage.*_count`) merge by LWW for now (an increment on
+  the losing side is dropped); a per-node partial-count CRDT is a follow-up.
+- TLS termination in-process, mDNS/reachability-triggered sync, and a relay for
+  NAT'd peers are follow-ups; the current MVP relies on a private network.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,6 +85,9 @@ tk-migrate-embeddings = "threadkeeper.migrate_embeddings:main"
 tk-backup = "threadkeeper.backup:main"
 # Dry-run/apply targeted erasure for one session/cid/thread/dialog UUID.
 tk-forget = "threadkeeper.forget:main"
+# One-time re-id migration that enables cross-machine sync (opt-in, destructive;
+# back up db.sqlite first). Equivalent to `python -m threadkeeper.sync.migrate`.
+tk-sync-migrate = "threadkeeper.sync.migrate:main"
 # JSON/text status feed for menu-bar widgets and terminal monitors.
 tk-agent-status = "threadkeeper.agent_status:main"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,6 +88,9 @@ tk-forget = "threadkeeper.forget:main"
 # One-time re-id migration that enables cross-machine sync (opt-in, destructive;
 # back up db.sqlite first). Equivalent to `python -m threadkeeper.sync.migrate`.
 tk-sync-migrate = "threadkeeper.sync.migrate:main"
+# Assign a fresh sync identity to a CLONED DB before it accepts writes/sync, so
+# two machines don't share one node_id. `python -m threadkeeper.sync.reset_node`.
+tk-sync-reset-node = "threadkeeper.sync.reset_node:main"
 # JSON/text status feed for menu-bar widgets and terminal monitors.
 tk-agent-status = "threadkeeper.agent_status:main"
 

--- a/tests/test_db_compact.py
+++ b/tests/test_db_compact.py
@@ -88,7 +88,8 @@ def test_db_compact_survives_rowid_renumbering(fresh_mp):
     assert conn.execute(
         "SELECT COUNT(*) FROM dialog_fts_docsize"
     ).fetchone()[0] == 2
-    assert conn.execute("PRAGMA user_version").fetchone()[0] == 2
+    assert conn.execute("PRAGMA user_version").fetchone()[0] == \
+        fresh_mp["db"].CURRENT_SCHEMA_VERSION
 
 
 def test_db_compact_single_flight(fresh_mp):

--- a/tests/test_db_migration_fts.py
+++ b/tests/test_db_migration_fts.py
@@ -92,7 +92,7 @@ def test_migrates_v1_to_external_content(tmp_path, monkeypatch):
     tk_db = _boot_db(monkeypatch, db_path)
     conn = tk_db.get_db()
 
-    assert conn.execute("PRAGMA user_version").fetchone()[0] == 2
+    assert conn.execute("PRAGMA user_version").fetchone()[0] == tk_db.CURRENT_SCHEMA_VERSION
     ddl = conn.execute(
         "SELECT sql FROM sqlite_master WHERE type='table' AND name='dialog_fts'"
     ).fetchone()[0]
@@ -155,8 +155,8 @@ def test_migration_rerun_is_noop(tmp_path, monkeypatch):
     )
     conn.close()
 
-    conn2 = tk_db.get_db()  # second connect: version already 2 → fast path
-    assert conn2.execute("PRAGMA user_version").fetchone()[0] == 2
+    conn2 = tk_db.get_db()  # second connect: version already current → fast path
+    assert conn2.execute("PRAGMA user_version").fetchone()[0] == tk_db.CURRENT_SCHEMA_VERSION
     counts2 = (
         conn2.execute("SELECT COUNT(*) FROM dialog_messages").fetchone()[0],
         conn2.execute("SELECT COUNT(*) FROM dialog_fts_docsize").fetchone()[0],
@@ -177,7 +177,7 @@ def test_pre_versioning_db_with_old_fts_migrates(tmp_path, monkeypatch):
 
     tk_db = _boot_db(monkeypatch, db_path)
     conn = tk_db.get_db()
-    assert conn.execute("PRAGMA user_version").fetchone()[0] == 2
+    assert conn.execute("PRAGMA user_version").fetchone()[0] == tk_db.CURRENT_SCHEMA_VERSION
     ddl = conn.execute(
         "SELECT sql FROM sqlite_master WHERE type='table' AND name='dialog_fts'"
     ).fetchone()[0]

--- a/tests/test_dialog_fts_external.py
+++ b/tests/test_dialog_fts_external.py
@@ -42,9 +42,10 @@ def test_fresh_schema_is_external_content(fresh_mp):
     assert triggers == {"dialog_fts_ai", "dialog_fts_ad", "dialog_fts_au"}
 
 
-def test_fresh_db_starts_at_v2(fresh_mp):
+def test_fresh_db_starts_at_current_version(fresh_mp):
     conn = fresh_mp["db"].get_db()
-    assert conn.execute("PRAGMA user_version").fetchone()[0] == 2
+    assert conn.execute("PRAGMA user_version").fetchone()[0] == \
+        fresh_mp["db"].CURRENT_SCHEMA_VERSION
 
 
 def test_trigger_insert_makes_row_searchable(fresh_mp):

--- a/tests/test_forget.py
+++ b/tests/test_forget.py
@@ -298,3 +298,63 @@ def test_forget_dry_run_then_apply_cascades_session(fresh_mp, tmp_path):
         "notes_vec v LEFT JOIN notes n ON n.id=v.id",
         "n.id IS NULL",
     ) == 0
+
+
+def test_forget_after_reid_migration(fresh_mp):
+    """R3-B2 regression: after the sync re-id migration, notes/verbatim/
+    dialectic ids are TEXT ULIDs. build_forget_plan must not raise int()-cast
+    errors, and apply must remove the note plus its FTS/vec/map sidecars with no
+    false orphans in the integrity report."""
+    from threadkeeper.sync import migrate
+    from threadkeeper import forget
+    from threadkeeper.embeddings import _vec_upsert_note, _notes_mapped
+    db = fresh_mp["db"]
+    config = fresh_mp["config"]
+
+    conn = db.get_db()
+    _ensure_vec_tables(conn, db)
+    conn.execute("INSERT INTO threads(id,question,state,opened_at,last_touched_at)"
+                 " VALUES('Tfg','q','active',1,1)")
+    conn.commit()
+    conn.close()
+
+    assert migrate.apply(db.DB_PATH, do_apply=True) == 0
+    assert _notes_mapped(db.get_db())  # sanity: migrated
+
+    conn = db.get_db()
+    try:
+        # post-migration inserts get TEXT ULID ids via the column DEFAULT
+        conn.execute("INSERT INTO notes(thread_id,content,kind,created_at,session_id)"
+                     " VALUES('Tfg','forget me capybara','move',1,'cid-fg')")
+        note_id = conn.execute(
+            "SELECT id FROM notes WHERE content LIKE 'forget me%'").fetchone()[0]
+        _vec_upsert_note(conn, note_id, _vec_blob(config))  # creates notes_vec_map row
+        conn.execute("INSERT INTO verbatim(speaker,content,thread_id,created_at)"
+                     " VALUES('user','verbatim capybara','Tfg',1)")
+        conn.commit()
+        assert not note_id.isdigit()  # TEXT ULID, the case that broke int() cast
+
+        # build a plan by thread — the previously-crashing path (_notes cast=int)
+        plan = forget.build_forget_plan(conn, "Tfg", "thread_id")
+        assert note_id in plan.note_ids
+        assert plan.verbatim_ids and all(not str(v).isdigit() for v in plan.verbatim_ids)
+        assert plan.counts["notes_vec"] == 1 and plan.counts["notes_vec_map"] == 1
+
+        deleted = forget._apply_forget(conn, plan)
+        conn.commit()
+        assert deleted["notes"] == 1
+        assert deleted["notes_vec"] == 1 and deleted["notes_vec_map"] == 1
+
+        # base row + all sidecars gone
+        assert conn.execute("SELECT COUNT(*) FROM notes WHERE id=?",
+                            (note_id,)).fetchone()[0] == 0
+        assert conn.execute("SELECT COUNT(*) FROM notes_vec_map WHERE gid=?",
+                            (note_id,)).fetchone()[0] == 0
+        assert conn.execute("SELECT COUNT(*) FROM verbatim").fetchone()[0] == 0
+        # integrity report reports no false orphans
+        orphans = forget._orphan_counts(conn)
+        assert orphans["notes_vec_orphans"] == 0
+        assert orphans["notes_vec_map_orphans"] == 0
+        assert orphans["notes_fts_orphans"] == 0
+    finally:
+        conn.close()

--- a/tests/test_sync_capture.py
+++ b/tests/test_sync_capture.py
@@ -73,3 +73,40 @@ def test_applying_guard_suppresses_capture(fresh_mp):
         assert r["origin_node"] == "Npeerxxx"
     finally:
         conn.close()
+
+
+def test_applying_guard_is_connection_local(fresh_mp):
+    """Blocker #3 regression: the apply guard must suppress capture on ITS
+    connection only. A concurrent local write on another connection must still
+    be captured — even when the guarded connection commits mid-guard, as
+    rebuild_derived's internal backfills do."""
+    import sqlite3
+    from threadkeeper.sync import capture
+    from threadkeeper.helpers import gen_global_id
+    db = _fresh_migrated(fresh_mp)
+    a = sqlite3.connect(str(db.DB_PATH))
+    b = sqlite3.connect(str(db.DB_PATH))
+    try:
+        tid = gen_global_id("T")
+        with capture.applying_guard(a):
+            # A commits WHILE the guard is active — mimics an inner commit in
+            # the guarded path leaking a shared suppression flag to others.
+            a.commit()
+            # B makes an ordinary local write and commits.
+            b.execute(
+                "INSERT INTO threads(id,question,state,opened_at,last_touched_at)"
+                " VALUES(?,?,?,?,?)", (tid, "local-on-B", "active", 1, 1))
+            b.commit()
+        # B's row must be fully captured despite A being mid-guard: stamped with
+        # origin/hlc and logged to the oplog (>=1; a separate pre-existing quirk
+        # double-logs puts, orthogonal to this connection-locality check).
+        row = b.execute(
+            "SELECT origin_node, hlc FROM threads WHERE id=?", (tid,)).fetchone()
+        assert row is not None and row[0] is not None and row[1], row
+        n = b.execute(
+            "SELECT COUNT(*) FROM sync_oplog WHERE gid=? AND op='put'", (tid,)
+        ).fetchone()[0]
+        assert n >= 1, n
+    finally:
+        a.close()
+        b.close()

--- a/tests/test_sync_capture.py
+++ b/tests/test_sync_capture.py
@@ -98,15 +98,43 @@ def test_applying_guard_is_connection_local(fresh_mp):
                 " VALUES(?,?,?,?,?)", (tid, "local-on-B", "active", 1, 1))
             b.commit()
         # B's row must be fully captured despite A being mid-guard: stamped with
-        # origin/hlc and logged to the oplog (>=1; a separate pre-existing quirk
-        # double-logs puts, orthogonal to this connection-locality check).
+        # origin/hlc and logged to the oplog exactly once.
         row = b.execute(
             "SELECT origin_node, hlc FROM threads WHERE id=?", (tid,)).fetchone()
         assert row is not None and row[0] is not None and row[1], row
         n = b.execute(
             "SELECT COUNT(*) FROM sync_oplog WHERE gid=? AND op='put'", (tid,)
         ).fetchone()[0]
-        assert n >= 1, n
+        assert n == 1, n
     finally:
         a.close()
         b.close()
+
+
+def test_single_write_logs_one_oplog_put(fresh_mp):
+    """A local insert must log exactly one oplog 'put', and a later edit exactly
+    one more. The AFTER-INSERT trigger's own stamping UPDATE fires the
+    AFTER-UPDATE trigger (recursive_triggers OFF only blocks self-recursion), so
+    without the OLD.origin_node guard each insert was double-logged."""
+    from threadkeeper.helpers import gen_global_id
+    db = _fresh_migrated(fresh_mp)
+    conn = db.get_db()
+    try:
+        tid = gen_global_id("T")
+        conn.execute(
+            "INSERT INTO threads(id,question,state,opened_at,last_touched_at)"
+            " VALUES(?,?,?,?,?)", (tid, "q", "active", 1, 1))
+        conn.commit()
+        puts = conn.execute(
+            "SELECT COUNT(*) FROM sync_oplog WHERE gid=? AND op='put'", (tid,)
+        ).fetchone()[0]
+        assert puts == 1, puts
+
+        conn.execute("UPDATE threads SET state='closed' WHERE id=?", (tid,))
+        conn.commit()
+        puts = conn.execute(
+            "SELECT COUNT(*) FROM sync_oplog WHERE gid=? AND op='put'", (tid,)
+        ).fetchone()[0]
+        assert puts == 2, puts  # exactly one more for the edit
+    finally:
+        conn.close()

--- a/tests/test_sync_capture.py
+++ b/tests/test_sync_capture.py
@@ -1,0 +1,75 @@
+"""Step 3: change capture. On a migrated DB, local writes to replicated tables
+are stamped with hlc/origin and logged to sync_oplog by triggers; the apply
+guard suppresses that so merging a peer's rows is not re-captured."""
+from __future__ import annotations
+
+
+def _fresh_migrated(fresh_mp):
+    from threadkeeper.sync import migrate
+    db = fresh_mp["db"]
+    db.get_db().close()  # materialize the DB file + schema first
+    assert migrate.apply(db.DB_PATH, do_apply=True) == 0
+    return db
+
+
+def test_capture_stamps_and_logs(fresh_mp):
+    from threadkeeper.sync import identity
+    from threadkeeper.helpers import gen_global_id
+    db = _fresh_migrated(fresh_mp)
+    conn = db.get_db()
+    try:
+        node = identity.get_node_id(conn)
+        tid = gen_global_id("T")
+        conn.execute(
+            "INSERT INTO threads(id,question,state,opened_at,last_touched_at)"
+            " VALUES(?,?,?,?,?)", (tid, "q", "active", 1, 1))
+        conn.commit()
+
+        row = conn.execute(
+            "SELECT hlc,origin_node FROM threads WHERE id=?", (tid,)).fetchone()
+        assert row["origin_node"] == node and row["hlc"]
+        op = conn.execute(
+            "SELECT tbl,op FROM sync_oplog WHERE gid=?", (tid,)).fetchone()
+        assert op["tbl"] == "threads" and op["op"] == "put"
+
+        # a local UPDATE is a fresh write → advances hlc + logs again
+        conn.execute("UPDATE threads SET state='closed' WHERE id=?", (tid,))
+        conn.commit()
+        assert conn.execute(
+            "SELECT COUNT(*) FROM sync_oplog WHERE gid=?", (tid,)).fetchone()[0] >= 2
+        h2 = conn.execute("SELECT hlc FROM threads WHERE id=?", (tid,)).fetchone()[0]
+        assert h2 > row["hlc"]
+
+        # a DELETE leaves a tombstone
+        conn.execute("DELETE FROM threads WHERE id=?", (tid,))
+        conn.commit()
+        assert conn.execute(
+            "SELECT op FROM sync_oplog WHERE gid=? ORDER BY seq DESC LIMIT 1",
+            (tid,)).fetchone()[0] == "del"
+    finally:
+        conn.close()
+
+
+def test_applying_guard_suppresses_capture(fresh_mp):
+    from threadkeeper.sync import capture
+    from threadkeeper.helpers import gen_global_id
+    db = _fresh_migrated(fresh_mp)
+    conn = db.get_db()
+    try:
+        before = conn.execute("SELECT COUNT(*) FROM sync_oplog").fetchone()[0]
+        with capture.applying_guard(conn):
+            # simulate applying a peer row: id + origin + hlc all pre-set
+            conn.execute(
+                "INSERT INTO threads(id,question,state,origin_node,hlc,"
+                "opened_at,last_touched_at) VALUES(?,?,?,?,?,?,?)",
+                (gen_global_id("T"), "peer-q", "active", "Npeerxxx",
+                 "000000000000001:000000:Npeerxxx", 1, 1))
+            conn.commit()
+        after = conn.execute("SELECT COUNT(*) FROM sync_oplog").fetchone()[0]
+        assert after == before  # nothing captured while applying
+        # and the peer's origin/hlc were preserved, not overwritten
+        r = conn.execute(
+            "SELECT origin_node,hlc FROM threads WHERE question='peer-q'").fetchone()
+        assert r["origin_node"] == "Npeerxxx"
+    finally:
+        conn.close()

--- a/tests/test_sync_identity.py
+++ b/tests/test_sync_identity.py
@@ -1,0 +1,75 @@
+"""Step 1 of cross-machine sync: additive schema, node identity, HLC.
+
+All non-destructive — no PK re-id here. Verifies the foundation the sync
+protocol builds on. See docs/sync.md."""
+from __future__ import annotations
+
+
+def test_schema_has_sync_tables_and_columns(fresh_mp):
+    db = fresh_mp["db"]
+    conn = db.get_db()
+    try:
+        tbls = {
+            r[0] for r in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table'"
+            )
+        }
+        assert {"sync_state", "sync_oplog", "sync_peer_vv"} <= tbls
+        # additive columns land on every replicated table
+        for t in ("notes", "threads", "core_memory", "dialog_messages"):
+            cols = {r[1] for r in conn.execute(f"PRAGMA table_info({t})")}
+            assert {"hlc", "origin_node", "deleted"} <= cols, t
+    finally:
+        conn.close()
+
+
+def test_node_id_persistent(fresh_mp):
+    from threadkeeper.sync import identity
+    db = fresh_mp["db"]
+    c1 = db.get_db()
+    n1 = identity.get_node_id(c1)
+    c1.close()
+    c2 = db.get_db()
+    n2 = identity.get_node_id(c2)
+    c2.close()
+    assert n1 == n2
+    assert n1.startswith("N") and len(n1) == 27  # 'N' + 26-char ULID
+
+
+def test_hlc_strictly_monotonic(fresh_mp):
+    from threadkeeper.sync import identity
+    db = fresh_mp["db"]
+    conn = db.get_db()
+    try:
+        prev = identity.hlc_now(conn)
+        for _ in range(200):
+            cur = identity.hlc_now(conn)
+            assert cur > prev  # zero-padded => lexical order == causal order
+            prev = cur
+    finally:
+        conn.close()
+
+
+def test_hlc_update_absorbs_future_remote(fresh_mp):
+    from threadkeeper.sync import identity
+    db = fresh_mp["db"]
+    conn = db.get_db()
+    try:
+        identity.hlc_now(conn)
+        remote = f"{99999999999999:015d}:000000:Nremotenode"
+        merged = identity.hlc_update(conn, remote)
+        assert merged > remote                     # local clock jumped ahead
+        assert identity.hlc_now(conn) > merged     # and keeps advancing
+    finally:
+        conn.close()
+
+
+def test_gen_global_id_unique_and_charset():
+    from threadkeeper.helpers import gen_global_id, _ulid, _ULID_B32
+    ids = [_ulid() for _ in range(2000)]
+    assert len(set(ids)) == 2000                   # no collisions
+    for i in ids:
+        assert len(i) == 26
+        assert all(ch in _ULID_B32 for ch in i)
+    assert gen_global_id("T").startswith("T")
+    assert len(gen_global_id("UC")) == 28          # 2-char prefix + 26

--- a/tests/test_sync_migrate.py
+++ b/tests/test_sync_migrate.py
@@ -121,12 +121,32 @@ def test_migration_idempotent(fresh_mp):
     assert migrate.apply(db.DB_PATH, do_apply=True) == 0
 
 
+def test_notes_fts_search_works_pre_migration(fresh_mp):
+    """The production retrieval path must work on a fresh, un-migrated DB too."""
+    from threadkeeper.retrieval import _notes_fts_search
+    db = fresh_mp["db"]
+    conn = db.get_db()
+    try:
+        conn.execute("INSERT INTO threads(id,question,state,opened_at,last_touched_at)"
+                     " VALUES('T1','q','active',1,1)")
+        conn.execute("INSERT INTO notes(thread_id,content,kind,created_at)"
+                     " VALUES('T1','wombat pre-migration note',?,1)", ("move",))
+        conn.commit()
+        hits = _notes_fts_search(conn, "wombat", 5)
+        assert any("wombat" in c.content for c in hits), hits
+    finally:
+        conn.close()
+
+
 def test_migration_rebuilds_notes_fts_and_indexes(fresh_mp):
-    """Blocker #2 regression: the re-id migration drops notes' indexes +
-    notes_fts triggers and leaves notes_fts keyed on the (now-TEXT) id. Both
-    pre-existing and newly-inserted notes must stay FTS-searchable, and the
-    indexes/triggers must be restored."""
+    """R3-B1 regression, via the PRODUCTION retrieval path (_notes_fts_search),
+    not a bespoke query: the re-id migration rebuilds notes and must leave notes
+    (pre-existing and newly-inserted) searchable, indexes/triggers restored, and
+    the FTS keyed on the integer rowid — with no false orphans in the integrity
+    report."""
     from threadkeeper.sync import migrate
+    from threadkeeper.retrieval import _notes_fts_search
+    from threadkeeper.forget import _orphan_counts
     db = fresh_mp["db"]
     conn = db.get_db()
     conn.execute("INSERT INTO threads(id,question,state,opened_at,last_touched_at)"
@@ -140,18 +160,16 @@ def test_migration_rebuilds_notes_fts_and_indexes(fresh_mp):
 
     conn = db.get_db()
     try:
-        def _fts(term):
-            return [r[0] for r in conn.execute(
-                "SELECT n.content FROM notes_fts f JOIN notes n ON n.rowid=f.rowid "
-                "WHERE notes_fts MATCH ?", (term,)).fetchall()]
+        def _hits(term):
+            return [c.content for c in _notes_fts_search(conn, term, 5)]
 
-        # pre-existing note is still searchable after migration
-        assert any("platypus" in c for c in _fts("platypus")), _fts("platypus")
-        # FTS triggers were recreated
+        # pre-existing note still found via the real retrieval function
+        assert any("platypus" in c for c in _hits("platypus")), _hits("platypus")
+        # FTS maintenance triggers recreated (incl. the UPDATE trigger)
         trigs = {r[0] for r in conn.execute(
             "SELECT name FROM sqlite_master WHERE type='trigger' "
-            "AND name IN ('notes_fts_ai','notes_fts_ad')")}
-        assert trigs == {"notes_fts_ai", "notes_fts_ad"}, trigs
+            "AND name IN ('notes_fts_ai','notes_fts_ad','notes_fts_au')")}
+        assert trigs == {"notes_fts_ai", "notes_fts_ad", "notes_fts_au"}, trigs
         # ordinary indexes were recreated
         idx = {r[0] for r in conn.execute(
             "SELECT name FROM sqlite_master WHERE type='index' "
@@ -161,11 +179,19 @@ def test_migration_rebuilds_notes_fts_and_indexes(fresh_mp):
         fts_sql = conn.execute(
             "SELECT sql FROM sqlite_master WHERE name='notes_fts'").fetchone()[0]
         assert "content_rowid='rowid'" in fts_sql, fts_sql
-        # a NEW note inserted post-migration is searchable via the recreated trigger
+        # a NEW note inserted post-migration is found via the real retrieval fn
         tid = conn.execute("SELECT id FROM threads LIMIT 1").fetchone()[0]
         conn.execute("INSERT INTO notes(thread_id,content,kind,created_at)"
                      " VALUES(?,?,?,2)", (tid, "narwhal post-migration", "move"))
         conn.commit()
-        assert any("narwhal" in c for c in _fts("narwhal")), _fts("narwhal")
+        assert any("narwhal" in c for c in _hits("narwhal")), _hits("narwhal")
+        # an in-place content edit re-indexes via notes_fts_au
+        nid = conn.execute("SELECT id FROM notes WHERE content LIKE 'narwhal%'").fetchone()[0]
+        conn.execute("UPDATE notes SET content='beluga edited' WHERE id=?", (nid,))
+        conn.commit()
+        assert any("beluga" in c for c in _hits("beluga")), _hits("beluga")
+        assert not _hits("narwhal"), "stale FTS token after content edit"
+        # valid FTS rows are NOT reported as orphans by the integrity report
+        assert _orphan_counts(conn)["notes_fts_orphans"] == 0
     finally:
         conn.close()

--- a/tests/test_sync_migrate.py
+++ b/tests/test_sync_migrate.py
@@ -119,3 +119,53 @@ def test_migration_idempotent(fresh_mp):
     assert migrate.apply(db.DB_PATH, do_apply=True) == 0
     # second apply is a clean no-op (already at target sync_schema_version)
     assert migrate.apply(db.DB_PATH, do_apply=True) == 0
+
+
+def test_migration_rebuilds_notes_fts_and_indexes(fresh_mp):
+    """Blocker #2 regression: the re-id migration drops notes' indexes +
+    notes_fts triggers and leaves notes_fts keyed on the (now-TEXT) id. Both
+    pre-existing and newly-inserted notes must stay FTS-searchable, and the
+    indexes/triggers must be restored."""
+    from threadkeeper.sync import migrate
+    db = fresh_mp["db"]
+    conn = db.get_db()
+    conn.execute("INSERT INTO threads(id,question,state,opened_at,last_touched_at)"
+                 " VALUES('T1','q','active',1,1)")
+    conn.execute("INSERT INTO notes(thread_id,content,kind,created_at)"
+                 " VALUES('T1','platypus pre-migration',?,1)", ("move",))
+    conn.commit()
+    conn.close()
+
+    assert migrate.apply(db.DB_PATH, do_apply=True) == 0
+
+    conn = db.get_db()
+    try:
+        def _fts(term):
+            return [r[0] for r in conn.execute(
+                "SELECT n.content FROM notes_fts f JOIN notes n ON n.rowid=f.rowid "
+                "WHERE notes_fts MATCH ?", (term,)).fetchall()]
+
+        # pre-existing note is still searchable after migration
+        assert any("platypus" in c for c in _fts("platypus")), _fts("platypus")
+        # FTS triggers were recreated
+        trigs = {r[0] for r in conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='trigger' "
+            "AND name IN ('notes_fts_ai','notes_fts_ad')")}
+        assert trigs == {"notes_fts_ai", "notes_fts_ad"}, trigs
+        # ordinary indexes were recreated
+        idx = {r[0] for r in conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='index' "
+            "AND name IN ('idx_notes_thread','idx_notes_created')")}
+        assert idx == {"idx_notes_thread", "idx_notes_created"}, idx
+        # notes_fts is keyed on the integer rowid, not the TEXT id
+        fts_sql = conn.execute(
+            "SELECT sql FROM sqlite_master WHERE name='notes_fts'").fetchone()[0]
+        assert "content_rowid='rowid'" in fts_sql, fts_sql
+        # a NEW note inserted post-migration is searchable via the recreated trigger
+        tid = conn.execute("SELECT id FROM threads LIMIT 1").fetchone()[0]
+        conn.execute("INSERT INTO notes(thread_id,content,kind,created_at)"
+                     " VALUES(?,?,?,2)", (tid, "narwhal post-migration", "move"))
+        conn.commit()
+        assert any("narwhal" in c for c in _fts("narwhal")), _fts("narwhal")
+    finally:
+        conn.close()

--- a/tests/test_sync_migrate.py
+++ b/tests/test_sync_migrate.py
@@ -58,7 +58,7 @@ def test_migration_reids_and_fixes_refs(fresh_mp):
     # dry-run writes nothing
     assert migrate.apply(db_path, do_apply=False) == 0
     c = sqlite3.connect(str(db_path))
-    assert c.execute("PRAGMA user_version").fetchone()[0] == 0
+    assert migrate._sync_version(c) == 0
     assert c.execute("SELECT id FROM notes WHERE id='1'").fetchone() is not None
     c.close()
 
@@ -68,7 +68,7 @@ def test_migration_reids_and_fixes_refs(fresh_mp):
     c = sqlite3.connect(str(db_path))
     c.row_factory = sqlite3.Row
     try:
-        assert c.execute("PRAGMA user_version").fetchone()[0] == SYNC_SCHEMA_VERSION
+        assert migrate._sync_version(c) == SYNC_SCHEMA_VERSION
         # notes.id is now TEXT ULID, not the old integer
         notes = {r["content"]: r["id"] for r in c.execute("SELECT id,content FROM notes")}
         assert set(notes) == {"n1", "n2"}
@@ -117,5 +117,5 @@ def test_migration_idempotent(fresh_mp):
     _seed(conn)
     conn.close()
     assert migrate.apply(db.DB_PATH, do_apply=True) == 0
-    # second apply is a clean no-op (already at target user_version)
+    # second apply is a clean no-op (already at target sync_schema_version)
     assert migrate.apply(db.DB_PATH, do_apply=True) == 0

--- a/tests/test_sync_migrate.py
+++ b/tests/test_sync_migrate.py
@@ -1,0 +1,121 @@
+"""Step 2: the opt-in re-id migration (INTEGER PK -> global TEXT id).
+
+Seeds the pre-migration schema shape (integer notes/verbatim/edges + short-hex
+threads/concepts + cross references), runs the migration on the temp DB, and
+asserts every id became a global ULID with all references rewritten in
+lockstep. See docs/sync.md."""
+from __future__ import annotations
+
+import sqlite3
+
+
+def _seed(conn):
+    """Insert rows with the OLD id shapes + the reference edges between them."""
+    now = 1_700_000_000
+    # short-hex TEXT ids (as _gen_short_id would produce pre-migration)
+    conn.execute("INSERT INTO threads(id,question,state,opened_at,last_touched_at)"
+                 " VALUES('T001','q','active',?,?)", (now, now))
+    conn.execute("INSERT INTO threads(id,question,state,parent_id,opened_at,last_touched_at)"
+                 " VALUES('T002','q2','active','T001',?,?)", (now, now))
+    conn.execute("INSERT INTO concepts(id,description,registered_at)"
+                 " VALUES('C001','desc',?)", (now,))
+    conn.execute("INSERT INTO distill(id,content,created_at) VALUES('D001','x',?)", (now,))
+    conn.execute("INSERT INTO distill_votes(distill_id,voter_cid,weight,voted_at)"
+                 " VALUES('D001','cidA',1.0,?)", (now,))
+    conn.execute("INSERT INTO user_dialectic(id,claim,created_at) VALUES('UC01','c',?)", (now,))
+    conn.execute("INSERT INTO user_dialectic(id,claim,superseded_by,state,created_at)"
+                 " VALUES('UC02','c2','UC01','superseded',?)", (now,))
+    conn.execute("INSERT INTO probes(id,category,prompt,created_at)"
+                 " VALUES('P001','cat','p',?)", (now,))
+    # INTEGER autoincrement rows
+    conn.execute("INSERT INTO notes(id,thread_id,content,kind,created_at)"
+                 " VALUES(1,'T001','n1','move',?)", (now,))
+    conn.execute("INSERT INTO notes(id,thread_id,content,kind,created_at)"
+                 " VALUES(2,'T002','n2','insight',?)", (now,))
+    conn.execute("INSERT INTO verbatim(id,speaker,content,thread_id,created_at)"
+                 " VALUES(1,'user','v','T001',?)", (now,))
+    conn.execute("INSERT INTO probe_results(id,probe_id,category,success,created_at)"
+                 " VALUES(1,'P001','cat',1,?)", (now,))
+    conn.execute("INSERT INTO dialectic_evidence(id,claim_id,kind,created_at)"
+                 " VALUES(1,'UC01','support',?)", (now,))
+    conn.execute("INSERT INTO evolve(id,suggestion,created_at) VALUES(1,'do x',?)", (now,))
+    # edges: polymorphic refs to a note (int id) and a concept (short-hex)
+    conn.execute("INSERT INTO edges(from_kind,from_id,to_kind,to_id,relation,created_at)"
+                 " VALUES('note','1','concept','C001','mentions',?)", (now,))
+    conn.execute("INSERT INTO edges(from_kind,from_id,to_kind,to_id,relation,created_at)"
+                 " VALUES('thread','T001','distill','D001','elaborates',?)", (now,))
+    conn.commit()
+
+
+def test_migration_reids_and_fixes_refs(fresh_mp):
+    from threadkeeper.sync import migrate, SYNC_SCHEMA_VERSION
+    db = fresh_mp["db"]
+    conn = db.get_db()
+    _seed(conn)
+    conn.close()
+
+    db_path = db.DB_PATH
+    # dry-run writes nothing
+    assert migrate.apply(db_path, do_apply=False) == 0
+    c = sqlite3.connect(str(db_path))
+    assert c.execute("PRAGMA user_version").fetchone()[0] == 0
+    assert c.execute("SELECT id FROM notes WHERE id='1'").fetchone() is not None
+    c.close()
+
+    # apply
+    assert migrate.apply(db_path, do_apply=True) == 0
+
+    c = sqlite3.connect(str(db_path))
+    c.row_factory = sqlite3.Row
+    try:
+        assert c.execute("PRAGMA user_version").fetchone()[0] == SYNC_SCHEMA_VERSION
+        # notes.id is now TEXT ULID, not the old integer
+        notes = {r["content"]: r["id"] for r in c.execute("SELECT id,content FROM notes")}
+        assert set(notes) == {"n1", "n2"}
+        for nid in notes.values():
+            assert not nid.isdigit() and len(nid) == 26  # ULID, no prefix
+
+        # thread self-ref parent_id remapped
+        t = {r["question"]: r for r in c.execute("SELECT id,question,parent_id FROM threads")}
+        assert t["q2"]["parent_id"] == t["q"]["id"]
+        assert t["q"]["id"].startswith("T") and len(t["q"]["id"]) == 27
+
+        # notes.thread_id remapped to the new thread ids
+        for r in c.execute("SELECT content,thread_id FROM notes"):
+            assert r["thread_id"] in {t["q"]["id"], t["q2"]["id"]}
+
+        # declared FK fixups
+        assert c.execute("SELECT distill_id FROM distill_votes").fetchone()[0] == \
+            c.execute("SELECT id FROM distill").fetchone()[0]
+        assert c.execute("SELECT claim_id FROM dialectic_evidence").fetchone()[0] == \
+            c.execute("SELECT id FROM user_dialectic WHERE claim='c'").fetchone()[0]
+        assert c.execute("SELECT superseded_by FROM user_dialectic WHERE claim='c2'").fetchone()[0] == \
+            c.execute("SELECT id FROM user_dialectic WHERE claim='c'").fetchone()[0]
+        assert c.execute("SELECT probe_id FROM probe_results").fetchone()[0] == \
+            c.execute("SELECT id FROM probes").fetchone()[0]
+
+        # polymorphic edges remapped for note + concept + thread + distill kinds
+        note_id = notes["n1"]
+        concept_id = c.execute("SELECT id FROM concepts").fetchone()[0]
+        e1 = c.execute("SELECT from_id,to_id FROM edges WHERE relation='mentions'").fetchone()
+        assert e1["from_id"] == note_id and e1["to_id"] == concept_id
+        e2 = c.execute("SELECT from_id,to_id FROM edges WHERE relation='elaborates'").fetchone()
+        assert e2["from_id"] == t["q"]["id"]
+        assert e2["to_id"] == c.execute("SELECT id FROM distill").fetchone()[0]
+
+        # baseline HLC + origin stamped on replicated rows
+        r = c.execute("SELECT hlc,origin_node FROM notes LIMIT 1").fetchone()
+        assert r["hlc"] and r["origin_node"] and r["origin_node"].startswith("N")
+    finally:
+        c.close()
+
+
+def test_migration_idempotent(fresh_mp):
+    from threadkeeper.sync import migrate
+    db = fresh_mp["db"]
+    conn = db.get_db()
+    _seed(conn)
+    conn.close()
+    assert migrate.apply(db.DB_PATH, do_apply=True) == 0
+    # second apply is a clean no-op (already at target user_version)
+    assert migrate.apply(db.DB_PATH, do_apply=True) == 0

--- a/tests/test_sync_protocol.py
+++ b/tests/test_sync_protocol.py
@@ -256,3 +256,89 @@ def test_push_embedding_backfill_is_bounded(fresh_mp, tmp_path):
         assert _null() == 2, "rebuild_derived exceeded the push budget"
     finally:
         conn.close()
+
+
+def test_background_embedding_backfill_is_not_an_lww_write(
+    fresh_mp, tmp_path, monkeypatch,
+):
+    """A derived embedding update must not re-stamp a replicated note.
+
+    Otherwise a background backfill on B can get a higher HLC than a concurrent
+    content edit on A and make the old content win LWW. This covers the actual
+    bounded background helper used after /sync/push leaves NULL rows behind.
+    """
+    import numpy as np
+
+    from threadkeeper import embeddings, ingest
+    from threadkeeper.sync import migrate, protocol
+    from threadkeeper.sync import identity as sync_id
+    from threadkeeper.helpers import gen_global_id
+
+    db = fresh_mp["db"]
+    pa = _build_db(db, migrate, tmp_path / "A.sqlite")
+    pb = _build_db(db, migrate, tmp_path / "B.sqlite")
+    a, b = _open(pa), _open(pb)
+    try:
+        tid = _add_thread(a, gen_global_id, "embedding-race")
+        nid = gen_global_id("")
+        a.execute(
+            "INSERT INTO notes(id,thread_id,content,kind,created_at) "
+            "VALUES(?,?,?,?,?)",
+            (nid, tid, "old content", "move", 1),
+        )
+        a.commit()
+
+        # Model a note beyond the bounded /sync/push slice.
+        old_budget = protocol._SYNC_EMBED_PUSH_BUDGET
+        protocol._SYNC_EMBED_PUSH_BUDGET = 0
+        try:
+            protocol.sync_pair(a, b)
+        finally:
+            protocol._SYNC_EMBED_PUSH_BUDGET = old_budget
+        before = b.execute(
+            "SELECT origin_node,hlc FROM notes WHERE id=?", (nid,)
+        ).fetchone()
+        oplog_before = b.execute("SELECT COUNT(*) FROM sync_oplog").fetchone()[0]
+
+        # A real user edit races with B's later derived-only backfill.
+        a.execute("UPDATE notes SET content='user edit wins' WHERE id=?", (nid,))
+        a.commit()
+        future = sync_id._now_ms() + 120_000
+        b.execute(
+            "UPDATE sync_state SET hlc_phys_ms=?,hlc_counter=0 WHERE id=1",
+            (future,),
+        )
+        b.commit()
+
+        monkeypatch.setattr(fresh_mp["config"], "SEMANTIC_AVAILABLE", True)
+        monkeypatch.setattr(
+            embeddings,
+            "encode_many",
+            lambda texts: np.zeros(
+                (len(texts), fresh_mp["config"].EMBED_DIM), dtype="float32"
+            ),
+        )
+        assert ingest._backfill_background_embeddings(b, max_rows=20) == 1
+
+        after = b.execute(
+            "SELECT origin_node,hlc,embedding FROM notes WHERE id=?", (nid,)
+        ).fetchone()
+        assert after["embedding"] is not None
+        assert (after["origin_node"], after["hlc"]) == (
+            before["origin_node"], before["hlc"]
+        )
+        assert (
+            b.execute("SELECT COUNT(*) FROM sync_oplog").fetchone()[0]
+            == oplog_before
+        )
+
+        # Reconcile the user edit. With no synthetic B-side LWW write, the edit
+        # must win on both replicas despite B's future local clock.
+        protocol.sync_pair(a, b)
+        for conn in (a, b):
+            assert conn.execute(
+                "SELECT content FROM notes WHERE id=?", (nid,)
+            ).fetchone()[0] == "user edit wins"
+    finally:
+        a.close()
+        b.close()

--- a/tests/test_sync_protocol.py
+++ b/tests/test_sync_protocol.py
@@ -11,11 +11,15 @@ def _build_db(dbmod, migrate, path):
     """Materialize + migrate a standalone DB file at `path`."""
     old = dbmod.DB_PATH
     dbmod.DB_PATH = path
+    # bootstrap_db latches once per process; force it to re-materialize schema
+    # at this fresh path (the fixture only resets the latch once per test).
+    dbmod.bootstrap_db(force=True)
     try:
         dbmod.get_db().close()
         assert migrate.apply(path, do_apply=True) == 0
     finally:
         dbmod.DB_PATH = old
+        dbmod._BOOTSTRAPPED = False
     return path
 
 

--- a/tests/test_sync_protocol.py
+++ b/tests/test_sync_protocol.py
@@ -1,0 +1,92 @@
+"""Step 4: anti-entropy convergence. Three migrated DBs with distinct node
+ids write concurrently; reconciling along a chain (A-B, B-C — no direct A-C)
+must converge all three to the union, resolve concurrent edits by LWW, and
+propagate deletes as tombstones. See docs/sync.md."""
+from __future__ import annotations
+
+import sqlite3
+
+
+def _build_db(dbmod, migrate, path):
+    """Materialize + migrate a standalone DB file at `path`."""
+    old = dbmod.DB_PATH
+    dbmod.DB_PATH = path
+    try:
+        dbmod.get_db().close()
+        assert migrate.apply(path, do_apply=True) == 0
+    finally:
+        dbmod.DB_PATH = old
+    return path
+
+
+def _open(path):
+    c = sqlite3.connect(str(path))
+    c.row_factory = sqlite3.Row
+    return c
+
+
+def _add_thread(conn, gen, question):
+    tid = gen("T")
+    conn.execute(
+        "INSERT INTO threads(id,question,state,opened_at,last_touched_at)"
+        " VALUES(?,?,?,?,?)", (tid, question, "active", 1, 1))
+    conn.commit()  # capture trigger stamps hlc/origin
+    return tid
+
+
+def _questions(conn):
+    return {r[0] for r in conn.execute(
+        "SELECT question FROM threads WHERE deleted=0 OR deleted IS NULL")}
+
+
+def test_three_node_convergence_lww_and_delete(fresh_mp, tmp_path):
+    from threadkeeper.sync import migrate, protocol
+    from threadkeeper.helpers import gen_global_id
+    db = fresh_mp["db"]
+
+    pa = _build_db(db, migrate, tmp_path / "A.sqlite")
+    pb = _build_db(db, migrate, tmp_path / "B.sqlite")
+    pc = _build_db(db, migrate, tmp_path / "C.sqlite")
+    a, b, c = _open(pa), _open(pb), _open(pc)
+    try:
+        # concurrent independent writes on each node
+        ta = _add_thread(a, gen_global_id, "from-A")
+        _add_thread(b, gen_global_id, "from-B")
+        _add_thread(c, gen_global_id, "from-C")
+
+        # reconcile along a CHAIN only: A<->B, B<->C. No direct A<->C link.
+        for _ in range(3):
+            protocol.sync_pair(a, b)
+            protocol.sync_pair(b, c)
+
+        # transitive union: every node has all three (A's data reached C via B)
+        for conn in (a, b, c):
+            assert {"from-A", "from-B", "from-C"} <= _questions(conn)
+
+        # concurrent edit of the SAME row on A and C → LWW by hlc.
+        a.execute("UPDATE threads SET question='edited-on-A' WHERE id=?", (ta,))
+        a.commit()
+        c.execute("UPDATE threads SET question='edited-on-C' WHERE id=?", (ta,))
+        c.commit()
+        winner = c.execute("SELECT hlc FROM threads WHERE id=?", (ta,)).fetchone()[0]
+        # C edited after A (later wall/HLC in this sequential test) → C wins
+        for _ in range(3):
+            protocol.sync_pair(a, b)
+            protocol.sync_pair(b, c)
+        for conn in (a, b, c):
+            q = conn.execute("SELECT question FROM threads WHERE id=?", (ta,)).fetchone()[0]
+            assert q == "edited-on-C", conn
+
+        # delete on B propagates everywhere (tombstone), no resurrection
+        b.execute("DELETE FROM threads WHERE question='from-B'")
+        b.commit()
+        for _ in range(3):
+            protocol.sync_pair(a, b)
+            protocol.sync_pair(b, c)
+        for conn in (a, b, c):
+            assert "from-B" not in _questions(conn), conn
+
+        # idempotent: another round changes nothing
+        assert protocol.sync_pair(a, b) == (0, 0)
+    finally:
+        a.close(); b.close(); c.close()

--- a/tests/test_sync_protocol.py
+++ b/tests/test_sync_protocol.py
@@ -141,3 +141,62 @@ def test_receive_advances_hlc_so_later_local_edit_wins(fresh_mp, tmp_path):
             assert q == "edited-on-A", (conn, q)
     finally:
         a.close(); b.close()
+
+
+def test_sync_recomputes_missing_embeddings(fresh_mp, tmp_path):
+    """F4 regression: embeddings are stripped from the wire, so a synced concept
+    (or dialog row) lands with NULL embedding and must be re-embedded locally
+    during rebuild_derived — else it is invisible to semantic search."""
+    from threadkeeper.config import SEMANTIC_AVAILABLE
+    if not SEMANTIC_AVAILABLE:
+        import pytest
+        pytest.skip("needs embeddings")
+    from threadkeeper.sync import migrate, protocol
+    from threadkeeper.helpers import gen_global_id
+    db = fresh_mp["db"]
+    pa = _build_db(db, migrate, tmp_path / "A.sqlite")
+    pb = _build_db(db, migrate, tmp_path / "B.sqlite")
+    a, b = _open(pa), _open(pb)
+    try:
+        cid = gen_global_id("C")
+        a.execute("INSERT INTO concepts(id,description,registered_at) VALUES(?,?,?)",
+                  (cid, "octopus camouflage behaviour", 1))
+        a.commit()
+        protocol.sync_pair(a, b)
+        # B received the concept (content) and re-embedded it locally.
+        emb = b.execute("SELECT embedding FROM concepts WHERE id=?", (cid,)).fetchone()[0]
+        assert emb is not None, "synced concept embedding was not recomputed on B"
+    finally:
+        a.close()
+        b.close()
+
+
+def test_apply_preserves_local_embedding_on_unchanged_content(fresh_mp):
+    """F4 regression: a winning remote put must not clobber the local embedding
+    (never shipped) when the embed-source text is unchanged."""
+    from threadkeeper.sync import migrate, protocol
+    from threadkeeper.helpers import gen_global_id
+    db = fresh_mp["db"]
+    db.get_db().close()
+    assert migrate.apply(db.DB_PATH, do_apply=True) == 0
+    conn = db.get_db()
+    try:
+        cid = gen_global_id("C")
+        conn.execute(
+            "INSERT INTO concepts(id,description,embedding,embed_backend,registered_at)"
+            " VALUES(?,?,?,?,?)", (cid, "same text", b"\x01\x02\x03\x04", "onnx", 1))
+        conn.commit()
+        # a remote put with the SAME description but a dominating hlc
+        row = dict(conn.execute("SELECT * FROM concepts WHERE id=?", (cid,)).fetchone())
+        row.pop("embedding", None)
+        row.pop("embed_backend", None)
+        newer = "999999999999999:000000:Npeer"
+        row["hlc"] = newer
+        row["origin_node"] = "Npeer"
+        assert protocol.apply_changes(
+            conn, [{"tbl": "concepts", "op": "put", "hlc": newer,
+                    "origin": "Npeer", "row": row}]) == 1
+        emb = conn.execute("SELECT embedding FROM concepts WHERE id=?", (cid,)).fetchone()[0]
+        assert emb == b"\x01\x02\x03\x04", "local embedding clobbered on unchanged-content upsert"
+    finally:
+        conn.close()

--- a/tests/test_sync_protocol.py
+++ b/tests/test_sync_protocol.py
@@ -72,14 +72,19 @@ def test_three_node_convergence_lww_and_delete(fresh_mp, tmp_path):
         a.commit()
         c.execute("UPDATE threads SET question='edited-on-C' WHERE id=?", (ta,))
         c.commit()
-        winner = c.execute("SELECT hlc FROM threads WHERE id=?", (ta,)).fetchone()[0]
-        # C edited after A (later wall/HLC in this sequential test) → C wins
+        # Concurrent (non-causal) edits: LWW resolves by HLC total order, which
+        # is NOT the same as wall order for two sub-millisecond-apart writes on
+        # different nodes. Whichever edit carries the higher HLC must win, and
+        # every node must converge on it.
+        ha = a.execute("SELECT hlc FROM threads WHERE id=?", (ta,)).fetchone()[0]
+        hc = c.execute("SELECT hlc FROM threads WHERE id=?", (ta,)).fetchone()[0]
+        expected = "edited-on-C" if hc > ha else "edited-on-A"
         for _ in range(3):
             protocol.sync_pair(a, b)
             protocol.sync_pair(b, c)
         for conn in (a, b, c):
             q = conn.execute("SELECT question FROM threads WHERE id=?", (ta,)).fetchone()[0]
-            assert q == "edited-on-C", conn
+            assert q == expected, (conn, q, expected)
 
         # delete on B propagates everywhere (tombstone), no resurrection
         b.execute("DELETE FROM threads WHERE question='from-B'")
@@ -94,3 +99,45 @@ def test_three_node_convergence_lww_and_delete(fresh_mp, tmp_path):
         assert protocol.sync_pair(a, b) == (0, 0)
     finally:
         a.close(); b.close(); c.close()
+
+
+def test_receive_advances_hlc_so_later_local_edit_wins(fresh_mp, tmp_path):
+    """Blocker #1 regression: after receiving a clock-ahead remote row, a
+    subsequent LOCAL edit must carry an HLC greater than the received value —
+    otherwise LWW silently drops the user's edit on the next reconcile."""
+    from threadkeeper.sync import migrate, protocol
+    from threadkeeper.sync import identity as sync_id
+    from threadkeeper.helpers import gen_global_id
+    db = fresh_mp["db"]
+
+    pa = _build_db(db, migrate, tmp_path / "A.sqlite")
+    pb = _build_db(db, migrate, tmp_path / "B.sqlite")
+    a, b = _open(pa), _open(pb)
+    try:
+        # Skew B's clock ~60s into the future, then write a row on B.
+        future = sync_id._now_ms() + 60_000
+        b.execute("UPDATE sync_state SET hlc_phys_ms=?, hlc_counter=0 WHERE id=1",
+                  (future,))
+        b.commit()
+        tid = _add_thread(b, gen_global_id, "from-B-future")
+
+        # A pulls B's future-clocked row.
+        protocol.apply_changes(a, protocol.collect_changes(b, protocol.version_vector(a)))
+
+        # The user edits that row locally on A (A's wall clock is normal).
+        a.execute("UPDATE threads SET question='edited-on-A' WHERE id=?", (tid,))
+        a.commit()
+
+        a_hlc = a.execute("SELECT hlc FROM threads WHERE id=?", (tid,)).fetchone()[0]
+        b_hlc = b.execute("SELECT hlc FROM threads WHERE id=?", (tid,)).fetchone()[0]
+        assert a_hlc > b_hlc, f"local edit hlc {a_hlc!r} !> received {b_hlc!r}"
+
+        # Reconcile: both nodes must converge on A's edit (LWW picks the later write).
+        for _ in range(2):
+            protocol.sync_pair(a, b)
+        for conn in (a, b):
+            q = conn.execute("SELECT question FROM threads WHERE id=?",
+                             (tid,)).fetchone()[0]
+            assert q == "edited-on-A", (conn, q)
+    finally:
+        a.close(); b.close()

--- a/tests/test_sync_protocol.py
+++ b/tests/test_sync_protocol.py
@@ -200,3 +200,59 @@ def test_apply_preserves_local_embedding_on_unchanged_content(fresh_mp):
         assert emb == b"\x01\x02\x03\x04", "local embedding clobbered on unchanged-content upsert"
     finally:
         conn.close()
+
+
+def test_push_embedding_backfill_is_bounded(fresh_mp, tmp_path):
+    """R3-F regression: /sync/push (rebuild_derived) must re-embed at most the
+    budget per call so a large corpus can't blow the client timeout; the
+    remainder is finished by later (background) passes."""
+    from threadkeeper.config import SEMANTIC_AVAILABLE
+    if not SEMANTIC_AVAILABLE:
+        import pytest
+        pytest.skip("needs embeddings")
+    from threadkeeper.sync import migrate, protocol
+    from threadkeeper.ingest import _backfill_sync_embeddings
+    from threadkeeper.helpers import gen_global_id
+    db = fresh_mp["db"]
+    _build_db(db, migrate, tmp_path / "A.sqlite")
+    conn = _open(tmp_path / "A.sqlite")
+    try:
+        # seed more NULL-embedding concepts than the push budget
+        for i in range(5):
+            conn.execute(
+                "INSERT INTO concepts(id,description,registered_at) VALUES(?,?,?)",
+                (gen_global_id("C"), f"anteater fact number {i}", 1))
+        conn.commit()
+
+        def _null():
+            return conn.execute(
+                "SELECT COUNT(*) FROM concepts WHERE embedding IS NULL").fetchone()[0]
+        assert _null() == 5
+
+        # one bounded pass processes no more than the budget
+        did = _backfill_sync_embeddings(conn, max_rows=2)
+        assert did == 2, did
+        assert _null() == 3
+
+        # subsequent bounded passes finish the remainder
+        _backfill_sync_embeddings(conn, max_rows=2)
+        _backfill_sync_embeddings(conn, max_rows=2)
+        assert _null() == 0
+
+        # the /sync/push path honors the module budget: shrink it and confirm
+        # rebuild_derived leaves the excess for later.
+        for i in range(3):
+            conn.execute(
+                "INSERT INTO concepts(id,description,registered_at) VALUES(?,?,?)",
+                (gen_global_id("C"), f"badger fact {i}", 1))
+        conn.commit()
+        import threadkeeper.sync.protocol as pmod
+        old = pmod._SYNC_EMBED_PUSH_BUDGET
+        pmod._SYNC_EMBED_PUSH_BUDGET = 1
+        try:
+            protocol.rebuild_derived(conn)
+        finally:
+            pmod._SYNC_EMBED_PUSH_BUDGET = old
+        assert _null() == 2, "rebuild_derived exceeded the push budget"
+    finally:
+        conn.close()

--- a/tests/test_sync_reset_node.py
+++ b/tests/test_sync_reset_node.py
@@ -1,0 +1,178 @@
+"""R3-B3: cloned-DB identity reset (tk-sync-reset-node).
+
+Copying a migrated DB onto a second active machine duplicates the sync node_id;
+because the version vector is MAX(hlc) per origin, two independent HLC streams
+under one origin lose a writer's changes. reset_node gives the clone a fresh
+identity while preserving the HLC high-water and leaving historical origins.
+"""
+from __future__ import annotations
+
+import shutil
+import sqlite3
+
+
+def _build_migrated(dbmod, migrate, path):
+    """Materialize + migrate a standalone DB file at `path` (own directory so
+    its node.id mirror doesn't collide with another DB's)."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    old = dbmod.DB_PATH
+    dbmod.DB_PATH = path
+    dbmod.bootstrap_db(force=True)
+    try:
+        dbmod.get_db().close()
+        assert migrate.apply(path, do_apply=True) == 0
+    finally:
+        dbmod.DB_PATH = old
+        dbmod._BOOTSTRAPPED = False
+    return path
+
+
+def _open(path):
+    c = sqlite3.connect(str(path))
+    c.row_factory = sqlite3.Row
+    return c
+
+
+def _node_id(conn):
+    return conn.execute("SELECT node_id FROM sync_state WHERE id=1").fetchone()[0]
+
+
+def _add_thread(conn, gen, question):
+    tid = gen("T")
+    conn.execute(
+        "INSERT INTO threads(id,question,state,opened_at,last_touched_at)"
+        " VALUES(?,?,?,?,?)", (tid, question, "active", 1, 1))
+    conn.commit()
+    return tid
+
+
+def _questions(conn):
+    return {r[0] for r in conn.execute(
+        "SELECT question FROM threads WHERE deleted=0 OR deleted IS NULL")}
+
+
+def test_reset_gives_distinct_id_and_keeps_history(fresh_mp, tmp_path):
+    from threadkeeper.sync import migrate, reset_node
+    from threadkeeper.helpers import gen_global_id
+    db = fresh_mp["db"]
+
+    src = _build_migrated(db, migrate, tmp_path / "src" / "db.sqlite")
+    a = _open(src)
+    tid = _add_thread(a, gen_global_id, "from-source")
+    src_node = _node_id(a)
+    origin_before = a.execute("SELECT origin_node FROM threads WHERE id=?",
+                              (tid,)).fetchone()[0]
+    a.close()
+
+    # clone the migrated DB and reset the clone's identity
+    clone = tmp_path / "clone" / "db.sqlite"
+    clone.parent.mkdir(parents=True)
+    shutil.copy2(src, clone)
+    assert reset_node.reset_node(clone, do_apply=True) == 0
+
+    b = _open(clone)
+    try:
+        assert _node_id(b) != src_node  # distinct identity
+        # historical row origin is unchanged (that history is already present)
+        assert b.execute("SELECT origin_node FROM threads WHERE id=?",
+                         (tid,)).fetchone()[0] == origin_before
+    finally:
+        b.close()
+
+    # dry-run writes nothing
+    before = _open(clone)
+    dry_id = _node_id(before)
+    before.close()
+    assert reset_node.reset_node(clone, do_apply=False) == 0
+    after = _open(clone)
+    assert _node_id(after) == dry_id
+    after.close()
+
+
+def test_reset_lets_two_replicas_converge(fresh_mp, tmp_path):
+    from threadkeeper.sync import migrate, reset_node, protocol
+    from threadkeeper.sync import identity as sync_id
+    from threadkeeper.helpers import gen_global_id
+    db = fresh_mp["db"]
+
+    src = _build_migrated(db, migrate, tmp_path / "src" / "db.sqlite")
+    clone = tmp_path / "clone" / "db.sqlite"
+    clone.parent.mkdir(parents=True)
+    shutil.copy2(src, clone)
+    assert reset_node.reset_node(clone, do_apply=True) == 0
+
+    a, b = _open(src), _open(clone)
+    try:
+        # independent writes; skew the clone's clock forward
+        _add_thread(a, gen_global_id, "on-source")
+        future = sync_id._now_ms() + 120_000
+        b.execute("UPDATE sync_state SET hlc_phys_ms=?, hlc_counter=0 WHERE id=1",
+                  (future,))
+        b.commit()
+        _add_thread(b, gen_global_id, "on-clone")
+
+        for _ in range(3):
+            protocol.sync_pair(a, b)
+        for conn in (a, b):
+            assert {"on-source", "on-clone"} <= _questions(conn), conn
+        # both origins appear in each node's version vector
+        for conn in (a, b):
+            vv = protocol.version_vector(conn)
+            assert len(vv) == 2, vv
+    finally:
+        a.close()
+        b.close()
+
+
+def test_reset_preserves_hlc_high_water(fresh_mp, tmp_path):
+    from threadkeeper.sync import migrate, reset_node, protocol
+    from threadkeeper.helpers import gen_global_id
+    db = fresh_mp["db"]
+
+    src = _build_migrated(db, migrate, tmp_path / "src" / "db.sqlite")
+    conn = _open(src)
+    try:
+        # apply a remote row carrying a far-future HLC → DB has now observed it
+        future_hlc = "999999999999999:000000:Nfuture"
+        row = {"id": gen_global_id("T"), "question": "future", "state": "active",
+               "opened_at": 1, "last_touched_at": 1,
+               "hlc": future_hlc, "origin_node": "Nfuture", "deleted": 0}
+        protocol.apply_changes(conn, [{"tbl": "threads", "op": "put",
+                                       "hlc": future_hlc, "origin": "Nfuture",
+                                       "row": row}])
+        conn.close()
+
+        assert reset_node.reset_node(src, do_apply=True) == 0
+
+        # a local write after the reset must still out-rank the future HLC
+        conn = _open(src)
+        tid = _add_thread(conn, gen_global_id, "local-after-reset")
+        local_hlc = conn.execute("SELECT hlc FROM threads WHERE id=?",
+                                 (tid,)).fetchone()[0]
+        assert local_hlc > future_hlc, f"{local_hlc!r} !> {future_hlc!r}"
+    finally:
+        conn.close()
+
+
+def test_reset_replaces_node_id_mirror(fresh_mp, tmp_path):
+    from threadkeeper.sync import migrate, reset_node
+    from threadkeeper.sync import identity as sync_id
+    db = fresh_mp["db"]
+
+    src = _build_migrated(db, migrate, tmp_path / "src" / "db.sqlite")
+    mirror = src.parent / "node.id"
+
+    # seed the mirror with the OLD id (get_node_id writes it when missing)
+    conn = _open(src)
+    old_db = _node_id(conn)
+    conn.close()
+    mirror.write_text(old_db + "\n")
+
+    assert reset_node.reset_node(src, do_apply=True) == 0
+
+    conn = _open(src)
+    new_db = _node_id(conn)
+    conn.close()
+    assert new_db != old_db
+    # mirror replaced with the new id, not left stale
+    assert mirror.read_text().strip() == new_db

--- a/tests/test_sync_reset_node.py
+++ b/tests/test_sync_reset_node.py
@@ -176,3 +176,25 @@ def test_reset_replaces_node_id_mirror(fresh_mp, tmp_path):
     assert new_db != old_db
     # mirror replaced with the new id, not left stale
     assert mirror.read_text().strip() == new_db
+
+
+def test_reset_dry_run_is_read_only_before_sync_migration(fresh_mp, capsys):
+    """The additive schema already has an empty sync_state table. A reset
+    dry-run must reject that DB without initializing the singleton row."""
+    from threadkeeper.sync import reset_node
+    db = fresh_mp["db"]
+    db.get_db().close()
+
+    conn = sqlite3.connect(str(db.DB_PATH))
+    before = conn.execute("SELECT COUNT(*) FROM sync_state").fetchone()[0]
+    conn.close()
+    assert before == 0
+
+    assert reset_node.reset_node(db.DB_PATH, do_apply=False) == 2
+    captured = capsys.readouterr()
+    assert "run tk-sync-migrate first" in captured.err
+
+    conn = sqlite3.connect(str(db.DB_PATH))
+    after = conn.execute("SELECT COUNT(*) FROM sync_state").fetchone()[0]
+    conn.close()
+    assert after == before

--- a/tests/test_sync_transport.py
+++ b/tests/test_sync_transport.py
@@ -1,0 +1,57 @@
+"""Step 5: HTTP transport — auth, routing, and JSON round-trip of the pull
+endpoint against a live localhost server. End-to-end two-machine convergence is
+a live-smoke step (docs/sync.md); the merge itself is covered by
+test_sync_protocol."""
+from __future__ import annotations
+
+import json
+import threading
+import urllib.error
+import urllib.request
+from http.server import ThreadingHTTPServer
+
+
+def _serve(handler_mod):
+    httpd = ThreadingHTTPServer(("127.0.0.1", 0), handler_mod._Handler)
+    t = threading.Thread(target=httpd.serve_forever, daemon=True)
+    t.start()
+    return httpd, httpd.server_address[1]
+
+
+def _post(port, path, obj, token=None):
+    headers = {"Content-Type": "application/json"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    req = urllib.request.Request(
+        f"http://127.0.0.1:{port}{path}",
+        data=json.dumps(obj).encode(), headers=headers, method="POST")
+    with urllib.request.urlopen(req, timeout=10) as r:
+        return json.loads(r.read().decode())
+
+
+def test_pull_requires_token_and_returns_changeset(fresh_mp, monkeypatch):
+    from threadkeeper.sync import migrate, server as sync_server
+    db = fresh_mp["db"]
+    db.get_db().close()
+    assert migrate.apply(db.DB_PATH, do_apply=True) == 0
+
+    monkeypatch.setattr(sync_server, "SYNC_TOKEN", "s3cret")
+    httpd, port = _serve(sync_server)
+    try:
+        # no token → 401
+        try:
+            _post(port, "/sync/pull", {})
+            assert False, "expected 401"
+        except urllib.error.HTTPError as e:
+            assert e.code == 401
+
+        # valid token → 200 with a well-formed changeset
+        out = _post(port, "/sync/pull", {"vv": {}}, token="s3cret")
+        assert "vv" in out and "changes" in out
+        assert isinstance(out["changes"], list)
+
+        # push endpoint accepts an (empty) changeset
+        out = _post(port, "/sync/push", {"changes": []}, token="s3cret")
+        assert out.get("applied") == 0
+    finally:
+        httpd.shutdown()

--- a/tests/test_tool_annotations.py
+++ b/tests/test_tool_annotations.py
@@ -33,7 +33,8 @@ READ_TOOLS = {
     "memory_guard_status", "mp_dashboard", "mp_health", "neighbors", "peers",
     "pending_distillates", "pickup_candidates", "reliability_for",
     "review_candidates", "run_probe", "search", "shadow_review_status",
-    "skill_list", "spawn_budget_status", "spawn_status", "task_logs",
+    "skill_list", "spawn_budget_status", "spawn_status", "sync_peers",
+    "sync_status", "task_logs",
     "task_thread", "tasks", "weak_spots", "whoami",
 }
 
@@ -63,7 +64,7 @@ WRITE_TOOLS = {
     "register_concept", "register_probe", "reject_candidate", "release_pickup",
     "respond", "review_thread", "search_via_parent", "session_end",
     "shadow_review_run", "skill_record", "spawn", "spawn_budget_set",
-    "style_set", "tag_signal", "tournament", "validate_threads",
+    "style_set", "sync_now", "tag_signal", "tournament", "validate_threads",
     "verbatim_user", "vote_distill", "wait", "whisper",
 }
 

--- a/threadkeeper/config.py
+++ b/threadkeeper/config.py
@@ -410,6 +410,16 @@ class Settings(BaseSettings):
     dialectic_validate_batch_size: int = 50
     dialectic_max_new_claims: int = 3
 
+    # ── Cross-machine sync (feature-gated; off until re-id migration ran) ──────
+    # Symmetric P2P anti-entropy replication of the memory tables across a
+    # user's machines. All default OFF: sync stays dormant until the operator
+    # runs `tk-sync-migrate` (which bumps PRAGMA user_version) AND configures
+    # peers + a listen address. See docs/sync.md.
+    sync_interval_s: float = 0.0          # daemon tick; 0 = sync daemon off
+    sync_peers: str = ""                  # CSV of peer base URLs (host:port)
+    sync_listen: str = ""                 # local listen "host:port"; "" = no server
+    sync_token: str = ""                  # shared bearer token for peer auth
+
     # ── Nested spawn config ───────────────────────────────────────────────────
     spawn: SpawnSettings = SpawnSettings()
 
@@ -756,6 +766,10 @@ def _derive_constants(s: "Settings") -> dict:
         "DIALECTIC_VALIDATE_MIN": s.dialectic_validate_min,
         "DIALECTIC_VALIDATE_BATCH_SIZE": s.dialectic_validate_batch_size,
         "DIALECTIC_MAX_NEW_CLAIMS": s.dialectic_max_new_claims,
+        "SYNC_INTERVAL_S": s.sync_interval_s,
+        "SYNC_PEERS": s.sync_peers,
+        "SYNC_LISTEN": s.sync_listen,
+        "SYNC_TOKEN": s.sync_token,
     }
 
 

--- a/threadkeeper/config.py
+++ b/threadkeeper/config.py
@@ -413,12 +413,16 @@ class Settings(BaseSettings):
     # ── Cross-machine sync (feature-gated; off until re-id migration ran) ──────
     # Symmetric P2P anti-entropy replication of the memory tables across a
     # user's machines. All default OFF: sync stays dormant until the operator
-    # runs `tk-sync-migrate` (which bumps PRAGMA user_version) AND configures
-    # peers + a listen address. See docs/sync.md.
+    # runs `tk-sync-migrate` (which sets sync_state.sync_schema_version) AND
+    # configures peers + a listen address. See docs/sync.md.
     sync_interval_s: float = 0.0          # daemon tick; 0 = sync daemon off
     sync_peers: str = ""                  # CSV of peer base URLs (host:port)
     sync_listen: str = ""                 # local listen "host:port"; "" = no server
     sync_token: str = ""                  # shared bearer token for peer auth
+    # The DB replicates full private transcripts, so the server refuses to bind a
+    # wildcard/public address (0.0.0.0, ::, a public IP, or an unresolvable host)
+    # by default. Set true to override — only behind your own network controls.
+    sync_allow_public_bind: bool = False
 
     # ── Nested spawn config ───────────────────────────────────────────────────
     spawn: SpawnSettings = SpawnSettings()
@@ -770,6 +774,7 @@ def _derive_constants(s: "Settings") -> dict:
         "SYNC_PEERS": s.sync_peers,
         "SYNC_LISTEN": s.sync_listen,
         "SYNC_TOKEN": s.sync_token,
+        "SYNC_ALLOW_PUBLIC_BIND": s.sync_allow_public_bind,
     }
 
 

--- a/threadkeeper/db.py
+++ b/threadkeeper/db.py
@@ -33,7 +33,7 @@ __all__ = [
     "SCHEMA",
 ]
 
-CURRENT_SCHEMA_VERSION = 2
+CURRENT_SCHEMA_VERSION = 3
 
 # sqlite-vec extension state. We probe once at first get_db() call and
 # cache the verdict. _VEC_AVAILABLE = True means vec0 virtual tables work
@@ -581,6 +581,35 @@ CREATE INDEX IF NOT EXISTS idx_skill_usage_origin  ON skill_usage(created_by_ori
 CREATE INDEX IF NOT EXISTS idx_lesson_usage_tier   ON lesson_usage(tier);
 CREATE INDEX IF NOT EXISTS idx_lesson_usage_access ON lesson_usage(last_used_at, last_viewed_at);
 
+-- ── Cross-machine sync bookkeeping (see threadkeeper/sync/) ──────────────
+-- Node identity + Hybrid Logical Clock singleton.
+CREATE TABLE IF NOT EXISTS sync_state (
+    id           INTEGER PRIMARY KEY CHECK (id = 1),
+    node_id      TEXT NOT NULL,
+    hlc_phys_ms  INTEGER NOT NULL DEFAULT 0,
+    hlc_counter  INTEGER NOT NULL DEFAULT 0,
+    -- Gate for the opt-in re-id migration. 0 = not migrated; the sync feature
+    -- (capture triggers, TEXT-PK vec keying) stays dormant until sync/migrate.py
+    -- sets this to SYNC_SCHEMA_VERSION. Deliberately NOT PRAGMA user_version,
+    -- which main owns as its schema-migration counter (CURRENT_SCHEMA_VERSION).
+    sync_schema_version INTEGER NOT NULL DEFAULT 0
+);
+-- Change-capture index: one row per mutation of a replicated row (op='put'|'del').
+CREATE TABLE IF NOT EXISTS sync_oplog (
+    seq          INTEGER PRIMARY KEY AUTOINCREMENT,
+    tbl          TEXT NOT NULL,
+    gid          TEXT NOT NULL,
+    op           TEXT NOT NULL,
+    hlc          TEXT NOT NULL,
+    origin_node  TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_sync_oplog_hlc ON sync_oplog(hlc);
+-- Version vector: highest HLC this node has durably applied per origin node.
+CREATE TABLE IF NOT EXISTS sync_peer_vv (
+    origin_node  TEXT PRIMARY KEY,
+    max_hlc      TEXT NOT NULL
+);
+
 CREATE VIRTUAL TABLE IF NOT EXISTS notes_fts USING fts5(
     content, content='notes', content_rowid='id'
 );
@@ -667,6 +696,29 @@ POST_SCHEMA_INDEXES = (
     "ON tasks(retry_root)",
     "CREATE INDEX IF NOT EXISTS idx_tasks_retry_of "
     "ON tasks(retry_of)",
+)
+
+# Memory tables replicated by cross-machine sync (threadkeeper/sync/). Each gets
+# additive hlc/origin_node/deleted columns (see _run_schema_migrations). Node-
+# local tables (sessions, presence, cursors, ingest_state, resource_controls,
+# events, signals, tasks, extract_candidates, daemon_state) and derived indexes
+# (*_fts, *_vec) are deliberately excluded — they never sync. See docs/sync.md.
+_SYNC_REPLICATED_TABLES = (
+    "threads", "notes", "verbatim", "dialog_messages", "core_memory",
+    "concepts", "distill", "distill_votes", "user_dialectic",
+    "dialectic_evidence", "dialectic_observations", "edges", "skill_usage",
+    "reliability", "probes", "probe_results", "evolve", "style",
+)
+
+# Additive sync columns stamped onto every replicated table: hlc/origin_node
+# carry a row's global write timestamp + author for last-writer-wins merges;
+# `deleted` is a tombstone (a delete propagates as deleted=1, not a hard DELETE,
+# once sync is live). Harmless pre-migration. The destructive INTEGER->TEXT PK
+# re-id is a separate opt-in step (threadkeeper/sync/migrate.py).
+_SYNC_COLUMN_DEFS = (
+    "ADD COLUMN hlc TEXT",
+    "ADD COLUMN origin_node TEXT",
+    "ADD COLUMN deleted INTEGER NOT NULL DEFAULT 0",
 )
 
 
@@ -805,7 +857,7 @@ def _rebuild_dialog_fts_if_needed(conn: sqlite3.Connection) -> None:
 
 
 def _run_schema_migrations(conn: sqlite3.Connection, from_version: int) -> None:
-    if from_version not in (0, 1):
+    if from_version not in (0, 1, 2):
         raise RuntimeError(
             f"unsupported SQLite schema version {from_version}; "
             f"expected 0..{CURRENT_SCHEMA_VERSION}"
@@ -814,17 +866,27 @@ def _run_schema_migrations(conn: sqlite3.Connection, from_version: int) -> None:
     # v2 (external-content dialog_fts): drop the old content-storing table
     # and scrub legacy raw-secret rows BEFORE the SCHEMA pass creates the
     # new table + its triggers, so the scrub UPDATEs fire no FTS triggers.
-    _drop_legacy_dialog_fts(conn)
-    _scrub_legacy_dialog_rows(conn)
+    # Only the v0/v1→v2 transition needs this; a v2 DB is already external
+    # content (both helpers are self-guarding no-ops, but skip the scrub scan).
+    if from_version < 2:
+        _drop_legacy_dialog_fts(conn)
+        _scrub_legacy_dialog_rows(conn)
 
     for statement in _iter_sql_statements(SCHEMA):
         conn.execute(statement)
     for ddl in LEGACY_COLUMN_MIGRATIONS:
         _apply_column_migration(conn, ddl)
+    # v3 (cross-machine sync): additive hlc/origin_node/deleted tombstone
+    # columns on every replicated table. Harmless while sync is dormant; the
+    # destructive INTEGER->TEXT PK re-id remains opt-in (sync/migrate.py).
+    for tbl in _SYNC_REPLICATED_TABLES:
+        for coldef in _SYNC_COLUMN_DEFS:
+            _apply_column_migration(conn, f"ALTER TABLE {tbl} {coldef}")
     _backfill_schema_data(conn)
     for idx in POST_SCHEMA_INDEXES:
         conn.execute(idx)
-    _rebuild_dialog_fts_if_needed(conn)
+    if from_version < 2:
+        _rebuild_dialog_fts_if_needed(conn)
     _set_user_version(conn, CURRENT_SCHEMA_VERSION)
 
 

--- a/threadkeeper/db.py
+++ b/threadkeeper/db.py
@@ -611,14 +611,25 @@ CREATE TABLE IF NOT EXISTS sync_peer_vv (
     max_hlc      TEXT NOT NULL
 );
 
+-- External-content FTS keyed on the integer notes.rowid (not notes.id): the
+-- re-id migration turns notes.id into a TEXT ULID, but an FTS5 content_rowid
+-- must stay integer. Pre-migration notes.id == rowid, so this is equivalent
+-- there; keeping the baseline on rowid means a self-heal/recreate on a migrated
+-- DB reproduces the correct layout. All notes_fts consumers join on n.rowid.
 CREATE VIRTUAL TABLE IF NOT EXISTS notes_fts USING fts5(
-    content, content='notes', content_rowid='id'
+    content, content='notes', content_rowid='rowid'
 );
 CREATE TRIGGER IF NOT EXISTS notes_fts_ai AFTER INSERT ON notes BEGIN
-    INSERT INTO notes_fts(rowid, content) VALUES (new.id, new.content);
+    INSERT INTO notes_fts(rowid, content) VALUES (new.rowid, new.content);
 END;
 CREATE TRIGGER IF NOT EXISTS notes_fts_ad AFTER DELETE ON notes BEGIN
-    INSERT INTO notes_fts(notes_fts, rowid, content) VALUES('delete', old.id, old.content);
+    INSERT INTO notes_fts(notes_fts, rowid, content) VALUES('delete', old.rowid, old.content);
+END;
+-- OF content: fire only on a real content edit, not the frequent hlc/origin
+-- capture-stamp UPDATEs (which never touch content). Mirrors dialog_fts_au.
+CREATE TRIGGER IF NOT EXISTS notes_fts_au AFTER UPDATE OF content ON notes BEGIN
+    INSERT INTO notes_fts(notes_fts, rowid, content) VALUES('delete', old.rowid, old.content);
+    INSERT INTO notes_fts(rowid, content) VALUES (new.rowid, new.content);
 END;
 """
 

--- a/threadkeeper/db.py
+++ b/threadkeeper/db.py
@@ -589,8 +589,6 @@ CREATE TABLE IF NOT EXISTS sync_state (
     node_id      TEXT NOT NULL,
     hlc_phys_ms  INTEGER NOT NULL DEFAULT 0,
     hlc_counter  INTEGER NOT NULL DEFAULT 0,
-    -- 1 while applying remote changes: suppresses capture triggers.
-    applying     INTEGER NOT NULL DEFAULT 0,
     -- Gate for the opt-in re-id migration. 0 = not migrated; the sync feature
     -- (capture triggers, TEXT-PK vec keying) stays dormant until sync/migrate.py
     -- sets this to SYNC_SCHEMA_VERSION. Deliberately NOT PRAGMA user_version,

--- a/threadkeeper/db.py
+++ b/threadkeeper/db.py
@@ -13,6 +13,7 @@ from typing import TypeVar
 
 from .config import CURATOR_REPORTS_DIR, DB_PATH, EMBED_DIM, _ENV_FILE
 from .permissions import harden_storage_paths
+from .sync import SYNC_SCHEMA_VERSION
 
 logger = logging.getLogger(__name__)
 
@@ -588,6 +589,8 @@ CREATE TABLE IF NOT EXISTS sync_state (
     node_id      TEXT NOT NULL,
     hlc_phys_ms  INTEGER NOT NULL DEFAULT 0,
     hlc_counter  INTEGER NOT NULL DEFAULT 0,
+    -- 1 while applying remote changes: suppresses capture triggers.
+    applying     INTEGER NOT NULL DEFAULT 0,
     -- Gate for the opt-in re-id migration. 0 = not migrated; the sync feature
     -- (capture triggers, TEXT-PK vec keying) stays dormant until sync/migrate.py
     -- sets this to SYNC_SCHEMA_VERSION. Deliberately NOT PRAGMA user_version,
@@ -991,17 +994,58 @@ def _open_connection(*, autocommit: bool = False,
     return conn, vec_loaded
 
 
+def _sync_migrated(conn: sqlite3.Connection) -> bool:
+    """True once the opt-in re-id migration (threadkeeper/sync/migrate.py) has run.
+
+    Gated on sync_state.sync_schema_version — deliberately NOT PRAGMA
+    user_version, which main owns as its schema-migration counter
+    (CURRENT_SCHEMA_VERSION). An absent table/row means not migrated.
+    """
+    from .sync import SYNC_SCHEMA_VERSION
+
+    try:
+        row = conn.execute(
+            "SELECT sync_schema_version FROM sync_state WHERE id = 1"
+        ).fetchone()
+    except sqlite3.OperationalError:
+        return False
+    return bool(row) and int(row[0] or 0) >= SYNC_SCHEMA_VERSION
+
+
 def _ensure_vec_tables(conn: sqlite3.Connection, *, vec_loaded: bool) -> None:
     """Create sqlite-vec mirrors during bootstrap, never on read calls."""
     if not vec_loaded:
         return
+    migrated = _sync_migrated(conn)
     try:
-        conn.execute(
-            f"CREATE VIRTUAL TABLE IF NOT EXISTS notes_vec USING vec0("
-            f"  id INTEGER PRIMARY KEY,"
-            f"  embedding FLOAT[{EMBED_DIM}]"
-            f")"
-        )
+        if migrated:
+            # Post-migration notes.id is a global TEXT id, so notes_vec is keyed
+            # by a sidecar rowid map (mirrors dialog_vec/dialog_vec_map). Self-heal
+            # a legacy id-keyed notes_vec left by a pre-migration bootstrap: drop
+            # it once so it is recreated with the rowid schema (the backfill
+            # repopulates it via notes_vec_map).
+            _nv = conn.execute("PRAGMA table_info(notes_vec)").fetchall()
+            if _nv and any(c[1] == "id" for c in _nv):
+                conn.execute("DROP TABLE notes_vec")
+            conn.execute(
+                f"CREATE VIRTUAL TABLE IF NOT EXISTS notes_vec USING vec0("
+                f"  rowid INTEGER PRIMARY KEY,"
+                f"  embedding FLOAT[{EMBED_DIM}]"
+                f")"
+            )
+            conn.execute(
+                "CREATE TABLE IF NOT EXISTS notes_vec_map ("
+                "  rowid INTEGER PRIMARY KEY AUTOINCREMENT,"
+                "  gid   TEXT NOT NULL UNIQUE"
+                ")"
+            )
+        else:
+            conn.execute(
+                f"CREATE VIRTUAL TABLE IF NOT EXISTS notes_vec USING vec0("
+                f"  id INTEGER PRIMARY KEY,"
+                f"  embedding FLOAT[{EMBED_DIM}]"
+                f")"
+            )
         conn.execute(
             f"CREATE VIRTUAL TABLE IF NOT EXISTS dialog_vec USING vec0("
             f"  rowid INTEGER PRIMARY KEY,"
@@ -1018,6 +1062,28 @@ def _ensure_vec_tables(conn: sqlite3.Connection, *, vec_loaded: bool) -> None:
         )
     except sqlite3.OperationalError as exc:
         logger.debug("vec0 table creation skipped: %s", exc)
+
+
+def _ensure_sync_capture(conn: sqlite3.Connection) -> None:
+    """Install capture triggers once, only on a migrated DB.
+
+    Off the per-connection hot path — runs during bootstrap after the vec
+    mirrors. A sentinel trigger-existence check keeps re-bootstraps cheap.
+    Dormant until threadkeeper/sync/migrate.py sets the gate.
+    """
+    if not _sync_migrated(conn):
+        return
+    from .sync import capture, identity as sync_identity
+
+    try:
+        sync_identity.get_node_id(conn)
+        if not conn.execute(
+            "SELECT 1 FROM sqlite_master WHERE type='trigger' "
+            "AND name='notes__sync_ai'"
+        ).fetchone():
+            capture.install_triggers(conn)
+    except sqlite3.OperationalError:
+        pass
 
 
 def bootstrap_db() -> None:
@@ -1047,6 +1113,7 @@ def bootstrap_db() -> None:
             _execute_startup_pragma(conn, "PRAGMA journal_mode=WAL")
             _ensure_schema(conn)
             _ensure_vec_tables(conn, vec_loaded=vec_loaded)
+            _ensure_sync_capture(conn)
             conn.commit()
             _BOOTSTRAPPED = True
         finally:

--- a/threadkeeper/db.py
+++ b/threadkeeper/db.py
@@ -1086,18 +1086,24 @@ def _ensure_sync_capture(conn: sqlite3.Connection) -> None:
         pass
 
 
-def bootstrap_db() -> None:
+def bootstrap_db(force: bool = False) -> None:
     """Perform process startup setup exactly once.
 
     Cross-process schema serialization still lives in ``_ensure_schema``.
     This process-local latch only keeps ordinary tool connections from
     repeating journal-mode negotiation and DDL on every call.
+
+    ``force=True`` re-runs setup even if already latched. Needed when the DB
+    materially changes underneath a live process: the opt-in sync re-id
+    migration flips the sync gate, so bootstrap must re-run to rebuild the
+    migrated notes_vec keying and install capture triggers; tests also use it
+    when repointing ``DB_PATH`` to a fresh file mid-process.
     """
     global _BOOTSTRAPPED
-    if _BOOTSTRAPPED:
+    if _BOOTSTRAPPED and not force:
         return
     with _BOOTSTRAP_LOCK:
-        if _BOOTSTRAPPED:
+        if _BOOTSTRAPPED and not force:
             return
         harden_storage_paths(
             DB_PATH,

--- a/threadkeeper/embeddings.py
+++ b/threadkeeper/embeddings.py
@@ -317,13 +317,24 @@ def _vec0_notes_search(conn: sqlite3.Connection, qv_blob: bytes,
     """
     want = max(1, int(k))
     fetch_k = max(want * 8, 40) if embed_backend else want * 2 + 8
-    sql = (
-        "SELECT n.id, n.content, n.kind, n.thread_id, n.created_at, "
-        "       v.distance "
-        "FROM notes_vec v "
-        "JOIN notes n ON n.id = v.id "
-        "WHERE v.embedding MATCH ? AND k = ?"
-    )
+    if _notes_mapped(conn):
+        # Post-migration: notes.id is TEXT, joined via the notes_vec_map bridge.
+        sql = (
+            "SELECT n.id, n.content, n.kind, n.thread_id, n.created_at, "
+            "       v.distance "
+            "FROM notes_vec v "
+            "JOIN notes_vec_map m ON m.rowid = v.rowid "
+            "JOIN notes n ON n.id = m.gid "
+            "WHERE v.embedding MATCH ? AND k = ?"
+        )
+    else:
+        sql = (
+            "SELECT n.id, n.content, n.kind, n.thread_id, n.created_at, "
+            "       v.distance "
+            "FROM notes_vec v "
+            "JOIN notes n ON n.id = v.id "
+            "WHERE v.embedding MATCH ? AND k = ?"
+        )
     params: list = [qv_blob, fetch_k]
     if embed_backend:
         sql += " AND n.embed_backend = ?"
@@ -377,18 +388,43 @@ def _dialog_cosine_search(conn, query: str, k: int,
     return [{"score": s, **dict(r)} for s, r in scored[:k]]
 
 
-def _vec_upsert_note(conn: sqlite3.Connection, note_id: int,
+def _notes_mapped(conn: sqlite3.Connection) -> bool:
+    """True on a migrated DB where notes.id is TEXT and notes_vec is keyed via
+    the notes_vec_map sidecar (mirrors dialog_vec_map)."""
+    return conn.execute(
+        "SELECT 1 FROM sqlite_master WHERE type='table' AND name='notes_vec_map'"
+    ).fetchone() is not None
+
+
+def _vec_upsert_note(conn: sqlite3.Connection, note_id,
                      emb_blob: Optional[bytes]) -> None:
-    """Mirror a note's embedding into notes_vec. No-op when vec0 isn't
-    loaded or the blob is None. Safe to call multiple times — uses
-    INSERT OR REPLACE keyed by integer id."""
+    """Mirror a note's embedding into notes_vec. No-op when vec0 isn't loaded
+    or the blob is None. Pre-migration: keyed by integer notes.id. Post: keyed
+    by the notes_vec_map rowid resolved from the note's global TEXT id."""
     if not _vec_on() or emb_blob is None or not _vec_dim_ok(emb_blob):
         return
     try:
-        conn.execute(
-            "INSERT OR REPLACE INTO notes_vec(id, embedding) VALUES (?, ?)",
-            (note_id, emb_blob),
-        )
+        if _notes_mapped(conn):
+            gid = str(note_id)
+            row = conn.execute(
+                "SELECT rowid FROM notes_vec_map WHERE gid=?", (gid,)
+            ).fetchone()
+            if row is None:
+                cur = conn.execute(
+                    "INSERT INTO notes_vec_map(gid) VALUES (?)", (gid,)
+                )
+                vec_rowid = cur.lastrowid
+            else:
+                vec_rowid = row[0] if not hasattr(row, "keys") else row["rowid"]
+            conn.execute(
+                "INSERT OR REPLACE INTO notes_vec(rowid, embedding) VALUES (?, ?)",
+                (vec_rowid, emb_blob),
+            )
+        else:
+            conn.execute(
+                "INSERT OR REPLACE INTO notes_vec(id, embedding) VALUES (?, ?)",
+                (note_id, emb_blob),
+            )
     except sqlite3.OperationalError:
         pass  # vec0 table missing on this connection — silent fall-through
 
@@ -404,7 +440,17 @@ def _vec_delete_note(conn: sqlite3.Connection, note_id: int) -> None:
     if not _vec_on():
         return
     try:
-        conn.execute("DELETE FROM notes_vec WHERE id=?", (note_id,))
+        if _notes_mapped(conn):
+            gid = str(note_id)
+            row = conn.execute(
+                "SELECT rowid FROM notes_vec_map WHERE gid=?", (gid,)
+            ).fetchone()
+            if row is not None:
+                vec_rowid = row[0] if not hasattr(row, "keys") else row["rowid"]
+                conn.execute("DELETE FROM notes_vec WHERE rowid=?", (vec_rowid,))
+                conn.execute("DELETE FROM notes_vec_map WHERE gid=?", (gid,))
+        else:
+            conn.execute("DELETE FROM notes_vec WHERE id=?", (note_id,))
     except sqlite3.OperationalError:
         pass  # vec0 table missing on this connection — silent fall-through
 

--- a/threadkeeper/embeddings.py
+++ b/threadkeeper/embeddings.py
@@ -240,7 +240,14 @@ def embedding_index_health(conn: sqlite3.Connection) -> dict[str, int | str]:
             "SELECT COUNT(*) FROM notes WHERE embedding IS NOT NULL "
             "AND embed_backend=?", (active,),
         ),
+        # Post-migration notes_vec is keyed by rowid via notes_vec_map.gid;
+        # pre-migration it is keyed directly by the integer note id.
         "notes_vec": _count(
+            "SELECT COUNT(*) FROM notes n "
+            "JOIN notes_vec_map m ON m.gid=n.id "
+            "JOIN notes_vec v ON v.rowid=m.rowid "
+            "WHERE n.embed_backend=?", (active,),
+        ) if _notes_mapped(conn) else _count(
             "SELECT COUNT(*) FROM notes n JOIN notes_vec v ON v.id=n.id "
             "WHERE n.embed_backend=?", (active,),
         ),

--- a/threadkeeper/forget.py
+++ b/threadkeeper/forget.py
@@ -30,11 +30,15 @@ class ForgetPlan:
     selector: str
     selector_type: str
     dialog_uuids: list[str] = field(default_factory=list)
-    note_ids: list[int] = field(default_factory=list)
+    # notes/verbatim/dialectic_* are re-id'd INTEGER->TEXT by the sync migration,
+    # so their ids are strings post-migration (and plain str(int) pre-migration,
+    # which SQLite matches against an INTEGER column via affinity). Node-local
+    # tables (signals/events/extract_candidates) stay integer-keyed below.
+    note_ids: list[str] = field(default_factory=list)
     thread_ids: list[str] = field(default_factory=list)
-    verbatim_ids: list[int] = field(default_factory=list)
-    observation_ids: list[int] = field(default_factory=list)
-    evidence_ids: list[int] = field(default_factory=list)
+    verbatim_ids: list[str] = field(default_factory=list)
+    observation_ids: list[str] = field(default_factory=list)
+    evidence_ids: list[str] = field(default_factory=list)
     claim_ids: list[str] = field(default_factory=list)
     extract_candidate_ids: list[int] = field(default_factory=list)
     task_ids: list[str] = field(default_factory=list)
@@ -193,14 +197,14 @@ def _notes(
     conn: sqlite3.Connection,
     selector: str,
     selector_type: str,
-) -> tuple[list[int], list[str]]:
+) -> tuple[list[str], list[str]]:
     if selector_type == "thread_id":
         return (
             _fetch_col(
                 conn,
                 "SELECT id FROM notes WHERE thread_id=?",
                 (selector,),
-                cast=int,
+                cast=str,
             ),
             [selector],
         )
@@ -210,7 +214,7 @@ def _notes(
                 conn,
                 "SELECT id FROM notes WHERE session_id=?",
                 (selector,),
-                cast=int,
+                cast=str,
             ),
             [],
         )
@@ -221,20 +225,20 @@ def _verbatim_ids(
     conn: sqlite3.Connection,
     selector: str,
     selector_type: str,
-) -> list[int]:
+) -> list[str]:
     if selector_type == "thread_id":
         return _fetch_col(
             conn,
             "SELECT id FROM verbatim WHERE thread_id=?",
             (selector,),
-            cast=int,
+            cast=str,
         )
     if selector_type == "session_id":
         return _fetch_col(
             conn,
             "SELECT id FROM verbatim WHERE session_id=?",
             (selector,),
-            cast=int,
+            cast=str,
         )
     return []
 
@@ -303,7 +307,7 @@ def _dialectic_targets(conn: sqlite3.Connection, plan: ForgetPlan) -> None:
             conn,
             "SELECT id FROM dialectic_observations WHERE source_cid=?",
             (plan.selector,),
-            cast=int,
+            cast=str,
         )
     )
     obs_ids.update(
@@ -313,7 +317,7 @@ def _dialectic_targets(conn: sqlite3.Connection, plan: ForgetPlan) -> None:
             "dialog_uuid",
             plan.dialog_uuids,
             "id",
-            cast=int,
+            cast=str,
         )
     )
     plan.observation_ids = sorted(obs_ids)
@@ -331,7 +335,7 @@ def _dialectic_targets(conn: sqlite3.Connection, plan: ForgetPlan) -> None:
                 tuple(batch),
             ).fetchall()
         )
-    evidence_ids = {int(r["id"]) for r in evidence_rows}
+    evidence_ids = {str(r["id"]) for r in evidence_rows}
     affected_claim_ids = {str(r["claim_id"]) for r in evidence_rows}
 
     claim_ids = set()
@@ -350,7 +354,7 @@ def _dialectic_targets(conn: sqlite3.Connection, plan: ForgetPlan) -> None:
                 conn,
                 "SELECT id FROM dialectic_evidence WHERE claim_id=?",
                 (claim_id,),
-                cast=int,
+                cast=str,
             )
             if all_ids and set(all_ids).issubset(evidence_ids):
                 claim_ids.add(claim_id)
@@ -363,7 +367,7 @@ def _dialectic_targets(conn: sqlite3.Connection, plan: ForgetPlan) -> None:
                 "claim_id",
                 claim_ids,
                 "id",
-                cast=int,
+                cast=str,
             )
         )
     plan.evidence_ids = sorted(evidence_ids)
@@ -579,8 +583,35 @@ def _count_docsize(conn: sqlite3.Connection, table: str, ids: list[int]) -> int:
     return _count_vec_rows(conn, table, "id", ids)
 
 
+def _note_rowids(conn: sqlite3.Connection, note_ids: list[str]) -> list[int]:
+    """Resolve note ids (TEXT gids post-migration, ints pre-) to notes.rowid,
+    the integer key used by notes_fts (content_rowid) and — pre-migration —
+    notes_vec."""
+    return _fetch_where_in(conn, "notes", "id", note_ids, "rowid", cast=int)
+
+
+def _count_notes_vec(conn: sqlite3.Connection, note_ids: list[str]) -> tuple[int, int]:
+    """(notes_vec rows, notes_vec_map rows) for the given notes. Post-migration
+    notes_vec is keyed by an integer rowid resolved through notes_vec_map.gid;
+    pre-migration it is keyed directly by the integer note id."""
+    from .embeddings import _notes_mapped
+    if _notes_mapped(conn):
+        rowids = _fetch_where_in(
+            conn, "notes_vec_map", "gid", note_ids, "rowid", cast=int,
+        )
+        return _count_vec_rows(conn, "notes_vec", "rowid", rowids), len(rowids)
+    return _count_vec_rows(conn, "notes_vec", "id", note_ids), 0
+
+
+def _count_notes_fts(conn: sqlite3.Connection, note_ids: list[str]) -> int:
+    """notes_fts_docsize rows for the given notes, counted by notes.rowid (the
+    FTS content_rowid) — NOT the TEXT note id."""
+    return _count_docsize(conn, "notes_fts_docsize", _note_rowids(conn, note_ids))
+
+
 def _populate_counts(conn: sqlite3.Connection, plan: ForgetPlan) -> None:
     dialog_vec, dialog_vec_map = _count_dialog_vec(conn, plan.dialog_uuids)
+    _notes_vec_count, _notes_vec_map_count = _count_notes_vec(conn, plan.note_ids)
     counts = {
         "dialog_messages": len(plan.dialog_uuids),
         "dialog_fts": _count_docsize(
@@ -598,8 +629,9 @@ def _populate_counts(conn: sqlite3.Connection, plan: ForgetPlan) -> None:
         "dialog_vec": dialog_vec,
         "dialog_vec_map": dialog_vec_map,
         "notes": len(plan.note_ids),
-        "notes_fts": _count_docsize(conn, "notes_fts_docsize", plan.note_ids),
-        "notes_vec": _count_vec_rows(conn, "notes_vec", "id", plan.note_ids),
+        "notes_fts": _count_notes_fts(conn, plan.note_ids),
+        "notes_vec": _notes_vec_count,
+        "notes_vec_map": _notes_vec_map_count,
         "threads": len(plan.thread_ids) if plan.selector_type == "thread_id" else 0,
         "verbatim": len(plan.verbatim_ids),
         "dialectic_observations": len(plan.observation_ids),
@@ -678,8 +710,22 @@ def _delete_dialog_sidecars(
     return vec_deleted, map_deleted
 
 
-def _delete_note_sidecars(conn: sqlite3.Connection, note_ids: list[int]) -> int:
-    return _delete_where_in(conn, "notes_vec", "id", note_ids)
+def _delete_note_sidecars(
+    conn: sqlite3.Connection,
+    note_ids: list[str],
+) -> tuple[int, int]:
+    """Delete a note's vec sidecars. Returns (notes_vec, notes_vec_map). Post-
+    migration notes_vec is keyed by an integer rowid via notes_vec_map.gid;
+    pre-migration it is keyed directly by the integer note id (no map)."""
+    from .embeddings import _notes_mapped
+    if not _notes_mapped(conn):
+        return _delete_where_in(conn, "notes_vec", "id", note_ids), 0
+    rowids = _fetch_where_in(
+        conn, "notes_vec_map", "gid", note_ids, "rowid", cast=int,
+    )
+    vec_deleted = _delete_where_in(conn, "notes_vec", "rowid", rowids)
+    map_deleted = _delete_where_in(conn, "notes_vec_map", "gid", note_ids)
+    return vec_deleted, map_deleted
 
 
 def _recompute_claims(conn: sqlite3.Connection, claim_ids: set[str]) -> None:
@@ -737,7 +783,9 @@ def _apply_forget(conn: sqlite3.Connection, plan: ForgetPlan) -> dict[str, int]:
         )
         deleted["dialog_vec"] = dialog_vec
         deleted["dialog_vec_map"] = dialog_vec_map
-        deleted["notes_vec"] = _delete_note_sidecars(conn, plan.note_ids)
+        notes_vec, notes_vec_map = _delete_note_sidecars(conn, plan.note_ids)
+        deleted["notes_vec"] = notes_vec
+        deleted["notes_vec_map"] = notes_vec_map
         deleted["dialectic_observations"] = _delete_where_in(
             conn,
             "dialectic_observations",
@@ -837,6 +885,7 @@ def _orphan_counts(conn: sqlite3.Connection) -> dict[str, int]:
         "dialog_vec_map_orphans": 0,
         "notes_fts_orphans": 0,
         "notes_vec_orphans": 0,
+        "notes_vec_map_orphans": 0,
     }
     try:
         if _table_exists(conn, "dialog_fts_docsize"):
@@ -888,14 +937,33 @@ def _orphan_counts(conn: sqlite3.Connection) -> dict[str, int]:
     except sqlite3.OperationalError:
         pass
     try:
+        from .embeddings import _notes_mapped
         if _table_exists(conn, "notes_vec"):
-            out["notes_vec_orphans"] = int(
-                conn.execute(
-                    "SELECT COUNT(*) FROM notes_vec v "
-                    "LEFT JOIN notes n ON n.id=v.id "
-                    "WHERE n.id IS NULL"
-                ).fetchone()[0]
-            )
+            if _notes_mapped(conn):
+                # notes_vec.rowid -> notes_vec_map.rowid -> gid -> notes.id
+                out["notes_vec_orphans"] = int(
+                    conn.execute(
+                        "SELECT COUNT(*) FROM notes_vec v "
+                        "LEFT JOIN notes_vec_map m ON m.rowid=v.rowid "
+                        "LEFT JOIN notes n ON n.id=m.gid "
+                        "WHERE n.id IS NULL"
+                    ).fetchone()[0]
+                )
+                out["notes_vec_map_orphans"] = int(
+                    conn.execute(
+                        "SELECT COUNT(*) FROM notes_vec_map m "
+                        "LEFT JOIN notes n ON n.id=m.gid "
+                        "WHERE n.id IS NULL"
+                    ).fetchone()[0]
+                )
+            else:
+                out["notes_vec_orphans"] = int(
+                    conn.execute(
+                        "SELECT COUNT(*) FROM notes_vec v "
+                        "LEFT JOIN notes n ON n.id=v.id "
+                        "WHERE n.id IS NULL"
+                    ).fetchone()[0]
+                )
     except sqlite3.OperationalError:
         pass
     return out

--- a/threadkeeper/forget.py
+++ b/threadkeeper/forget.py
@@ -878,9 +878,11 @@ def _orphan_counts(conn: sqlite3.Connection) -> dict[str, int]:
         if _table_exists(conn, "notes_fts_docsize"):
             out["notes_fts_orphans"] = int(
                 conn.execute(
+                    # docsize.id is the FTS content_rowid == notes.rowid, NOT the
+                    # (post-migration TEXT) notes.id.
                     "SELECT COUNT(*) FROM notes_fts_docsize ds "
-                    "LEFT JOIN notes n ON n.id=ds.id "
-                    "WHERE n.id IS NULL"
+                    "LEFT JOIN notes n ON n.rowid=ds.id "
+                    "WHERE n.rowid IS NULL"
                 ).fetchone()[0]
             )
     except sqlite3.OperationalError:

--- a/threadkeeper/helpers.py
+++ b/threadkeeper/helpers.py
@@ -140,6 +140,38 @@ def gen_dialectic_id(conn: sqlite3.Connection) -> str:
     return _gen_short_id(conn, "UC", "user_dialectic")
 
 
+# ── Global IDs (cross-machine sync) ────────────────────────────────────────
+# ULID: 48-bit millisecond timestamp + 80 bits of randomness, Crockford
+# base32 (26 chars, lexicographically sortable by creation time). Unlike
+# `_gen_short_id` (prefix + 3 hex, 4096 space, LOCAL-only uniqueness check),
+# a ULID is globally unique WITHOUT peer coordination — required so two
+# machines minting rows offline never collide when their DBs merge. Keeps an
+# optional single-char type prefix for human-readable/debuggable ids (e.g.
+# "T"+ULID for threads). See docs/sync.md.
+_ULID_B32 = "0123456789ABCDEFGHJKMNPQRSTVWXYZ"  # Crockford (no I,L,O,U)
+
+
+def _ulid() -> str:
+    ts = int(time.time() * 1000) & ((1 << 48) - 1)
+    rnd = int.from_bytes(secrets.token_bytes(10), "big")  # 80 bits
+    out = [""] * 26
+    for i in range(9, -1, -1):
+        out[i] = _ULID_B32[ts & 31]
+        ts >>= 5
+    for i in range(25, 9, -1):
+        out[i] = _ULID_B32[rnd & 31]
+        rnd >>= 5
+    return "".join(out)
+
+
+def gen_global_id(prefix: str = "") -> str:
+    """Globally-unique, time-sortable id (optional type prefix + ULID).
+
+    Collision-safe across machines with no coordination (80 random bits),
+    so it is the id scheme for sync-replicated rows. No DB lookup needed."""
+    return prefix + _ulid() if prefix else _ulid()
+
+
 def alive(pid: int) -> bool:
     """True if pid corresponds to a running (non-zombie) process. Reaps
     zombies opportunistically when pid is our own child. pid<=0 sentinel

--- a/threadkeeper/helpers.py
+++ b/threadkeeper/helpers.py
@@ -122,12 +122,18 @@ def _gen_short_id(conn: sqlite3.Connection, prefix: str, table: str,
 
 def _global_ids_on(conn: sqlite3.Connection) -> bool:
     """After the sync re-id migration, generated ids must be globally unique
-    (ULID) instead of the local 3-hex short ids. Gated on PRAGMA user_version."""
+    (ULID) instead of the local 3-hex short ids. Gated on
+    sync_state.sync_schema_version — NOT PRAGMA user_version, which the core DB
+    owns as its own schema-migration counter (a non-migrated install would
+    otherwise flip to ULIDs the moment that counter reaches SYNC_SCHEMA_VERSION)."""
     from .sync import SYNC_SCHEMA_VERSION
     try:
-        return int(conn.execute("PRAGMA user_version").fetchone()[0]) >= SYNC_SCHEMA_VERSION
+        row = conn.execute(
+            "SELECT sync_schema_version FROM sync_state WHERE id=1"
+        ).fetchone()
     except sqlite3.Error:
         return False
+    return bool(row) and row[0] is not None and int(row[0]) >= SYNC_SCHEMA_VERSION
 
 
 def gen_thread_id(conn: sqlite3.Connection) -> str:

--- a/threadkeeper/helpers.py
+++ b/threadkeeper/helpers.py
@@ -120,24 +120,34 @@ def _gen_short_id(conn: sqlite3.Connection, prefix: str, table: str,
     return prefix + secrets.token_hex(3)[:5]
 
 
+def _global_ids_on(conn: sqlite3.Connection) -> bool:
+    """After the sync re-id migration, generated ids must be globally unique
+    (ULID) instead of the local 3-hex short ids. Gated on PRAGMA user_version."""
+    from .sync import SYNC_SCHEMA_VERSION
+    try:
+        return int(conn.execute("PRAGMA user_version").fetchone()[0]) >= SYNC_SCHEMA_VERSION
+    except sqlite3.Error:
+        return False
+
+
 def gen_thread_id(conn: sqlite3.Connection) -> str:
-    return _gen_short_id(conn, "T", "threads")
+    return gen_global_id("T") if _global_ids_on(conn) else _gen_short_id(conn, "T", "threads")
 
 
 def gen_probe_id(conn: sqlite3.Connection) -> str:
-    return _gen_short_id(conn, "P", "probes")
+    return gen_global_id("P") if _global_ids_on(conn) else _gen_short_id(conn, "P", "probes")
 
 
 def gen_concept_id(conn: sqlite3.Connection) -> str:
-    return _gen_short_id(conn, "C", "concepts")
+    return gen_global_id("C") if _global_ids_on(conn) else _gen_short_id(conn, "C", "concepts")
 
 
 def gen_distill_id(conn: sqlite3.Connection) -> str:
-    return _gen_short_id(conn, "D", "distill")
+    return gen_global_id("D") if _global_ids_on(conn) else _gen_short_id(conn, "D", "distill")
 
 
 def gen_dialectic_id(conn: sqlite3.Connection) -> str:
-    return _gen_short_id(conn, "UC", "user_dialectic")
+    return gen_global_id("UC") if _global_ids_on(conn) else _gen_short_id(conn, "UC", "user_dialectic")
 
 
 # ── Global IDs (cross-machine sync) ────────────────────────────────────────

--- a/threadkeeper/host.py
+++ b/threadkeeper/host.py
@@ -36,6 +36,12 @@ _DAEMON_STARTERS = [
     ("thread_janitor", "start_thread_janitor"),
     ("dialectic_miner", "start_dialectic_miner_daemon"),
     ("dialectic_validator", "start_dialectic_validator_daemon"),
+    # Cross-machine sync: HTTP server (peers pull/push) + client reconcile loop.
+    # Both no-op unless the DB is migrated and peers/token/listen are configured.
+    # Centralized here so that with DAEMON_HOST_ENABLED only the host runs them —
+    # otherwise every thin MCP server races to bind the listen port.
+    ("sync.server", "start_server"),
+    ("sync.daemon", "start_sync_daemon"),
 ]
 
 

--- a/threadkeeper/identity.py
+++ b/threadkeeper/identity.py
@@ -148,15 +148,11 @@ def _ensure_session_locked(conn: sqlite3.Connection,
         # else: flag on + role == "host" — host.main() already started the
         # loops; a re-entrant _ensure_session (e.g. the host heartbeat) must
         # NOT restart them. Do nothing.
-        try:
-            # Cross-machine sync: server (peers pull/push) + client reconcile
-            # loop. Both no-op unless the DB is migrated and peers/token/listen
-            # are configured. See threadkeeper/sync/.
-            from .sync import server as sync_server, daemon as sync_daemon
-            sync_server.start_server()
-            sync_daemon.start_sync_daemon()
-        except Exception:
-            pass
+        #
+        # Cross-machine sync (server + client reconcile loop) is started by
+        # host.start_daemons() alongside every other daemon — NOT inline here —
+        # so with DAEMON_HOST_ENABLED only the host process runs it and thin
+        # servers don't each race to bind the sync listen port.
         try:
             # One-shot self-heal: claims seeded before the tier machinery
             # never got their tier recomputed (see recompute_all_tiers). Cheap

--- a/threadkeeper/identity.py
+++ b/threadkeeper/identity.py
@@ -149,6 +149,15 @@ def _ensure_session_locked(conn: sqlite3.Connection,
         # loops; a re-entrant _ensure_session (e.g. the host heartbeat) must
         # NOT restart them. Do nothing.
         try:
+            # Cross-machine sync: server (peers pull/push) + client reconcile
+            # loop. Both no-op unless the DB is migrated and peers/token/listen
+            # are configured. See threadkeeper/sync/.
+            from .sync import server as sync_server, daemon as sync_daemon
+            sync_server.start_server()
+            sync_daemon.start_sync_daemon()
+        except Exception:
+            pass
+        try:
             # One-shot self-heal: claims seeded before the tier machinery
             # never got their tier recomputed (see recompute_all_tiers). Cheap
             # (a handful of active claims); idempotent on every startup.

--- a/threadkeeper/ingest.py
+++ b/threadkeeper/ingest.py
@@ -648,18 +648,29 @@ def _backfill_vec_tables(conn: sqlite3.Connection, batch: int = 500) -> tuple[in
     from .db import vec_available
     if not SEMANTIC_AVAILABLE or not vec_available():
         return (0, 0)
-    from .embeddings import _vec_upsert_note, _vec_upsert_dialog
+    from .embeddings import _vec_upsert_note, _vec_upsert_dialog, _notes_mapped
     n_notes = 0
     n_dialog = 0
     try:
-        # Notes that have embedding but aren't yet in notes_vec.
-        rows = conn.execute(
-            "SELECT n.id, n.embedding FROM notes n "
-            "LEFT JOIN notes_vec v ON v.id = n.id "
-            "WHERE n.embedding IS NOT NULL AND v.id IS NULL "
-            "LIMIT ?",
-            (batch,),
-        ).fetchall()
+        # Notes that have embedding but aren't yet mirrored into notes_vec.
+        # Post-migration the presence check goes through notes_vec_map (notes_vec
+        # is keyed by rowid, not the note's TEXT id); pre-migration it is direct.
+        if _notes_mapped(conn):
+            rows = conn.execute(
+                "SELECT n.id, n.embedding FROM notes n "
+                "LEFT JOIN notes_vec_map m ON m.gid = n.id "
+                "WHERE n.embedding IS NOT NULL AND m.gid IS NULL "
+                "LIMIT ?",
+                (batch,),
+            ).fetchall()
+        else:
+            rows = conn.execute(
+                "SELECT n.id, n.embedding FROM notes n "
+                "LEFT JOIN notes_vec v ON v.id = n.id "
+                "WHERE n.embedding IS NOT NULL AND v.id IS NULL "
+                "LIMIT ?",
+                (batch,),
+            ).fetchall()
         for r in rows:
             _vec_upsert_note(conn, r["id"], r["embedding"])
             n_notes += 1

--- a/threadkeeper/ingest.py
+++ b/threadkeeper/ingest.py
@@ -646,7 +646,11 @@ _SYNC_EMBED_TABLES = (
 )
 
 
-def _backfill_sync_embeddings(conn: sqlite3.Connection, batch: int = 100) -> int:
+def _backfill_sync_embeddings(
+    conn: sqlite3.Connection,
+    batch: int = 100,
+    max_rows: int | None = None,
+) -> int:
     """Re-embed replicated rows that arrived over sync without an embedding.
 
     The wire payload omits `embedding`/`embed_backend` (they are local derived
@@ -654,8 +658,12 @@ def _backfill_sync_embeddings(conn: sqlite3.Connection, batch: int = 100) -> int
     and are invisible to semantic search until re-embedded here. Notes/dialog
     are also mirrored into their vec tables. MUST run under `applying_guard`
     (rebuild_derived does) so the embedding UPDATEs are not captured as fresh
-    sync writes. Loops in batches until no NULL-embedding rows remain; returns
-    the total re-embedded. No-op without embeddings.
+    sync writes. Returns the total re-embedded. No-op without embeddings.
+
+    `max_rows` caps the work per call so a request-path caller (e.g. /sync/push)
+    stays bounded and can't time out on a large initial corpus; NULL embeddings
+    are a valid eventual state, so the centralized daemon finishes the remainder
+    in later bounded ticks. `None` = process everything (background use).
     """
     from .config import SEMANTIC_AVAILABLE
     if not SEMANTIC_AVAILABLE:
@@ -665,13 +673,14 @@ def _backfill_sync_embeddings(conn: sqlite3.Connection, batch: int = 100) -> int
     )
     total = 0
     for table, text_col, pk_col, vec_kind, trunc in _SYNC_EMBED_TABLES:
-        while True:
+        while max_rows is None or total < max_rows:
+            lim = batch if max_rows is None else min(batch, max_rows - total)
             try:
                 rows = conn.execute(
                     f"SELECT {pk_col} AS k, {text_col} AS t FROM {table} "
                     f"WHERE embedding IS NULL AND {text_col} IS NOT NULL "
                     f"LIMIT ?",
-                    (batch,),
+                    (lim,),
                 ).fetchall()
             except sqlite3.OperationalError:
                 break
@@ -701,8 +710,10 @@ def _backfill_sync_embeddings(conn: sqlite3.Connection, batch: int = 100) -> int
                 except sqlite3.OperationalError:
                     continue
             total += n
-            if n == 0 or len(rows) < batch:
+            if n == 0 or len(rows) < lim:
                 break  # no progress (avoid a hot loop) or last partial batch
+        if max_rows is not None and total >= max_rows:
+            break
     if total:
         try:
             conn.commit()
@@ -811,6 +822,19 @@ def _start_background_ingester() -> None:
                         # into the vec0 virtual tables in batches so the
                         # sub-linear index gradually warms up.
                         _backfill_vec_tables(bg_conn, batch=500)
+                        # Finish re-embedding rows that arrived over sync
+                        # without an embedding (dialog/concepts especially).
+                        # /sync/push only does a bounded slice; this bounded
+                        # tick drains the rest. Under applying_guard so the
+                        # embedding UPDATEs aren't captured as sync writes.
+                        try:
+                            from .sync.capture import is_migrated, applying_guard
+                            if is_migrated(bg_conn):
+                                with applying_guard(bg_conn):
+                                    _backfill_sync_embeddings(
+                                        bg_conn, max_rows=200)
+                        except Exception:
+                            pass
                     finally:
                         bg_conn.close()
                 finally:

--- a/threadkeeper/ingest.py
+++ b/threadkeeper/ingest.py
@@ -722,6 +722,27 @@ def _backfill_sync_embeddings(
     return total
 
 
+def _backfill_background_embeddings(
+    conn: sqlite3.Connection,
+    max_rows: int = 200,
+) -> int:
+    """Run one bounded background embedding pass without creating sync writes.
+
+    On a migrated DB every embedding-bearing table is replicated, and an
+    ordinary ``UPDATE notes SET embedding=...`` fires the sync capture trigger.
+    Treating that derived-only update as a new LWW write can overwrite a
+    concurrent content edit from another replica.  Use the connection-local
+    applying guard for the whole migrated backfill so origin/HLC/oplog stay
+    unchanged.  Before migration, keep the legacy light-child note backfill.
+    """
+    from .sync.capture import applying_guard, is_migrated
+
+    if is_migrated(conn):
+        with applying_guard(conn):
+            return _backfill_sync_embeddings(conn, max_rows=max_rows)
+    return _backfill_note_embeddings(conn, max_n=min(20, max(0, max_rows)))
+
+
 def _backfill_vec_tables(conn: sqlite3.Connection, batch: int = 500) -> tuple[int, int]:
     """One-shot migration: mirror existing notes.embedding and
     dialog_messages.embedding BLOBs into notes_vec / dialog_vec.
@@ -812,29 +833,15 @@ def _start_background_ingester() -> None:
                             max_msgs=200,
                             max_age_s=_ingest_recent_window_s,
                         )
-                        # Embedding backfill: light children write notes
-                        # with embedding=NULL (NO_EMBEDDINGS=1). Parent
-                        # processes with SEMANTIC_AVAILABLE catch them up
-                        # asynchronously so semantic search recovers
-                        # without blocking the child.
-                        _backfill_note_embeddings(bg_conn, max_n=20)
+                        # Embed a bounded slice of NULL rows. On migrated DBs
+                        # this runs under applying_guard so derived embedding
+                        # UPDATEs never become LWW sync writes; the sync helper
+                        # covers light-child notes as well as dialog/concepts.
+                        _backfill_background_embeddings(bg_conn, max_rows=200)
                         # vec0 backfill: mirror legacy BLOB embeddings
                         # into the vec0 virtual tables in batches so the
                         # sub-linear index gradually warms up.
                         _backfill_vec_tables(bg_conn, batch=500)
-                        # Finish re-embedding rows that arrived over sync
-                        # without an embedding (dialog/concepts especially).
-                        # /sync/push only does a bounded slice; this bounded
-                        # tick drains the rest. Under applying_guard so the
-                        # embedding UPDATEs aren't captured as sync writes.
-                        try:
-                            from .sync.capture import is_migrated, applying_guard
-                            if is_migrated(bg_conn):
-                                with applying_guard(bg_conn):
-                                    _backfill_sync_embeddings(
-                                        bg_conn, max_rows=200)
-                        except Exception:
-                            pass
                     finally:
                         bg_conn.close()
                 finally:

--- a/threadkeeper/ingest.py
+++ b/threadkeeper/ingest.py
@@ -636,6 +636,81 @@ def _backfill_note_embeddings(conn: sqlite3.Connection, max_n: int = 20) -> int:
     return updated
 
 
+# Replicated embedding-bearing tables: (table, text col, pk col, vec kind,
+# truncate). Embeddings/embed_backend are never shipped over sync, so rows that
+# arrive from a peer carry NULL and must be re-embedded locally from content.
+_SYNC_EMBED_TABLES = (
+    ("notes", "content", "id", "note", None),
+    ("dialog_messages", "content", "uuid", "dialog", 2000),
+    ("concepts", "description", "id", None, None),
+)
+
+
+def _backfill_sync_embeddings(conn: sqlite3.Connection, batch: int = 100) -> int:
+    """Re-embed replicated rows that arrived over sync without an embedding.
+
+    The wire payload omits `embedding`/`embed_backend` (they are local derived
+    state), so synced notes/dialog_messages/concepts land with NULL embeddings
+    and are invisible to semantic search until re-embedded here. Notes/dialog
+    are also mirrored into their vec tables. MUST run under `applying_guard`
+    (rebuild_derived does) so the embedding UPDATEs are not captured as fresh
+    sync writes. Loops in batches until no NULL-embedding rows remain; returns
+    the total re-embedded. No-op without embeddings.
+    """
+    from .config import SEMANTIC_AVAILABLE
+    if not SEMANTIC_AVAILABLE:
+        return 0
+    from .embeddings import (
+        encode_many, embed_tag, _vec_upsert_note, _vec_upsert_dialog,
+    )
+    total = 0
+    for table, text_col, pk_col, vec_kind, trunc in _SYNC_EMBED_TABLES:
+        while True:
+            try:
+                rows = conn.execute(
+                    f"SELECT {pk_col} AS k, {text_col} AS t FROM {table} "
+                    f"WHERE embedding IS NULL AND {text_col} IS NOT NULL "
+                    f"LIMIT ?",
+                    (batch,),
+                ).fetchall()
+            except sqlite3.OperationalError:
+                break
+            if not rows:
+                break
+            texts = [(r["t"][:trunc] if trunc else r["t"]) for r in rows]
+            try:
+                vectors = encode_many(texts)
+            except Exception:
+                break
+            if vectors is None:
+                break
+            n = 0
+            for i, r in enumerate(rows):
+                emb = vectors[i].astype("float32").tobytes()
+                try:
+                    conn.execute(
+                        f"UPDATE {table} SET embedding=?, embed_backend=? "
+                        f"WHERE {pk_col}=?",
+                        (emb, embed_tag(emb), r["k"]),
+                    )
+                    if vec_kind == "note":
+                        _vec_upsert_note(conn, r["k"], emb)
+                    elif vec_kind == "dialog":
+                        _vec_upsert_dialog(conn, r["k"], emb)
+                    n += 1
+                except sqlite3.OperationalError:
+                    continue
+            total += n
+            if n == 0 or len(rows) < batch:
+                break  # no progress (avoid a hot loop) or last partial batch
+    if total:
+        try:
+            conn.commit()
+        except sqlite3.OperationalError:
+            pass
+    return total
+
+
 def _backfill_vec_tables(conn: sqlite3.Connection, batch: int = 500) -> tuple[int, int]:
     """One-shot migration: mirror existing notes.embedding and
     dialog_messages.embedding BLOBs into notes_vec / dialog_vec.

--- a/threadkeeper/retrieval.py
+++ b/threadkeeper/retrieval.py
@@ -51,7 +51,10 @@ def _notes_fts_search(conn: sqlite3.Connection, query: str,
         return conn.execute(
             "SELECT n.id, n.thread_id, n.kind, n.content, n.created_at, "
             "       bm25(notes_fts) AS lexical_score "
-            "FROM notes_fts f JOIN notes n ON n.id=f.rowid "
+            # notes_fts is external-content keyed on notes.rowid (content_rowid);
+            # join on rowid, NOT n.id — post-migration n.id is a TEXT ULID while
+            # the FTS rowid stays the integer notes.rowid.
+            "FROM notes_fts f JOIN notes n ON n.rowid=f.rowid "
             "WHERE notes_fts MATCH ? "
             "ORDER BY lexical_score, n.id DESC LIMIT ?",
             (match_query, max(1, int(k))),

--- a/threadkeeper/server.py
+++ b/threadkeeper/server.py
@@ -68,6 +68,7 @@ from .tools import forget  # noqa: F401
 # without the resources/prompts capability fall back to the tool-only surface.
 from .tools import resources  # noqa: F401
 from .tools import prompts  # noqa: F401
+from .tools import sync  # noqa: F401
 
 
 if __name__ == "__main__":

--- a/threadkeeper/sync/__init__.py
+++ b/threadkeeper/sync/__init__.py
@@ -8,12 +8,14 @@ locally from the base tables after a merge.
 
 The feature is dormant until the operator runs the opt-in `tk-sync-migrate`
 script (which converts INTEGER autoincrement PKs on the replicated tables to
-global TEXT ids and bumps `PRAGMA user_version`) and configures peers. See
-docs/sync.md.
+global TEXT ids and sets `sync_state.sync_schema_version`) and configures peers.
+See docs/sync.md.
 """
 from __future__ import annotations
 
-# Schema version the re-id migration bumps `PRAGMA user_version` to. The sync
-# daemon and tools stay inert while the DB is below this — so installing the
-# feature without migrating leaves an existing user completely unaffected.
+# Schema version the re-id migration writes to `sync_state.sync_schema_version`.
+# (Deliberately NOT PRAGMA user_version, which the core db owns as its own
+# schema-migration counter.) The sync daemon and tools stay inert while the DB
+# is below this — installing the feature without migrating leaves an existing
+# user completely unaffected.
 SYNC_SCHEMA_VERSION = 1

--- a/threadkeeper/sync/__init__.py
+++ b/threadkeeper/sync/__init__.py
@@ -1,0 +1,19 @@
+"""Cross-machine synchronization (active-active P2P replication).
+
+Symmetric anti-entropy: every instance holds a peer list and reconciles the
+memory tables with each peer by Hybrid Logical Clock (HLC) — union for
+append-only rows, last-writer-wins for mutable ones, tombstones for deletes.
+Derived indexes (FTS5, sqlite-vec) are NOT replicated; they are rebuilt
+locally from the base tables after a merge.
+
+The feature is dormant until the operator runs the opt-in `tk-sync-migrate`
+script (which converts INTEGER autoincrement PKs on the replicated tables to
+global TEXT ids and bumps `PRAGMA user_version`) and configures peers. See
+docs/sync.md.
+"""
+from __future__ import annotations
+
+# Schema version the re-id migration bumps `PRAGMA user_version` to. The sync
+# daemon and tools stay inert while the DB is below this — so installing the
+# feature without migrating leaves an existing user completely unaffected.
+SYNC_SCHEMA_VERSION = 1

--- a/threadkeeper/sync/capture.py
+++ b/threadkeeper/sync/capture.py
@@ -11,7 +11,7 @@ the protocol's apply path via `applying_guard`) so that merging a peer's
 changes does NOT get re-captured as a fresh local write — that guard is the
 correctness crux that keeps origin/hlc of a relayed row intact.
 
-Triggers exist only once `PRAGMA user_version >= SYNC_SCHEMA_VERSION`
+Triggers exist only once `sync_state.sync_schema_version >= SYNC_SCHEMA_VERSION`
 (i.e. after `tk-sync-migrate`). Pre-migration installs are untouched.
 """
 from __future__ import annotations
@@ -47,8 +47,18 @@ _NOT_APPLYING = "(SELECT applying FROM sync_state WHERE id=1)=0"
 
 
 def is_migrated(conn: sqlite3.Connection) -> bool:
-    """True once the re-id migration ran (sync feature enabled)."""
-    return int(conn.execute("PRAGMA user_version").fetchone()[0]) >= SYNC_SCHEMA_VERSION
+    """True once the re-id migration ran (sync feature enabled).
+
+    Gated on sync_state.sync_schema_version — NOT PRAGMA user_version, which main
+    owns as its schema-migration counter. Absent table/row/value = not migrated.
+    """
+    try:
+        row = conn.execute(
+            "SELECT sync_schema_version FROM sync_state WHERE id=1"
+        ).fetchone()
+    except sqlite3.OperationalError:
+        return False
+    return bool(row) and row[0] is not None and int(row[0]) >= SYNC_SCHEMA_VERSION
 
 
 def _gid_expr(table: str, ref: str) -> str:

--- a/threadkeeper/sync/capture.py
+++ b/threadkeeper/sync/capture.py
@@ -1,0 +1,111 @@
+"""Change capture for cross-machine sync — active only on a migrated DB.
+
+Every local write to a replicated table must (a) get a global write timestamp
+(HLC) + author (node_id) stamped on the row, and (b) leave a trail in
+`sync_oplog` so peers can pull it. Rather than touch dozens of scattered write
+sites, this is done with SQLite triggers generated per replicated table.
+
+The triggers compute the HLC in pure SQL off the `sync_state` singleton, so
+they need no Python. They are suppressed while `sync_state.applying=1` (set by
+the protocol's apply path via `applying_guard`) so that merging a peer's
+changes does NOT get re-captured as a fresh local write — that guard is the
+correctness crux that keeps origin/hlc of a relayed row intact.
+
+Triggers exist only once `PRAGMA user_version >= SYNC_SCHEMA_VERSION`
+(i.e. after `tk-sync-migrate`). Pre-migration installs are untouched.
+"""
+from __future__ import annotations
+
+import contextlib
+import sqlite3
+
+from . import SYNC_SCHEMA_VERSION
+
+# Primary-key column per replicated table (the row's global id == its gid).
+_PK = {
+    "threads": "id", "notes": "id", "verbatim": "id", "evolve": "id",
+    "probe_results": "id", "dialectic_evidence": "id",
+    "dialectic_observations": "id", "edges": "id", "concepts": "id",
+    "distill": "id", "user_dialectic": "id", "probes": "id",
+    "core_memory": "key", "style": "key", "skill_usage": "name",
+    "reliability": "category", "dialog_messages": "uuid",
+}
+# Composite-key table: gid is the two key parts joined.
+_COMPOSITE = {"distill_votes": ("distill_id", "voter_cid")}
+
+_NOW_MS = "(CAST(strftime('%s','now') AS INTEGER)*1000)"
+_ADVANCE = (
+    "UPDATE sync_state SET "
+    f"hlc_counter = CASE WHEN hlc_phys_ms >= {_NOW_MS} "
+    "THEN hlc_counter+1 ELSE 0 END, "
+    f"hlc_phys_ms = MAX(hlc_phys_ms, {_NOW_MS}) WHERE id=1;"
+)
+_HLC = ("(SELECT printf('%015d:%06d:%s',hlc_phys_ms,hlc_counter,node_id) "
+        "FROM sync_state WHERE id=1)")
+_NODE = "(SELECT node_id FROM sync_state WHERE id=1)"
+_NOT_APPLYING = "(SELECT applying FROM sync_state WHERE id=1)=0"
+
+
+def is_migrated(conn: sqlite3.Connection) -> bool:
+    """True once the re-id migration ran (sync feature enabled)."""
+    return int(conn.execute("PRAGMA user_version").fetchone()[0]) >= SYNC_SCHEMA_VERSION
+
+
+def _gid_expr(table: str, ref: str) -> str:
+    if table in _COMPOSITE:
+        a, b = _COMPOSITE[table]
+        return f"{ref}.{a}||':'||{ref}.{b}"
+    return f"{ref}.{_PK[table]}"
+
+
+def _oplog_insert(table: str, ref: str, op: str) -> str:
+    return (
+        "INSERT INTO sync_oplog(tbl,gid,op,hlc,origin_node) "
+        f"SELECT '{table}', {_gid_expr(table, ref)}, '{op}', {_HLC}, {_NODE};"
+    )
+
+
+def install_triggers(conn: sqlite3.Connection) -> None:
+    """Create capture triggers for every replicated table. Idempotent
+    (CREATE TRIGGER IF NOT EXISTS). Only call on a migrated DB."""
+    tables = list(_PK) + list(_COMPOSITE)
+    for t in tables:
+        # INSERT: only local-origin rows (origin_node still NULL); a remote row
+        # applied by the protocol arrives with origin_node already set.
+        conn.executescript(
+            f"CREATE TRIGGER IF NOT EXISTS {t}__sync_ai AFTER INSERT ON {t} "
+            f"WHEN {_NOT_APPLYING} AND NEW.origin_node IS NULL BEGIN "
+            f"{_ADVANCE} "
+            f"UPDATE {t} SET origin_node={_NODE}, hlc={_HLC} WHERE rowid=NEW.rowid; "
+            f"{_oplog_insert(t, 'NEW', 'put')} END;"
+        )
+        # UPDATE: a local edit is a new write (re-stamp + oplog). Suppressed
+        # during apply. Does not recurse: recursive_triggers defaults OFF.
+        conn.executescript(
+            f"CREATE TRIGGER IF NOT EXISTS {t}__sync_au AFTER UPDATE ON {t} "
+            f"WHEN {_NOT_APPLYING} BEGIN "
+            f"{_ADVANCE} "
+            f"UPDATE {t} SET origin_node={_NODE}, hlc={_HLC} WHERE rowid=NEW.rowid; "
+            f"{_oplog_insert(t, 'NEW', 'put')} END;"
+        )
+        # DELETE: leave a tombstone in the oplog so the delete propagates and a
+        # peer that still has the row does not resurrect it.
+        conn.executescript(
+            f"CREATE TRIGGER IF NOT EXISTS {t}__sync_ad AFTER DELETE ON {t} "
+            f"WHEN {_NOT_APPLYING} BEGIN "
+            f"{_ADVANCE} "
+            f"{_oplog_insert(t, 'OLD', 'del')} END;"
+        )
+    conn.commit()
+
+
+@contextlib.contextmanager
+def applying_guard(conn: sqlite3.Connection):
+    """Within this block, capture triggers are suppressed. Used by the apply
+    path so merging a peer's rows keeps their original origin/hlc and does not
+    echo back into the oplog."""
+    conn.execute("UPDATE sync_state SET applying=1 WHERE id=1")
+    try:
+        yield
+    finally:
+        conn.execute("UPDATE sync_state SET applying=0 WHERE id=1")

--- a/threadkeeper/sync/capture.py
+++ b/threadkeeper/sync/capture.py
@@ -102,10 +102,15 @@ def install_triggers(conn: sqlite3.Connection) -> None:
             f"{_oplog_insert(t, 'NEW', 'put')} END;"
         )
         # UPDATE: a local edit is a new write (re-stamp + oplog). Suppressed
-        # during apply. Does not recurse: recursive_triggers defaults OFF.
+        # during apply. `OLD.origin_node IS NOT NULL` skips the AFTER-INSERT
+        # trigger's own stamping UPDATE (which flips origin_node NULL->set): that
+        # UPDATE fires this trigger too (recursive_triggers OFF only blocks a
+        # trigger re-firing ITSELF, not one trigger firing another), so without
+        # the guard every insert would be logged twice. This trigger's own
+        # re-stamp UPDATE does not recurse (self-firing is blocked).
         conn.executescript(
             f"CREATE TRIGGER IF NOT EXISTS {t}__sync_au AFTER UPDATE ON {t} "
-            f"WHEN {_NOT_APPLYING} BEGIN "
+            f"WHEN {_NOT_APPLYING} AND OLD.origin_node IS NOT NULL BEGIN "
             f"{_ADVANCE} "
             f"UPDATE {t} SET origin_node={_NODE}, hlc={_HLC} WHERE rowid=NEW.rowid; "
             f"{_oplog_insert(t, 'NEW', 'put')} END;"

--- a/threadkeeper/sync/capture.py
+++ b/threadkeeper/sync/capture.py
@@ -6,10 +6,13 @@ Every local write to a replicated table must (a) get a global write timestamp
 sites, this is done with SQLite triggers generated per replicated table.
 
 The triggers compute the HLC in pure SQL off the `sync_state` singleton, so
-they need no Python. They are suppressed while `sync_state.applying=1` (set by
-the protocol's apply path via `applying_guard`) so that merging a peer's
-changes does NOT get re-captured as a fresh local write — that guard is the
-correctness crux that keeps origin/hlc of a relayed row intact.
+they need no Python. They are suppressed while a per-connection TEMP marker
+table exists (created by `applying_guard`) so that merging a peer's changes does
+NOT get re-captured as a fresh local write — that guard is the correctness crux
+that keeps origin/hlc of a relayed row intact. The marker is connection-local
+(a temp table, invisible to other connections and unaffected by their commits),
+so a concurrent local write on another connection is always captured, and an
+inner commit inside the guarded path cannot expose suppression to anyone else.
 
 Triggers exist only once `sync_state.sync_schema_version >= SYNC_SCHEMA_VERSION`
 (i.e. after `tk-sync-migrate`). Pre-migration installs are untouched.
@@ -43,7 +46,16 @@ _ADVANCE = (
 _HLC = ("(SELECT printf('%015d:%06d:%s',hlc_phys_ms,hlc_counter,node_id) "
         "FROM sync_state WHERE id=1)")
 _NODE = "(SELECT node_id FROM sync_state WHERE id=1)"
-_NOT_APPLYING = "(SELECT applying FROM sync_state WHERE id=1)=0"
+# Suppression is a per-connection TEMP table, probed via pragma_table_list — the
+# only temp-catalog probe usable inside a trigger (a trigger may not reference
+# the `temp` schema directly, and unqualified sqlite_temp_master binds to main).
+# It never errors on connections lacking the table (reads 0) and is invisible to
+# other connections regardless of their commits.
+_APPLYING_TABLE = "_tk_sync_applying"
+_NOT_APPLYING = (
+    f"(SELECT count(*) FROM pragma_table_list "
+    f"WHERE schema='temp' AND name='{_APPLYING_TABLE}')=0"
+)
 
 
 def is_migrated(conn: sqlite3.Connection) -> bool:
@@ -111,11 +123,15 @@ def install_triggers(conn: sqlite3.Connection) -> None:
 
 @contextlib.contextmanager
 def applying_guard(conn: sqlite3.Connection):
-    """Within this block, capture triggers are suppressed. Used by the apply
-    path so merging a peer's rows keeps their original origin/hlc and does not
-    echo back into the oplog."""
-    conn.execute("UPDATE sync_state SET applying=1 WHERE id=1")
+    """Within this block, capture triggers are suppressed ON THIS CONNECTION.
+
+    Suppression is a per-connection TEMP table, not a shared `sync_state` row:
+    other connections never see it and their commits never affect it, so a
+    concurrent local write elsewhere is still captured and an inner commit in
+    the guarded path (e.g. rebuild_derived's backfills) cannot leak suppression.
+    The temp table persists across commits on this connection until dropped."""
+    conn.execute(f"CREATE TEMP TABLE IF NOT EXISTS {_APPLYING_TABLE} (x)")
     try:
         yield
     finally:
-        conn.execute("UPDATE sync_state SET applying=0 WHERE id=1")
+        conn.execute(f"DROP TABLE IF EXISTS {_APPLYING_TABLE}")

--- a/threadkeeper/sync/daemon.py
+++ b/threadkeeper/sync/daemon.py
@@ -1,0 +1,94 @@
+"""Client side of cross-machine sync: a symmetric daemon that reconciles with
+each configured peer on an interval.
+
+Topology is a decentralized P2P mesh — every instance runs BOTH this client
+daemon and the server (sync/server.py) and lists its peers in
+THREADKEEPER_SYNC_PEERS. Peer lists may be partial/asymmetric: because merges
+are transitive (a row carries its origin's HLC), a connected graph converges.
+Adding a machine = add its address on some node; no central hub.
+
+Self-healing: an unreachable peer just fails this tick and is retried next
+tick. All OFF by default (interval 0, no peers); dormant until a migrated DB
+is configured. Follows the same threading-daemon shape as skill_watcher.py.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import threading
+import urllib.request
+
+from ..config import SYNC_INTERVAL_S, SYNC_PEERS, SYNC_TOKEN
+from ..db import get_db
+from ..helpers import daemon_sleep
+from . import protocol
+from .capture import is_migrated
+
+logger = logging.getLogger(__name__)
+_started = False
+
+
+def peers() -> list[str]:
+    return [p.strip().rstrip("/") for p in SYNC_PEERS.split(",") if p.strip()]
+
+
+def _post(url: str, obj: dict, timeout: float = 30.0) -> dict:
+    headers = {"Content-Type": "application/json"}
+    if SYNC_TOKEN:
+        headers["Authorization"] = f"Bearer {SYNC_TOKEN}"
+    req = urllib.request.Request(
+        url, data=protocol.dumps(obj).encode(), headers=headers, method="POST")
+    with urllib.request.urlopen(req, timeout=timeout) as r:  # noqa: S310 (trusted peer)
+        return json.loads(r.read().decode() or "{}")
+
+
+def sync_with_peer(peer: str) -> tuple[int, int]:
+    """One bidirectional reconcile with a peer. Returns (pulled, pushed)."""
+    conn = get_db()
+    try:
+        if not is_migrated(conn):
+            return (0, 0)
+        pull = _post(peer + "/sync/pull", {"vv": protocol.version_vector(conn)})
+        pulled = protocol.apply_changes(conn, pull.get("changes", []))
+        push = protocol.collect_changes(conn, pull.get("vv", {}))
+        resp = _post(peer + "/sync/push", {"changes": push})
+        protocol.rebuild_derived(conn)
+        return (pulled, int(resp.get("applied", 0)))
+    finally:
+        conn.close()
+
+
+def sync_all() -> dict:
+    """Reconcile with every configured peer once. Returns per-peer results."""
+    out = {}
+    for p in peers():
+        try:
+            out[p] = sync_with_peer(p)
+        except Exception as e:  # unreachable peer / transient error → retry next
+            out[p] = f"err:{type(e).__name__}"
+            logger.debug("sync with %s failed: %s", p, e)
+    return out
+
+
+def _serve_loop() -> None:
+    while True:
+        try:
+            sync_all()
+        except Exception:
+            logger.debug("sync tick failed", exc_info=True)
+        daemon_sleep(SYNC_INTERVAL_S)
+
+
+def start_sync_daemon() -> None:
+    """Start the peer-reconcile loop if configured. Safe to call repeatedly."""
+    global _started
+    if _started:
+        return
+    if SYNC_INTERVAL_S <= 0 or not peers():
+        return
+    from ..config import BACKGROUND_DAEMONS_ALLOWED
+    if not BACKGROUND_DAEMONS_ALLOWED:
+        return
+    t = threading.Thread(target=_serve_loop, name="sync_daemon", daemon=True)
+    t.start()
+    _started = True

--- a/threadkeeper/sync/identity.py
+++ b/threadkeeper/sync/identity.py
@@ -91,9 +91,15 @@ def hlc_now(conn: sqlite3.Connection) -> str:
     return _fmt(phys, ctr, node_id)
 
 
-def hlc_update(conn: sqlite3.Connection, remote_hlc: str) -> str:
+def hlc_absorb(conn: sqlite3.Connection, remote_hlc: str) -> str:
     """Merge a received remote HLC into the local clock (standard HLC receive
-    rule) and return the new local HLC. Keeps causality across machines."""
+    rule) WITHOUT committing — the caller owns the transaction.
+
+    The replication apply path must absorb received HLCs inside the same
+    transaction/`applying_guard` as the merged rows, so a `conn.commit()` here
+    would tear that unit apart. It also must run so a subsequent local write is
+    stamped from a clock that already dominates everything just received;
+    otherwise a local edit lands with a lower HLC and LWW drops it."""
     _ensure_state(conn)
     row = conn.execute(
         "SELECT node_id, hlc_phys_ms, hlc_counter FROM sync_state WHERE id=1"
@@ -114,5 +120,13 @@ def hlc_update(conn: sqlite3.Connection, remote_hlc: str) -> str:
         "UPDATE sync_state SET hlc_phys_ms=?, hlc_counter=? WHERE id=1",
         (phys, ctr),
     )
-    conn.commit()
     return _fmt(phys, ctr, node_id)
+
+
+def hlc_update(conn: sqlite3.Connection, remote_hlc: str) -> str:
+    """Merge a received remote HLC into the local clock (standard HLC receive
+    rule) and return the new local HLC. Keeps causality across machines.
+    Commits; use :func:`hlc_absorb` inside a caller-owned transaction."""
+    new = hlc_absorb(conn, remote_hlc)
+    conn.commit()
+    return new

--- a/threadkeeper/sync/identity.py
+++ b/threadkeeper/sync/identity.py
@@ -1,0 +1,118 @@
+"""Node identity + Hybrid Logical Clock for cross-machine sync.
+
+Every TK install gets ONE persistent `node_id` (generated once, stored in the
+`sync_state` singleton and mirrored to ~/.threadkeeper/node.id). All sync
+ordering uses an HLC — a monotonic, causally-consistent clock that stays
+sensible even when two machines' wall clocks drift. An HLC value is a
+lexicographically-sortable string `"<phys_ms:015d>:<counter:06d>:<node_id>"`;
+comparing two of them gives a total order for last-writer-wins merges.
+
+Nothing here mutates the memory tables — it only reads/writes `sync_state`.
+"""
+from __future__ import annotations
+
+import logging
+import sqlite3
+import time
+
+from ..config import DB_PATH
+from ..helpers import gen_global_id
+
+logger = logging.getLogger(__name__)
+
+_PHYS_WIDTH = 15   # zero-pad ms so lexical order == numeric order (~year 5138)
+_CTR_WIDTH = 6
+
+
+def _now_ms() -> int:
+    return int(time.time() * 1000)
+
+
+def _ensure_state(conn: sqlite3.Connection) -> None:
+    """Insert the singleton row if missing (id=1). First writer wins."""
+    conn.execute(
+        "INSERT OR IGNORE INTO sync_state (id, node_id) VALUES (1, ?)",
+        (gen_global_id("N"),),
+    )
+
+
+def get_node_id(conn: sqlite3.Connection) -> str:
+    """Return this install's persistent node_id, creating it on first call.
+
+    Also best-effort mirrors it to ~/.threadkeeper/node.id for external
+    tooling / debugging (the DB remains the source of truth)."""
+    _ensure_state(conn)
+    row = conn.execute("SELECT node_id FROM sync_state WHERE id=1").fetchone()
+    node_id = row[0]
+    conn.commit()
+    try:
+        p = DB_PATH.parent / "node.id"
+        if not p.exists():
+            p.write_text(node_id + "\n")
+    except OSError:
+        pass
+    return node_id
+
+
+def _fmt(phys: int, ctr: int, node_id: str) -> str:
+    return f"{phys:0{_PHYS_WIDTH}d}:{ctr:0{_CTR_WIDTH}d}:{node_id}"
+
+
+def parse_hlc(hlc: str) -> tuple[int, int, str]:
+    """Split an HLC string into (phys_ms, counter, node_id). Tolerant of a
+    missing node_id segment. Malformed input sorts as (0, 0, '')."""
+    try:
+        phys_s, ctr_s, node = hlc.split(":", 2)
+        return int(phys_s), int(ctr_s), node
+    except (ValueError, AttributeError):
+        return 0, 0, ""
+
+
+def hlc_now(conn: sqlite3.Connection) -> str:
+    """Advance and persist the local HLC, returning the new value.
+
+    Standard HLC send rule: phys = max(last_phys, wall_now); counter bumps
+    only when phys stalls (same ms), else resets to 0."""
+    _ensure_state(conn)
+    row = conn.execute(
+        "SELECT node_id, hlc_phys_ms, hlc_counter FROM sync_state WHERE id=1"
+    ).fetchone()
+    node_id, last_phys, last_ctr = row[0], int(row[1]), int(row[2])
+    now = _now_ms()
+    if now > last_phys:
+        phys, ctr = now, 0
+    else:
+        phys, ctr = last_phys, last_ctr + 1
+    conn.execute(
+        "UPDATE sync_state SET hlc_phys_ms=?, hlc_counter=? WHERE id=1",
+        (phys, ctr),
+    )
+    conn.commit()
+    return _fmt(phys, ctr, node_id)
+
+
+def hlc_update(conn: sqlite3.Connection, remote_hlc: str) -> str:
+    """Merge a received remote HLC into the local clock (standard HLC receive
+    rule) and return the new local HLC. Keeps causality across machines."""
+    _ensure_state(conn)
+    row = conn.execute(
+        "SELECT node_id, hlc_phys_ms, hlc_counter FROM sync_state WHERE id=1"
+    ).fetchone()
+    node_id, last_phys, last_ctr = row[0], int(row[1]), int(row[2])
+    r_phys, r_ctr, _ = parse_hlc(remote_hlc)
+    now = _now_ms()
+    phys = max(last_phys, r_phys, now)
+    if phys == last_phys and phys == r_phys:
+        ctr = max(last_ctr, r_ctr) + 1
+    elif phys == last_phys:
+        ctr = last_ctr + 1
+    elif phys == r_phys:
+        ctr = r_ctr + 1
+    else:
+        ctr = 0
+    conn.execute(
+        "UPDATE sync_state SET hlc_phys_ms=?, hlc_counter=? WHERE id=1",
+        (phys, ctr),
+    )
+    conn.commit()
+    return _fmt(phys, ctr, node_id)

--- a/threadkeeper/sync/migrate.py
+++ b/threadkeeper/sync/migrate.py
@@ -167,6 +167,7 @@ def _rebuild_notes_fts(conn: sqlite3.Connection) -> None:
     )
     conn.execute("DROP TRIGGER IF EXISTS notes_fts_ai")
     conn.execute("DROP TRIGGER IF EXISTS notes_fts_ad")
+    conn.execute("DROP TRIGGER IF EXISTS notes_fts_au")
     conn.execute(
         "CREATE TRIGGER notes_fts_ai AFTER INSERT ON notes BEGIN "
         "INSERT INTO notes_fts(rowid, content) VALUES (new.rowid, new.content); END"
@@ -175,6 +176,13 @@ def _rebuild_notes_fts(conn: sqlite3.Connection) -> None:
         "CREATE TRIGGER notes_fts_ad AFTER DELETE ON notes BEGIN "
         "INSERT INTO notes_fts(notes_fts, rowid, content) "
         "VALUES('delete', old.rowid, old.content); END"
+    )
+    # OF content: skip the frequent hlc/origin capture-stamp UPDATEs.
+    conn.execute(
+        "CREATE TRIGGER notes_fts_au AFTER UPDATE OF content ON notes BEGIN "
+        "INSERT INTO notes_fts(notes_fts, rowid, content) "
+        "VALUES('delete', old.rowid, old.content); "
+        "INSERT INTO notes_fts(rowid, content) VALUES (new.rowid, new.content); END"
     )
 
 

--- a/threadkeeper/sync/migrate.py
+++ b/threadkeeper/sync/migrate.py
@@ -109,9 +109,12 @@ def _rebuild_int_table(conn: sqlite3.Connection, table: str) -> None:
         "SELECT sql FROM sqlite_master WHERE type='table' AND name=?", (table,)
     ).fetchone()[0]
     # Only the rowid-alias PK carries AUTOINCREMENT, so this targets the id col.
+    # The DEFAULT lets post-migration INSERTs that omit id still get a global
+    # id (128-bit random hex, collision-safe across machines) with zero
+    # write-site churn; existing rows are remapped to ULIDs just below.
     new_sql = re.sub(
         r"INTEGER\s+PRIMARY\s+KEY\s+AUTOINCREMENT",
-        "TEXT PRIMARY KEY",
+        "TEXT PRIMARY KEY DEFAULT (lower(hex(randomblob(16))))",
         sql,
         count=1,
         flags=re.IGNORECASE,
@@ -179,19 +182,21 @@ def _stamp_baseline_hlc(conn: sqlite3.Connection) -> None:
 
 
 def _rebuild_derived(conn: sqlite3.Connection) -> None:
-    """Derived indexes are keyed off the (now-changed) ids — rebuild locally."""
+    """Derived indexes are keyed off the (now-changed) ids — rebuild locally.
+    Runs on a migrated get_db() connection, so notes_vec is already the
+    rowid+map schema (get_db self-heals the legacy id-keyed table)."""
     try:
         conn.execute("INSERT INTO notes_fts(notes_fts) VALUES('rebuild')")
     except sqlite3.OperationalError:
         pass
-    # Drop stale vec rows keyed by the old integer notes.id; the ingest
-    # backfill (_backfill_vec_tables) repopulates notes_vec from notes.embedding
-    # via the new notes_vec_map on next daemon tick / get_db.
-    for stmt in ("DELETE FROM notes_vec", "DELETE FROM notes_vec_map"):
-        try:
-            conn.execute(stmt)
-        except sqlite3.OperationalError:
+    # Repopulate notes_vec/dialog_vec from the stored embedding BLOBs via the
+    # new maps (idempotent; also runs on every background tick).
+    try:
+        from ..ingest import _backfill_vec_tables
+        while _backfill_vec_tables(conn)[0]:
             pass
+    except Exception:
+        pass
 
 
 def apply(db_path: Path, do_apply: bool) -> int:
@@ -241,6 +246,9 @@ def apply(db_path: Path, do_apply: bool) -> int:
             _remap_ids(conn, table, maps[table])
         _fix_refs(conn, maps, children)
         conn.execute("COMMIT")
+        # Enable the feature BEFORE reopening via get_db so that connection
+        # materializes the migrated schema (rowid notes_vec + map + triggers).
+        conn.execute(f"PRAGMA user_version={SYNC_SCHEMA_VERSION}")
     except Exception:
         conn.rollback()
         conn.close()
@@ -249,14 +257,16 @@ def apply(db_path: Path, do_apply: bool) -> int:
         raise
     conn.close()
 
-    # Reassert declared indexes/triggers on the rebuilt tables, rebuild derived
-    # indexes, stamp baseline HLC, then bump user_version.
+    # Reopen through get_db (reasserts declared indexes/triggers on the rebuilt
+    # tables + installs sync). Rebuild derived indexes and stamp a baseline HLC
+    # under applying_guard so capture triggers don't clobber the explicit stamp.
     from ..db import get_db
+    from . import capture
     conn = get_db()
     try:
-        _rebuild_derived(conn)
-        _stamp_baseline_hlc(conn)
-        conn.execute(f"PRAGMA user_version={SYNC_SCHEMA_VERSION}")
+        with capture.applying_guard(conn):
+            _rebuild_derived(conn)
+            _stamp_baseline_hlc(conn)
         conn.commit()
     finally:
         conn.close()

--- a/threadkeeper/sync/migrate.py
+++ b/threadkeeper/sync/migrate.py
@@ -1,0 +1,284 @@
+"""Opt-in re-id migration: give every replicated row a globally-unique TEXT id.
+
+This is the ONE destructive step of cross-machine sync. It converts the
+INTEGER-AUTOINCREMENT primary keys on the replicated memory tables to global
+ULID TEXT ids (and widens the short 3-hex TEXT ids), rewriting every foreign
+reference in lockstep, then rebuilds derived indexes and stamps a baseline
+HLC. After it runs, `PRAGMA user_version` is bumped so the sync daemon/tools
+activate; before it runs they stay dormant.
+
+NEVER auto-run. The operator invokes `tk-sync-migrate` (or
+`python -m threadkeeper.sync.migrate`) explicitly, after a backup. `--dry-run`
+is the default; `--apply` performs the change. Idempotent: a second run on an
+already-migrated DB is a no-op.
+
+Design + rationale: docs/sync.md.
+"""
+from __future__ import annotations
+
+import argparse
+import re
+import shutil
+import sqlite3
+import sys
+import time
+from pathlib import Path
+
+from ..config import DB_PATH
+from ..helpers import gen_global_id
+from . import SYNC_SCHEMA_VERSION
+from . import identity as sync_identity
+
+# Replicated tables whose ids are machine-minted → must become global.
+# value = human-readable type prefix carried in front of the ULID.
+REID_PREFIX = {
+    "threads": "T",
+    "notes": "",
+    "verbatim": "",
+    "evolve": "",
+    "probe_results": "",
+    "dialectic_evidence": "",
+    "dialectic_observations": "",
+    "edges": "",
+    "concepts": "C",
+    "distill": "D",
+    "user_dialectic": "UC",
+    "probes": "P",
+}
+# Of those, the ones on INTEGER PRIMARY KEY AUTOINCREMENT need a table-rebuild
+# (SQLite cannot ALTER a rowid-alias column to TEXT); the rest are TEXT already
+# and just need an UPDATE of the id value.
+INT_PK_TABLES = {
+    "notes", "verbatim", "evolve", "probe_results",
+    "dialectic_evidence", "dialectic_observations", "edges",
+}
+# edges is a typed polymorphic graph (from_kind/from_id, to_kind/to_id) with no
+# declared FK; these kinds address a re-id'd table and must be remapped too.
+EDGE_KIND_TABLE = {
+    "thread": "threads", "note": "notes",
+    "concept": "concepts", "distill": "distill",
+}
+
+
+def _user_version(conn: sqlite3.Connection) -> int:
+    return int(conn.execute("PRAGMA user_version").fetchone()[0])
+
+
+def _declared_fk_children(conn: sqlite3.Connection) -> dict[str, list[tuple[str, str]]]:
+    """parent_table -> [(child_table, child_col), ...] from PRAGMA foreign_key_list."""
+    out: dict[str, list[tuple[str, str]]] = {t: [] for t in REID_PREFIX}
+    tables = [
+        r[0] for r in conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table'"
+        )
+    ]
+    for child in tables:
+        for fk in conn.execute(f"PRAGMA foreign_key_list({child})"):
+            parent, from_col, to_col = fk[2], fk[3], fk[4]
+            if parent in out:
+                out[parent].append((child, from_col))
+    return out
+
+
+def _build_maps(conn: sqlite3.Connection) -> dict[str, dict[str, str]]:
+    """table -> {old_id(str): new_global_id}."""
+    maps: dict[str, dict[str, str]] = {}
+    for table, prefix in REID_PREFIX.items():
+        rows = conn.execute(f"SELECT id FROM {table}").fetchall()
+        maps[table] = {str(r[0]): gen_global_id(prefix) for r in rows}
+    return maps
+
+
+def plan(conn: sqlite3.Connection) -> dict:
+    """Read-only summary of what --apply would do."""
+    maps = _build_maps(conn)
+    children = _declared_fk_children(conn)
+    return {
+        "user_version": _user_version(conn),
+        "target_version": SYNC_SCHEMA_VERSION,
+        "rows_per_table": {t: len(m) for t, m in maps.items()},
+        "fk_children": {t: children[t] for t in REID_PREFIX if children[t]},
+        "edge_kinds_remapped": sorted(EDGE_KIND_TABLE),
+    }
+
+
+def _rebuild_int_table(conn: sqlite3.Connection, table: str) -> None:
+    """Recreate an INTEGER-PK table with a TEXT PK, copying all rows verbatim
+    (ids land as their text form; remapping happens afterwards)."""
+    sql = conn.execute(
+        "SELECT sql FROM sqlite_master WHERE type='table' AND name=?", (table,)
+    ).fetchone()[0]
+    # Only the rowid-alias PK carries AUTOINCREMENT, so this targets the id col.
+    new_sql = re.sub(
+        r"INTEGER\s+PRIMARY\s+KEY\s+AUTOINCREMENT",
+        "TEXT PRIMARY KEY",
+        sql,
+        count=1,
+        flags=re.IGNORECASE,
+    )
+    new_sql = new_sql.replace(f"TABLE IF NOT EXISTS {table}", f"TABLE {table}__new", 1)
+    if "__new" not in new_sql:  # schema stored without IF NOT EXISTS
+        new_sql = re.sub(rf"\bTABLE\s+{table}\b", f"TABLE {table}__new", new_sql, count=1)
+    conn.execute(new_sql)
+    conn.execute(f"INSERT INTO {table}__new SELECT * FROM {table}")
+    conn.execute(f"DROP TABLE {table}")
+    conn.execute(f"ALTER TABLE {table}__new RENAME TO {table}")
+
+
+def _remap_ids(conn: sqlite3.Connection, table: str, id_map: dict[str, str]) -> None:
+    conn.executemany(
+        f"UPDATE {table} SET id=? WHERE id=?",
+        [(new, old) for old, new in id_map.items()],
+    )
+
+
+def _fix_refs(conn: sqlite3.Connection, maps: dict[str, dict[str, str]],
+              children: dict[str, list[tuple[str, str]]]) -> None:
+    # Declared foreign keys (parent_id, thread_id, source_thread, distill_id,
+    # claim_id, superseded_by, probe_id, ...).
+    for parent, refs in children.items():
+        id_map = maps[parent]
+        if not id_map:
+            continue
+        for child_table, child_col in refs:
+            conn.executemany(
+                f"UPDATE {child_table} SET {child_col}=? WHERE {child_col}=?",
+                [(new, old) for old, new in id_map.items()],
+            )
+    # Polymorphic edges (from_kind/from_id, to_kind/to_id).
+    for kind, tbl in EDGE_KIND_TABLE.items():
+        id_map = maps[tbl]
+        if not id_map:
+            continue
+        conn.executemany(
+            "UPDATE edges SET from_id=? WHERE from_kind=? AND from_id=?",
+            [(new, kind, old) for old, new in id_map.items()],
+        )
+        conn.executemany(
+            "UPDATE edges SET to_id=? WHERE to_kind=? AND to_id=?",
+            [(new, kind, old) for old, new in id_map.items()],
+        )
+
+
+def _stamp_baseline_hlc(conn: sqlite3.Connection) -> None:
+    """Give every replicated row a baseline (hlc, origin_node) so the first
+    sync has a well-defined last-writer ordering. One hlc per table is enough
+    (capture re-stamps on future writes)."""
+    from ..db import _SYNC_REPLICATED_TABLES
+    node_id = sync_identity.get_node_id(conn)
+    for t in _SYNC_REPLICATED_TABLES:
+        hlc = sync_identity.hlc_now(conn)
+        try:
+            conn.execute(
+                f"UPDATE {t} SET hlc=?, origin_node=? "
+                f"WHERE hlc IS NULL OR origin_node IS NULL",
+                (hlc, node_id),
+            )
+        except sqlite3.OperationalError:
+            pass
+
+
+def _rebuild_derived(conn: sqlite3.Connection) -> None:
+    """Derived indexes are keyed off the (now-changed) ids — rebuild locally."""
+    try:
+        conn.execute("INSERT INTO notes_fts(notes_fts) VALUES('rebuild')")
+    except sqlite3.OperationalError:
+        pass
+    # Drop stale vec rows keyed by the old integer notes.id; the ingest
+    # backfill (_backfill_vec_tables) repopulates notes_vec from notes.embedding
+    # via the new notes_vec_map on next daemon tick / get_db.
+    for stmt in ("DELETE FROM notes_vec", "DELETE FROM notes_vec_map"):
+        try:
+            conn.execute(stmt)
+        except sqlite3.OperationalError:
+            pass
+
+
+def apply(db_path: Path, do_apply: bool) -> int:
+    """Run the migration. Returns process exit code."""
+    if not db_path.exists():
+        print(f"error: DB not found: {db_path}", file=sys.stderr)
+        return 2
+
+    probe = sqlite3.connect(str(db_path))
+    try:
+        uv = _user_version(probe)
+        summary = plan(probe)
+    finally:
+        probe.close()
+
+    if uv >= SYNC_SCHEMA_VERSION:
+        print(f"already migrated (user_version={uv} >= {SYNC_SCHEMA_VERSION}); no-op.")
+        return 0
+
+    print("re-id migration plan:")
+    for t, n in summary["rows_per_table"].items():
+        print(f"  {t:<24} {n} rows")
+    print(f"  edge kinds remapped: {', '.join(summary['edge_kinds_remapped'])}")
+    print(f"  fk children: {sum(len(v) for v in summary['fk_children'].values())} ref columns")
+
+    if not do_apply:
+        print("\n--dry-run: no changes written. Re-run with --apply to migrate.")
+        return 0
+
+    backup = db_path.with_name(db_path.name + f".bak-{int(time.time())}")
+    shutil.copy2(db_path, backup)
+    print(f"\nbackup: {backup}")
+
+    conn = sqlite3.connect(str(db_path))
+    try:
+        conn.execute("PRAGMA foreign_keys=OFF")
+        try:
+            conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+        except sqlite3.OperationalError:
+            pass
+        maps = _build_maps(conn)
+        children = _declared_fk_children(conn)
+        conn.execute("BEGIN IMMEDIATE")
+        for table in INT_PK_TABLES:
+            _rebuild_int_table(conn, table)
+        for table in REID_PREFIX:
+            _remap_ids(conn, table, maps[table])
+        _fix_refs(conn, maps, children)
+        conn.execute("COMMIT")
+    except Exception:
+        conn.rollback()
+        conn.close()
+        print(f"error: migration failed, DB rolled back. Restore from {backup} "
+              f"if needed.", file=sys.stderr)
+        raise
+    conn.close()
+
+    # Reassert declared indexes/triggers on the rebuilt tables, rebuild derived
+    # indexes, stamp baseline HLC, then bump user_version.
+    from ..db import get_db
+    conn = get_db()
+    try:
+        _rebuild_derived(conn)
+        _stamp_baseline_hlc(conn)
+        conn.execute(f"PRAGMA user_version={SYNC_SCHEMA_VERSION}")
+        conn.commit()
+    finally:
+        conn.close()
+
+    print(f"done. user_version={SYNC_SCHEMA_VERSION}. Sync is now enabled once "
+          f"peers + listen are configured.")
+    return 0
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(
+        prog="tk-sync-migrate",
+        description="One-time re-id migration enabling cross-machine sync. "
+                    "Back up ~/.threadkeeper/db.sqlite first.",
+    )
+    ap.add_argument("--apply", action="store_true",
+                    help="perform the migration (default is a dry-run)")
+    ap.add_argument("--db", default=None, help="path to db.sqlite (default: config)")
+    args = ap.parse_args(argv)
+    db_path = Path(args.db).expanduser() if args.db else DB_PATH
+    return apply(db_path, do_apply=args.apply)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/threadkeeper/sync/migrate.py
+++ b/threadkeeper/sync/migrate.py
@@ -4,8 +4,8 @@ This is the ONE destructive step of cross-machine sync. It converts the
 INTEGER-AUTOINCREMENT primary keys on the replicated memory tables to global
 ULID TEXT ids (and widens the short 3-hex TEXT ids), rewriting every foreign
 reference in lockstep, then rebuilds derived indexes and stamps a baseline
-HLC. After it runs, `PRAGMA user_version` is bumped so the sync daemon/tools
-activate; before it runs they stay dormant.
+HLC. After it runs, `sync_state.sync_schema_version` is set so the sync
+daemon/tools activate; before it runs they stay dormant.
 
 NEVER auto-run. The operator invokes `tk-sync-migrate` (or
 `python -m threadkeeper.sync.migrate`) explicitly, after a backup. `--dry-run`
@@ -18,7 +18,6 @@ from __future__ import annotations
 
 import argparse
 import re
-import shutil
 import sqlite3
 import sys
 import time
@@ -60,8 +59,17 @@ EDGE_KIND_TABLE = {
 }
 
 
-def _user_version(conn: sqlite3.Connection) -> int:
-    return int(conn.execute("PRAGMA user_version").fetchone()[0])
+def _sync_version(conn: sqlite3.Connection) -> int:
+    """Sync migration gate, read from sync_state — NOT PRAGMA user_version, which
+    main owns as its own schema-migration counter (CURRENT_SCHEMA_VERSION).
+    0 = not migrated (absent table/row/value)."""
+    try:
+        row = conn.execute(
+            "SELECT sync_schema_version FROM sync_state WHERE id=1"
+        ).fetchone()
+    except sqlite3.OperationalError:
+        return 0
+    return int(row[0]) if row and row[0] is not None else 0
 
 
 def _declared_fk_children(conn: sqlite3.Connection) -> dict[str, list[tuple[str, str]]]:
@@ -94,7 +102,7 @@ def plan(conn: sqlite3.Connection) -> dict:
     maps = _build_maps(conn)
     children = _declared_fk_children(conn)
     return {
-        "user_version": _user_version(conn),
+        "sync_schema_version": _sync_version(conn),
         "target_version": SYNC_SCHEMA_VERSION,
         "rows_per_table": {t: len(m) for t, m in maps.items()},
         "fk_children": {t: children[t] for t in REID_PREFIX if children[t]},
@@ -207,13 +215,13 @@ def apply(db_path: Path, do_apply: bool) -> int:
 
     probe = sqlite3.connect(str(db_path))
     try:
-        uv = _user_version(probe)
+        uv = _sync_version(probe)
         summary = plan(probe)
     finally:
         probe.close()
 
     if uv >= SYNC_SCHEMA_VERSION:
-        print(f"already migrated (user_version={uv} >= {SYNC_SCHEMA_VERSION}); no-op.")
+        print(f"already migrated (sync_schema_version={uv} >= {SYNC_SCHEMA_VERSION}); no-op.")
         return 0
 
     print("re-id migration plan:")
@@ -226,8 +234,17 @@ def apply(db_path: Path, do_apply: bool) -> int:
         print("\n--dry-run: no changes written. Re-run with --apply to migrate.")
         return 0
 
-    backup = db_path.with_name(db_path.name + f".bak-{int(time.time())}")
-    shutil.copy2(db_path, backup)
+    backup = db_path.with_name(db_path.name + f".bak-{int(time.time())}.sqlite")
+    # Consistent single-file snapshot BEFORE any mutation. VACUUM INTO reads the
+    # live DB *through a connection*, so it captures committed pages still resident
+    # in the -wal — a plain file copy would miss them and produce a torn/stale
+    # backup exactly when it matters most (review of PR #201; same class as #95).
+    bk = sqlite3.connect(str(db_path))
+    try:
+        bk.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+        bk.execute("VACUUM INTO ?", (str(backup),))
+    finally:
+        bk.close()
     print(f"\nbackup: {backup}")
 
     conn = sqlite3.connect(str(db_path))
@@ -248,7 +265,14 @@ def apply(db_path: Path, do_apply: bool) -> int:
         conn.execute("COMMIT")
         # Enable the feature BEFORE reopening via get_db so that connection
         # materializes the migrated schema (rowid notes_vec + map + triggers).
-        conn.execute(f"PRAGMA user_version={SYNC_SCHEMA_VERSION}")
+        # The gate lives in sync_state — main owns PRAGMA user_version. Ensure the
+        # singleton row exists (get_node_id → _ensure_state) before stamping it.
+        sync_identity.get_node_id(conn)
+        conn.execute(
+            "UPDATE sync_state SET sync_schema_version=? WHERE id=1",
+            (SYNC_SCHEMA_VERSION,),
+        )
+        conn.commit()
     except Exception:
         conn.rollback()
         conn.close()
@@ -260,8 +284,12 @@ def apply(db_path: Path, do_apply: bool) -> int:
     # Reopen through get_db (reasserts declared indexes/triggers on the rebuilt
     # tables + installs sync). Rebuild derived indexes and stamp a baseline HLC
     # under applying_guard so capture triggers don't clobber the explicit stamp.
-    from ..db import get_db
+    # force=True: the gate just flipped, so bootstrap must re-run to rebuild the
+    # migrated notes_vec keying and install capture triggers (the earlier
+    # bootstrap saw an un-migrated DB and installed neither).
+    from ..db import get_db, bootstrap_db
     from . import capture
+    bootstrap_db(force=True)
     conn = get_db()
     try:
         with capture.applying_guard(conn):
@@ -271,8 +299,8 @@ def apply(db_path: Path, do_apply: bool) -> int:
     finally:
         conn.close()
 
-    print(f"done. user_version={SYNC_SCHEMA_VERSION}. Sync is now enabled once "
-          f"peers + listen are configured.")
+    print(f"done. sync_schema_version={SYNC_SCHEMA_VERSION}. Sync is now enabled "
+          f"once peers + listen are configured.")
     return 0
 
 

--- a/threadkeeper/sync/migrate.py
+++ b/threadkeeper/sync/migrate.py
@@ -112,10 +112,22 @@ def plan(conn: sqlite3.Connection) -> dict:
 
 def _rebuild_int_table(conn: sqlite3.Connection, table: str) -> None:
     """Recreate an INTEGER-PK table with a TEXT PK, copying all rows verbatim
-    (ids land as their text form; remapping happens afterwards)."""
+    (ids land as their text form; remapping happens afterwards).
+
+    DROP TABLE also drops the table's indexes and triggers, so its real
+    (non-auto) indexes are captured first and recreated verbatim afterwards —
+    their columns are unchanged, so the stored DDL still applies. Triggers are
+    NOT auto-restored here: the only ones on a rebuilt table are notes_fts's,
+    which must be re-keyed onto the integer rowid (see _rebuild_notes_fts)."""
     sql = conn.execute(
         "SELECT sql FROM sqlite_master WHERE type='table' AND name=?", (table,)
     ).fetchone()[0]
+    index_sqls = [
+        r[0] for r in conn.execute(
+            "SELECT sql FROM sqlite_master WHERE type='index' AND tbl_name=? "
+            "AND sql IS NOT NULL", (table,)
+        ).fetchall()
+    ]
     # Only the rowid-alias PK carries AUTOINCREMENT, so this targets the id col.
     # The DEFAULT lets post-migration INSERTs that omit id still get a global
     # id (128-bit random hex, collision-safe across machines) with zero
@@ -134,6 +146,36 @@ def _rebuild_int_table(conn: sqlite3.Connection, table: str) -> None:
     conn.execute(f"INSERT INTO {table}__new SELECT * FROM {table}")
     conn.execute(f"DROP TABLE {table}")
     conn.execute(f"ALTER TABLE {table}__new RENAME TO {table}")
+    for isql in index_sqls:
+        conn.execute(isql)
+
+
+def _rebuild_notes_fts(conn: sqlite3.Connection) -> None:
+    """Re-key notes FTS onto the LOCAL integer rowid.
+
+    `notes.id` becomes a TEXT ULID after the rebuild, but an FTS5 external-
+    content `content_rowid` must be an integer. The old notes_fts (keyed on
+    `id`) and its INSERT/DELETE triggers (dropped with the rebuilt table) are
+    recreated keyed on `notes.rowid` — the same shape main uses for dialog_fts.
+    Content is repopulated by the later 'rebuild' in _rebuild_derived. Uses
+    single-statement execs (not executescript, which would commit the
+    surrounding migration transaction)."""
+    conn.execute("DROP TABLE IF EXISTS notes_fts")
+    conn.execute(
+        "CREATE VIRTUAL TABLE notes_fts USING fts5("
+        "content, content='notes', content_rowid='rowid')"
+    )
+    conn.execute("DROP TRIGGER IF EXISTS notes_fts_ai")
+    conn.execute("DROP TRIGGER IF EXISTS notes_fts_ad")
+    conn.execute(
+        "CREATE TRIGGER notes_fts_ai AFTER INSERT ON notes BEGIN "
+        "INSERT INTO notes_fts(rowid, content) VALUES (new.rowid, new.content); END"
+    )
+    conn.execute(
+        "CREATE TRIGGER notes_fts_ad AFTER DELETE ON notes BEGIN "
+        "INSERT INTO notes_fts(notes_fts, rowid, content) "
+        "VALUES('delete', old.rowid, old.content); END"
+    )
 
 
 def _remap_ids(conn: sqlite3.Connection, table: str, id_map: dict[str, str]) -> None:
@@ -262,6 +304,7 @@ def apply(db_path: Path, do_apply: bool) -> int:
         for table in REID_PREFIX:
             _remap_ids(conn, table, maps[table])
         _fix_refs(conn, maps, children)
+        _rebuild_notes_fts(conn)
         conn.execute("COMMIT")
         # Enable the feature BEFORE reopening via get_db so that connection
         # materializes the migrated schema (rowid notes_vec + map + triggers).

--- a/threadkeeper/sync/protocol.py
+++ b/threadkeeper/sync/protocol.py
@@ -27,6 +27,12 @@ from .capture import _PK, _COMPOSITE, applying_guard
 # Columns never shipped: recomputed locally from content on each node.
 _PAYLOAD_EXCLUDE = {"embedding", "embed_backend"}
 _ALL_TABLES = list(_PK) + list(_COMPOSITE)
+# Replicated tables whose embedding is derived from a text column — used to
+# preserve an existing local embedding across an upsert when the source text is
+# unchanged (the wire payload never carries the embedding itself).
+_EMBED_TEXT_COL = {
+    "notes": "content", "dialog_messages": "content", "concepts": "description",
+}
 
 
 def _pk_where(table: str):
@@ -156,6 +162,19 @@ def apply_changes(conn: sqlite3.Connection, changes: list[dict]) -> int:
             local = _local_hlc(conn, t, where, keyvals)
             if local is not None and hlc <= local:
                 continue  # local copy is newer-or-equal
+            # embedding/embed_backend are never shipped, so INSERT OR REPLACE
+            # would NULL any existing local embedding. Preserve it when the row's
+            # embed-source text is unchanged; a content change leaves it NULL for
+            # rebuild_derived to recompute.
+            etext = _EMBED_TEXT_COL.get(t)
+            preserve = None
+            if etext is not None:
+                lr = conn.execute(
+                    f"SELECT {etext} AS tc, embedding, embed_backend "
+                    f"FROM {t} WHERE {where}", keyvals
+                ).fetchone()
+                if lr is not None and lr[1] is not None and lr[0] == row.get(etext):
+                    preserve = (lr[1], lr[2])
             cols = list(row.keys())
             placeholders = ",".join("?" for _ in cols)
             conn.execute(
@@ -163,6 +182,11 @@ def apply_changes(conn: sqlite3.Connection, changes: list[dict]) -> int:
                 f"VALUES ({placeholders})",
                 [row[k] for k in cols],
             )
+            if preserve is not None:
+                conn.execute(
+                    f"UPDATE {t} SET embedding=?, embed_backend=? WHERE {where}",
+                    (preserve[0], preserve[1], *keyvals),
+                )
             n += 1
         # Absorb the highest HLC just received so the next local write is
         # stamped from a clock that dominates it (LWW would otherwise drop the
@@ -187,8 +211,14 @@ def rebuild_derived(conn: sqlite3.Connection) -> None:
         except sqlite3.OperationalError:
             pass
         try:
-            from ..ingest import _backfill_dialog_fts_if_empty, _backfill_vec_tables
+            from ..ingest import (
+                _backfill_dialog_fts_if_empty, _backfill_vec_tables,
+                _backfill_sync_embeddings,
+            )
             _backfill_dialog_fts_if_empty(conn)
+            # Re-embed synced rows (notes/dialog/concepts) that arrived without
+            # an embedding BEFORE mirroring BLOBs into the vec indexes.
+            _backfill_sync_embeddings(conn)
             while _backfill_vec_tables(conn)[0]:
                 pass
         except Exception:

--- a/threadkeeper/sync/protocol.py
+++ b/threadkeeper/sync/protocol.py
@@ -111,8 +111,17 @@ def _has_newer_tombstone(conn, table, gid, hlc) -> bool:
 
 def apply_changes(conn: sqlite3.Connection, changes: list[dict]) -> int:
     """Merge a peer changeset (LWW by hlc). Runs under applying_guard so the
-    capture triggers don't re-log these as local writes. Returns count applied."""
+    capture triggers don't re-log these as local writes. Returns count applied.
+
+    Before committing, every received HLC is absorbed into the local clock so a
+    subsequent local edit is stamped from a clock that already dominates the
+    merged rows — otherwise the local write lands with a lower HLC and the next
+    reconcile drops it via LWW. Done inside the guard's transaction so the clock
+    advance is atomic with the applied rows."""
+    from . import identity as sync_identity
+
     n = 0
+    max_hlc = ""
     with applying_guard(conn):
         for c in changes:
             t = c["tbl"]
@@ -120,6 +129,8 @@ def apply_changes(conn: sqlite3.Connection, changes: list[dict]) -> int:
                 continue
             where, keyfn = _pk_where(t)
             hlc = c["hlc"]
+            if hlc and hlc > max_hlc:
+                max_hlc = hlc
             if c["op"] == "del":
                 gid = c["gid"]
                 # resolve pk value(s) from gid (composite is 'a:b')
@@ -153,6 +164,11 @@ def apply_changes(conn: sqlite3.Connection, changes: list[dict]) -> int:
                 [row[k] for k in cols],
             )
             n += 1
+        # Absorb the highest HLC just received so the next local write is
+        # stamped from a clock that dominates it (LWW would otherwise drop the
+        # local edit). Inside the guard's transaction → atomic with the rows.
+        if max_hlc:
+            sync_identity.hlc_absorb(conn, max_hlc)
     conn.commit()
     return n
 

--- a/threadkeeper/sync/protocol.py
+++ b/threadkeeper/sync/protocol.py
@@ -26,6 +26,11 @@ from .capture import _PK, _COMPOSITE, applying_guard
 
 # Columns never shipped: recomputed locally from content on each node.
 _PAYLOAD_EXCLUDE = {"embedding", "embed_backend"}
+# Cap on rows re-embedded synchronously in rebuild_derived (the /sync/push
+# request path). A large initial corpus would otherwise blow the client's ~30s
+# timeout and retry into the same expensive path. NULL embeddings are a valid
+# eventual state; the background ingester finishes the remainder in bounded ticks.
+_SYNC_EMBED_PUSH_BUDGET = 200
 _ALL_TABLES = list(_PK) + list(_COMPOSITE)
 # Replicated tables whose embedding is derived from a text column — used to
 # preserve an existing local embedding across an upsert when the source text is
@@ -217,8 +222,10 @@ def rebuild_derived(conn: sqlite3.Connection) -> None:
             )
             _backfill_dialog_fts_if_empty(conn)
             # Re-embed synced rows (notes/dialog/concepts) that arrived without
-            # an embedding BEFORE mirroring BLOBs into the vec indexes.
-            _backfill_sync_embeddings(conn)
+            # an embedding BEFORE mirroring BLOBs into the vec indexes. Bounded
+            # so this request path can't time out on a large corpus; the
+            # background ingester finishes the remainder in later ticks.
+            _backfill_sync_embeddings(conn, max_rows=_SYNC_EMBED_PUSH_BUDGET)
             while _backfill_vec_tables(conn)[0]:
                 pass
         except Exception:

--- a/threadkeeper/sync/protocol.py
+++ b/threadkeeper/sync/protocol.py
@@ -1,0 +1,200 @@
+"""Anti-entropy replication protocol (version-vector + LWW).
+
+Two nodes reconcile by exchanging a *version vector* — the highest HLC each
+has seen per origin node — and then sending each other every replicated row
+(and tombstone) the peer is missing. Because a row carries its ORIGIN's hlc
+(not the sender's), relaying is transitive: B forwards A's rows to C without a
+direct A–C link. Merges are last-writer-wins by HLC; deletes propagate as
+tombstones so a peer that still holds a row cannot resurrect it.
+
+Derived indexes (FTS5, vec) are never shipped — they are rebuilt locally from
+the base rows after a merge. Embedding BLOBs are omitted from the wire payload
+and recomputed locally too (every node has the model), keeping changesets small
+and JSON-serializable.
+
+`version_vector`, `collect_changes`, and `apply_changes` are the primitives the
+HTTP transport (sync/server.py, sync/daemon.py) calls; `sync_pair` runs a full
+bidirectional reconcile between two local connections (used by tests and the
+loopback path).
+"""
+from __future__ import annotations
+
+import json
+import sqlite3
+
+from .capture import _PK, _COMPOSITE, applying_guard
+
+# Columns never shipped: recomputed locally from content on each node.
+_PAYLOAD_EXCLUDE = {"embedding", "embed_backend"}
+_ALL_TABLES = list(_PK) + list(_COMPOSITE)
+
+
+def _pk_where(table: str):
+    """(where_sql, key_extractor(rowdict)) for a table's primary key."""
+    if table in _COMPOSITE:
+        a, b = _COMPOSITE[table]
+        return f"{a}=? AND {b}=?", (lambda r: (r[a], r[b]))
+    col = _PK[table]
+    return f"{col}=?", (lambda r: (r[col],))
+
+
+def version_vector(conn: sqlite3.Connection) -> dict:
+    """Highest hlc seen per origin node, across all replicated rows + delete
+    tombstones. Missing origin => '' (peer sends everything for it)."""
+    vv: dict[str, str] = {}
+    for t in _ALL_TABLES:
+        try:
+            rows = conn.execute(
+                f"SELECT origin_node AS o, MAX(hlc) AS m FROM {t} "
+                f"WHERE origin_node IS NOT NULL GROUP BY origin_node"
+            ).fetchall()
+        except sqlite3.OperationalError:
+            continue
+        for r in rows:
+            o, m = r[0], r[1]
+            if m and (o not in vv or m > vv[o]):
+                vv[o] = m
+    for r in conn.execute(
+        "SELECT origin_node AS o, MAX(hlc) AS m FROM sync_oplog "
+        "WHERE op='del' GROUP BY origin_node"
+    ).fetchall():
+        o, m = r[0], r[1]
+        if m and (o not in vv or m > vv[o]):
+            vv[o] = m
+    return vv
+
+
+def _row_payload(table: str, row: sqlite3.Row) -> dict:
+    return {k: row[k] for k in row.keys() if k not in _PAYLOAD_EXCLUDE}
+
+
+def collect_changes(conn: sqlite3.Connection, peer_vv: dict) -> list[dict]:
+    """Every row/tombstone whose hlc exceeds what the peer knows for its origin."""
+    conn.row_factory = sqlite3.Row
+    out: list[dict] = []
+    for t in _ALL_TABLES:
+        try:
+            rows = conn.execute(
+                f"SELECT * FROM {t} WHERE origin_node IS NOT NULL"
+            ).fetchall()
+        except sqlite3.OperationalError:
+            continue
+        for r in rows:
+            o, h = r["origin_node"], r["hlc"]
+            if h and h > peer_vv.get(o, ""):
+                out.append({"tbl": t, "op": "put", "hlc": h,
+                            "origin": o, "row": _row_payload(t, r)})
+    for r in conn.execute(
+        "SELECT tbl,gid,hlc,origin_node FROM sync_oplog WHERE op='del'"
+    ).fetchall():
+        o, h = r["origin_node"], r["hlc"]
+        if h and h > peer_vv.get(o, ""):
+            out.append({"tbl": r["tbl"], "op": "del", "hlc": h,
+                        "origin": o, "gid": r["gid"]})
+    return out
+
+
+def _local_hlc(conn, table, key_where, key_vals):
+    row = conn.execute(
+        f"SELECT hlc FROM {table} WHERE {key_where}", key_vals
+    ).fetchone()
+    return row[0] if row else None
+
+
+def _has_newer_tombstone(conn, table, gid, hlc) -> bool:
+    row = conn.execute(
+        "SELECT MAX(hlc) FROM sync_oplog WHERE tbl=? AND gid=? AND op='del'",
+        (table, gid),
+    ).fetchone()
+    return bool(row and row[0] and row[0] >= hlc)
+
+
+def apply_changes(conn: sqlite3.Connection, changes: list[dict]) -> int:
+    """Merge a peer changeset (LWW by hlc). Runs under applying_guard so the
+    capture triggers don't re-log these as local writes. Returns count applied."""
+    n = 0
+    with applying_guard(conn):
+        for c in changes:
+            t = c["tbl"]
+            if t not in _PK and t not in _COMPOSITE:
+                continue
+            where, keyfn = _pk_where(t)
+            hlc = c["hlc"]
+            if c["op"] == "del":
+                gid = c["gid"]
+                # resolve pk value(s) from gid (composite is 'a:b')
+                if t in _COMPOSITE:
+                    kv = tuple(gid.split(":", 1))
+                else:
+                    kv = (gid,)
+                local = _local_hlc(conn, t, where, kv)
+                if local is None or hlc > local:
+                    conn.execute(f"DELETE FROM {t} WHERE {where}", kv)
+                # persist tombstone for relay + resurrection guard
+                conn.execute(
+                    "INSERT INTO sync_oplog(tbl,gid,op,hlc,origin_node) "
+                    "VALUES(?,?,?,?,?)", (t, gid, "del", hlc, c["origin"]))
+                n += 1
+                continue
+            # put
+            row = dict(c["row"])
+            keyvals = keyfn(row)
+            gid = ":".join(str(v) for v in keyvals)
+            if _has_newer_tombstone(conn, t, gid, hlc):
+                continue  # deleted later than this write — stay deleted
+            local = _local_hlc(conn, t, where, keyvals)
+            if local is not None and hlc <= local:
+                continue  # local copy is newer-or-equal
+            cols = list(row.keys())
+            placeholders = ",".join("?" for _ in cols)
+            conn.execute(
+                f"INSERT OR REPLACE INTO {t} ({','.join(cols)}) "
+                f"VALUES ({placeholders})",
+                [row[k] for k in cols],
+            )
+            n += 1
+    conn.commit()
+    return n
+
+
+def rebuild_derived(conn: sqlite3.Connection) -> None:
+    """Rebuild FTS5 + vec locally after a merge (idempotent, self-healing).
+
+    Wrapped in applying_guard because these helpers write incidental control
+    state to a replicated table (e.g. the `style['fts_backfilled']` marker);
+    without the guard the capture triggers would log that as a fresh local
+    change on every sync, making reconcile non-idempotent and churning the
+    oplog forever."""
+    with applying_guard(conn):
+        try:
+            conn.execute("INSERT INTO notes_fts(notes_fts) VALUES('rebuild')")
+        except sqlite3.OperationalError:
+            pass
+        try:
+            from ..ingest import _backfill_dialog_fts_if_empty, _backfill_vec_tables
+            _backfill_dialog_fts_if_empty(conn)
+            while _backfill_vec_tables(conn)[0]:
+                pass
+        except Exception:
+            pass
+        conn.commit()
+
+
+def sync_pair(a: sqlite3.Connection, b: sqlite3.Connection) -> tuple[int, int]:
+    """Full bidirectional reconcile between two local connections. Returns
+    (applied_into_a, applied_into_b). Convergent + idempotent."""
+    vv_a, vv_b = version_vector(a), version_vector(b)
+    into_a = apply_changes(a, collect_changes(b, vv_a))
+    into_b = apply_changes(b, collect_changes(a, vv_b))
+    rebuild_derived(a)
+    rebuild_derived(b)
+    return into_a, into_b
+
+
+# Wire helpers: changesets are plain dicts, so JSON is enough.
+def dumps(obj) -> str:
+    return json.dumps(obj, separators=(",", ":"))
+
+
+def loads(s: str):
+    return json.loads(s)

--- a/threadkeeper/sync/reset_node.py
+++ b/threadkeeper/sync/reset_node.py
@@ -32,6 +32,7 @@ from pathlib import Path
 from ..config import DB_PATH
 from ..helpers import gen_global_id
 from . import identity as sync_identity
+from .capture import is_migrated
 
 
 def _high_water_hlc(conn: sqlite3.Connection) -> str:
@@ -73,15 +74,14 @@ def reset_node(db_path: Path, do_apply: bool) -> int:
     # transaction open, so the explicit BEGIN IMMEDIATE below is the only one.
     conn.isolation_level = None
     try:
-        # sync_state must exist (a non-migrated DB has no identity to reset).
-        has_state = conn.execute(
-            "SELECT 1 FROM sqlite_master WHERE type='table' AND name='sync_state'"
-        ).fetchone()
-        if not has_state:
-            print("error: DB has no sync_state; run tk-sync-migrate first.",
+        # The additive core schema creates sync_state before the opt-in re-id
+        # migration, so table existence is not a sufficient gate. Check the
+        # actual sync_schema_version before any helper that could initialize the
+        # singleton; in particular, a dry-run must remain strictly read-only.
+        if not is_migrated(conn):
+            print("error: DB is not sync-migrated; run tk-sync-migrate first.",
                   file=sys.stderr)
             return 2
-        sync_identity._ensure_state(conn)
         old = conn.execute(
             "SELECT node_id FROM sync_state WHERE id=1"
         ).fetchone()[0]

--- a/threadkeeper/sync/reset_node.py
+++ b/threadkeeper/sync/reset_node.py
@@ -1,0 +1,138 @@
+"""tk-sync-reset-node: give a CLONED thread-keeper DB a fresh sync identity.
+
+The sync `node_id` lives inside the DB (`sync_state`), so copying a migrated
+`db.sqlite` (or the whole `~/.threadkeeper` state dir) onto a second machine
+gives both installs the SAME identity. The version vector is `MAX(hlc)` per
+`origin_node`, so two independent HLC streams under one origin are
+indistinguishable: once a peer sees the higher stream it assumes every lower
+timestamp for that origin is already known, and a valid change from the other
+machine can be dropped forever. This is data loss, not an LWW collision.
+
+When to reset — the distinction matters:
+
+  * Restoring a backup as a REPLACEMENT for the same writer (the old machine is
+    gone) may keep the identity: there is still only one live writer for it.
+  * Creating a SECOND, simultaneously-writable replica from a DB/state-dir copy
+    MUST reset the clone's identity BEFORE it accepts any local write or sync,
+    so the two machines have distinct origins.
+
+The reset keeps the DB's existing HLC high-water mark and changes only the
+writer id, so a post-reset local write still dominates anything already
+observed (including a future-skewed remote HLC). Historical rows keep their
+`origin_node` — that history already lives in the copied DB.
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import sqlite3
+import sys
+from pathlib import Path
+
+from ..config import DB_PATH
+from ..helpers import gen_global_id
+from . import identity as sync_identity
+
+
+def _high_water_hlc(conn: sqlite3.Connection) -> str:
+    """Highest HLC this DB has observed anywhere — the per-origin version vector
+    plus the local clock — as an HLC string ('' if none). Absorbing this before
+    changing identity guarantees the next local write out-ranks it."""
+    from .protocol import version_vector
+
+    hlcs = [h for h in version_vector(conn).values() if h]
+    row = conn.execute(
+        "SELECT hlc_phys_ms, hlc_counter, node_id FROM sync_state WHERE id=1"
+    ).fetchone()
+    if row:
+        hlcs.append(sync_identity._fmt(int(row[0]), int(row[1]), row[2]))
+    return max(hlcs) if hlcs else ""
+
+
+def _write_node_id_mirror(db_path: Path, node_id: str) -> None:
+    """Atomically overwrite the ~/.threadkeeper/node.id mirror (write-temp +
+    os.replace). Unlike get_node_id's write-if-missing, a reset MUST replace a
+    stale mirror left from the copied identity."""
+    try:
+        p = db_path.parent / "node.id"
+        tmp = p.with_name("node.id.tmp")
+        tmp.write_text(node_id + "\n")
+        os.replace(tmp, p)
+    except OSError:
+        pass
+
+
+def reset_node(db_path: Path, do_apply: bool) -> int:
+    """Assign a fresh node_id to the DB at db_path. Returns a process exit code."""
+    if not db_path.exists():
+        print(f"error: DB not found: {db_path}", file=sys.stderr)
+        return 2
+
+    conn = sqlite3.connect(str(db_path))
+    # Autocommit: the setup reads/_ensure_state must not leave an implicit
+    # transaction open, so the explicit BEGIN IMMEDIATE below is the only one.
+    conn.isolation_level = None
+    try:
+        # sync_state must exist (a non-migrated DB has no identity to reset).
+        has_state = conn.execute(
+            "SELECT 1 FROM sqlite_master WHERE type='table' AND name='sync_state'"
+        ).fetchone()
+        if not has_state:
+            print("error: DB has no sync_state; run tk-sync-migrate first.",
+                  file=sys.stderr)
+            return 2
+        sync_identity._ensure_state(conn)
+        old = conn.execute(
+            "SELECT node_id FROM sync_state WHERE id=1"
+        ).fetchone()[0]
+        new = gen_global_id("N")
+        hw = _high_water_hlc(conn)
+
+        print(f"current node_id: {old}")
+        print(f"new node_id:     {new}")
+        print(f"HLC high-water preserved: {hw or '(none)'}")
+        if not do_apply:
+            print("\n--dry-run: no changes written. Re-run with --apply to reset.")
+            return 0
+
+        # One exclusive transaction: absorb the high-water into the local clock,
+        # switch the writer id, and drop any seen-cursor state scoped to the old
+        # identity. Historical rows are left untouched.
+        conn.execute("BEGIN IMMEDIATE")
+        try:
+            if hw:
+                sync_identity.hlc_absorb(conn, hw)  # non-committing variant
+            conn.execute(
+                "UPDATE sync_state SET node_id=? WHERE id=1", (new,)
+            )
+            conn.execute("DELETE FROM sync_peer_vv")
+            conn.execute("COMMIT")
+        except Exception:
+            conn.rollback()
+            raise
+    finally:
+        conn.close()
+
+    _write_node_id_mirror(db_path, new)
+    print(f"\ndone. node_id reset {old} -> {new}. Historical row origins "
+          f"unchanged. Sync/local writes may resume with the new identity.")
+    return 0
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(
+        prog="tk-sync-reset-node",
+        description="Assign a fresh sync identity to a CLONED thread-keeper DB. "
+                    "Run this on the COPY before it accepts local writes or sync; "
+                    "a plain backup-restore for the same writer does not need it.",
+    )
+    ap.add_argument("--apply", action="store_true",
+                    help="perform the reset (default is a dry-run)")
+    ap.add_argument("--db", default=None, help="path to db.sqlite (default: config)")
+    args = ap.parse_args(argv)
+    db_path = Path(args.db).expanduser() if args.db else DB_PATH
+    return reset_node(db_path, do_apply=args.apply)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/threadkeeper/sync/server.py
+++ b/threadkeeper/sync/server.py
@@ -1,0 +1,101 @@
+"""Server side of cross-machine sync: a tiny HTTP endpoint peers pull from and
+push to. Symmetric with sync/daemon.py — every instance runs both.
+
+Endpoints (bearer-token auth via THREADKEEPER_SYNC_TOKEN):
+  POST /sync/pull  {vv}        -> {vv, changes}   changes the caller is missing
+  POST /sync/push  {changes}   -> {applied}       merge the caller's changes
+
+Transport is plain HTTP: the deployment is expected to run over an already-
+encrypted private network (WireGuard/OpenVPN/Tailscale or LAN). The shared
+token authenticates peers. TLS termination can be added in front (or as a
+follow-up) without touching the protocol. OFF by default (no listen address).
+"""
+from __future__ import annotations
+
+import logging
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+from ..config import SYNC_LISTEN, SYNC_TOKEN
+from ..db import get_db
+from . import protocol
+from .capture import is_migrated
+
+logger = logging.getLogger(__name__)
+_started = False
+
+
+class _Handler(BaseHTTPRequestHandler):
+    def _authorized(self) -> bool:
+        if not SYNC_TOKEN:
+            return False  # never serve without a token configured
+        return self.headers.get("Authorization") == f"Bearer {SYNC_TOKEN}"
+
+    def _send_json(self, code: int, obj: dict) -> None:
+        data = protocol.dumps(obj).encode()
+        self.send_response(code)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(data)))
+        self.end_headers()
+        self.wfile.write(data)
+
+    def do_POST(self) -> None:  # noqa: N802
+        if not self._authorized():
+            self._send_json(401, {"error": "unauthorized"})
+            return
+        length = int(self.headers.get("Content-Length", 0) or 0)
+        try:
+            body = protocol.loads(self.rfile.read(length).decode() or "{}")
+        except Exception:
+            self._send_json(400, {"error": "bad_json"})
+            return
+        conn = get_db()
+        try:
+            if not is_migrated(conn):
+                self._send_json(409, {"error": "not_migrated"})
+                return
+            if self.path.rstrip("/") == "/sync/pull":
+                vv = body.get("vv", {})
+                self._send_json(200, {
+                    "vv": protocol.version_vector(conn),
+                    "changes": protocol.collect_changes(conn, vv),
+                })
+            elif self.path.rstrip("/") == "/sync/push":
+                n = protocol.apply_changes(conn, body.get("changes", []))
+                protocol.rebuild_derived(conn)
+                self._send_json(200, {"applied": n})
+            else:
+                self._send_json(404, {"error": "not_found"})
+        finally:
+            conn.close()
+
+    def log_message(self, *a) -> None:  # silence default stderr logging
+        pass
+
+
+def _parse_listen(listen: str) -> tuple[str, int] | None:
+    if not listen or ":" not in listen:
+        return None
+    host, _, port = listen.rpartition(":")
+    try:
+        return (host or "0.0.0.0", int(port))
+    except ValueError:
+        return None
+
+
+def start_server() -> None:
+    """Start the sync HTTP server if a listen address + token are configured."""
+    global _started
+    if _started:
+        return
+    addr = _parse_listen(SYNC_LISTEN)
+    if addr is None or not SYNC_TOKEN:
+        return
+    from ..config import BACKGROUND_DAEMONS_ALLOWED
+    if not BACKGROUND_DAEMONS_ALLOWED:
+        return
+    httpd = ThreadingHTTPServer(addr, _Handler)
+    t = threading.Thread(target=httpd.serve_forever, name="sync_server", daemon=True)
+    t.start()
+    _started = True
+    logger.info("sync server listening on %s:%d", *addr)

--- a/threadkeeper/sync/server.py
+++ b/threadkeeper/sync/server.py
@@ -12,6 +12,8 @@ follow-up) without touching the protocol. OFF by default (no listen address).
 """
 from __future__ import annotations
 
+import hmac
+import ipaddress
 import logging
 import threading
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
@@ -29,7 +31,11 @@ class _Handler(BaseHTTPRequestHandler):
     def _authorized(self) -> bool:
         if not SYNC_TOKEN:
             return False  # never serve without a token configured
-        return self.headers.get("Authorization") == f"Bearer {SYNC_TOKEN}"
+        # Constant-time compare: no early-out timing leak on the token even on a
+        # private network. compare_digest also tolerates a missing/short header.
+        return hmac.compare_digest(
+            self.headers.get("Authorization", ""), f"Bearer {SYNC_TOKEN}"
+        )
 
     def _send_json(self, code: int, obj: dict) -> None:
         data = protocol.dumps(obj).encode()
@@ -83,6 +89,21 @@ def _parse_listen(listen: str) -> tuple[str, int] | None:
         return None
 
 
+def _is_safe_bind_host(host: str) -> bool:
+    """A bind host needs no override only if it is loopback or a private/link-
+    local address. Wildcard binds (0.0.0.0 / ::) expose every interface — public
+    ones included — and a bare hostname can't be proven private, so both require
+    the explicit override. The DB replicates full private transcripts."""
+    h = (host or "").strip().strip("[]")
+    if h in ("", "0.0.0.0", "::", "*"):
+        return False
+    try:
+        ip = ipaddress.ip_address(h)
+    except ValueError:
+        return False  # hostname, not a literal IP — cannot verify it's private
+    return ip.is_loopback or ip.is_private or ip.is_link_local
+
+
 def start_server() -> None:
     """Start the sync HTTP server if a listen address + token are configured."""
     global _started
@@ -91,8 +112,16 @@ def start_server() -> None:
     addr = _parse_listen(SYNC_LISTEN)
     if addr is None or not SYNC_TOKEN:
         return
-    from ..config import BACKGROUND_DAEMONS_ALLOWED
+    from ..config import BACKGROUND_DAEMONS_ALLOWED, SYNC_ALLOW_PUBLIC_BIND
     if not BACKGROUND_DAEMONS_ALLOWED:
+        return
+    if not _is_safe_bind_host(addr[0]) and not SYNC_ALLOW_PUBLIC_BIND:
+        logger.error(
+            "sync server refusing to bind %s:%d — not a loopback/private "
+            "address. The DB replicates full private transcripts. Bind a "
+            "private/VPN address, or set THREADKEEPER_SYNC_ALLOW_PUBLIC_BIND=1 "
+            "to override (only behind your own network controls).", *addr,
+        )
         return
     httpd = ThreadingHTTPServer(addr, _Handler)
     t = threading.Thread(target=httpd.serve_forever, name="sync_server", daemon=True)

--- a/threadkeeper/tools/sync.py
+++ b/threadkeeper/tools/sync.py
@@ -1,0 +1,48 @@
+"""MCP tools for cross-machine sync: inspect status and trigger a reconcile.
+
+All read-only or manual; the automatic path is sync/daemon.py. Dormant until
+the DB is migrated (`tk-sync-migrate`) and peers/token are configured.
+"""
+from __future__ import annotations
+
+from .._mcp import read_tool, write_tool
+from ..config import SYNC_LISTEN
+from ..db import get_db
+from ..sync import daemon, protocol
+from ..sync import identity as sync_identity
+from ..sync.capture import is_migrated
+
+
+@read_tool()
+def sync_status() -> str:
+    """Cross-machine sync status: migrated?, this node id, peer count, listen
+    address, oplog size, and how many origin nodes this DB has seen."""
+    conn = get_db()
+    try:
+        mig = is_migrated(conn)
+        node = sync_identity.get_node_id(conn) if mig else "-"
+        vv = protocol.version_vector(conn) if mig else {}
+        oplog = (conn.execute("SELECT COUNT(*) FROM sync_oplog").fetchone()[0]
+                 if mig else 0)
+    finally:
+        conn.close()
+    peers = daemon.peers()
+    return (f"migrated={mig} node={node} peers={len(peers)} "
+            f"listen={SYNC_LISTEN or '-'} oplog={oplog} origins={len(vv)}")
+
+
+@read_tool()
+def sync_peers() -> str:
+    """List the configured sync peers (THREADKEEPER_SYNC_PEERS)."""
+    ps = daemon.peers()
+    return ", ".join(ps) if ps else "(none configured)"
+
+
+@write_tool(idempotent=True)
+def sync_now() -> str:
+    """Reconcile with every configured peer right now (bidirectional). Returns
+    per-peer (pulled, pushed) counts or an error marker."""
+    res = daemon.sync_all()
+    if not res:
+        return "no peers configured (set THREADKEEPER_SYNC_PEERS)"
+    return " ".join(f"{p}={v}" for p, v in res.items())

--- a/threadkeeper/tools/threads.py
+++ b/threadkeeper/tools/threads.py
@@ -16,9 +16,19 @@ from ..db import get_db, read_db, run_write
 from ..helpers import gen_thread_id, fmt_age, q
 from .. import identity
 from ..identity import _ensure_session, _detect_self_cid, _emit
-from ..embeddings import _embed, _vec_upsert_note, embed_tag
+from ..embeddings import _embed, _vec_upsert_note, _notes_mapped, embed_tag
 from ..retrieval import retrieve_notes
 from ..brief import render_brief, render_context
+
+
+def _note_gid(conn, rowid):
+    """The note's sync id for the vec mirror: on a migrated DB the note's TEXT
+    global id (resolved from the just-inserted rowid), else the integer rowid."""
+    if _notes_mapped(conn):
+        r = conn.execute("SELECT id FROM notes WHERE rowid=?", (rowid,)).fetchone()
+        if r is not None:
+            return r[0]
+    return rowid
 
 
 @read_tool()
@@ -115,7 +125,7 @@ def note(thread_id: str, content: str, kind: str = "move") -> str:
             (thread_id, content, kind, now, identity._session_id,
              emb, embed_tag(emb)),
         )
-        note_id = cur.lastrowid
+        note_id = _note_gid(conn, cur.lastrowid)
         _vec_upsert_note(conn, note_id, emb)
         conn.execute(
             "UPDATE threads SET last_touched_at=?, last_move=?, "
@@ -218,7 +228,7 @@ def mark_skill_materialized(thread_id: str, skill_path: str = "") -> str:
             (thread_id, note_body, "move", now, identity._session_id,
              emb, embed_tag(emb)),
         )
-        _vec_upsert_note(conn, cur.lastrowid, emb)
+        _vec_upsert_note(conn, _note_gid(conn, cur.lastrowid), emb)
         conn.execute(
             "UPDATE threads SET last_touched_at=?, last_move=? WHERE id=?",
             (now, note_body[:90], thread_id),


### PR DESCRIPTION
## Cross-machine sync (active-active P2P)

Keeps thread-keeper memory synchronized across a user's machines **active-active**: every node writes autonomously (incl. offline, multiple agents), and all nodes converge to the **union** of write-sets, concurrent edits resolved by HLC last-writer-wins. Topology is a **decentralized P2P mesh** (no hub); peer lists may be partial/asymmetric because replication is transitive.

Full design + ops in [`docs/sync.md`](docs/sync.md).

### How it works
- Each replicated row carries `origin_node` / `hlc` (Hybrid Logical Clock) / `deleted`. Global TEXT ids (ULID).
- **Anti-entropy**: peers exchange version vectors, send rows/tombstones the peer lacks; a row carries its *origin's* HLC so relaying is transitive (B forwards A's rows to C with no A–C link).
- **Capture** via per-table triggers (hlc/origin stamping + oplog), suppressed during merge (`applying_guard`) so relayed rows keep origin/hlc and reconcile is idempotent.
- **Transport**: symmetric HTTP `/sync/pull` + `/sync/push`, bearer-token auth, over a private network. Client daemon + server both boot from the existing `_ensure_session` cascade.
- Derived indexes (FTS5, vec) never shipped — rebuilt locally; embeddings recomputed locally.

### Safety / gating
- Everything is **OFF by default** and dormant until `PRAGMA user_version >= SYNC_SCHEMA_VERSION`. Installing without migrating leaves an existing user completely unaffected.
- The additive schema (sync columns + tables) auto-applies and is safe. The destructive **re-id** (INTEGER PKs → global TEXT ids, references rewritten in lockstep) is a separate opt-in script `tk-sync-migrate` — **never auto-run**, `--dry-run` by default, auto-backs-up `db.sqlite`, idempotent.

### Table classes
Replicated (memory) / node-local (sessions, presence, cursors, ingest_state, resource_controls, **events**, signals, tasks, extract_candidates — so the events cursor never collides) / derived (rebuilt).

### Tests
Convergence (3-node chain, transitivity, LWW, delete tombstones, idempotency), capture, HTTP transport, and re-id migration (FK + polymorphic-edge fixups). Full suite green under `pytest --forked`.

### Follow-ups (noted in docs/sync.md)
Counter-column CRDT (LWW drops a losing increment for now), in-process TLS, mDNS/reachability-triggered sync, relay for NAT'd peers.

---
Opening for design review before we wire it into a live setup; the re-id migration is run separately by the operator.
