### PR TITLE
fix: requeue closed-unmerged roadmap applier PRs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -139,6 +139,12 @@ version bumps follow semver per the policy in
   instead of silently switching tasks, and skip telemetry is visible through
   `evolve_apply_status()` plus the `roadmap_issue_skipped` dashboard outcome.
 
+- **Evolve applier applied-marker reconciliation (#51).** Open roadmap issues
+  with a `roadmap_issue_applied` marker now check the recorded applier PR state
+  before being skipped. Open or merged PRs remain suppressed; a closed-unmerged
+  PR records `roadmap_issue_requeued`, supersedes the stale marker, and lets the
+  issue flow through the existing retry backoff/dead-letter gates again.
+
 ## v0.14.0 — 2026-06-25
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -701,9 +701,12 @@ before spawning, and advances to the next issue when an issue-local dispatch
 failure prevents startup. It implements exactly that issue, runs the full suite,
 opens a PR whose body includes `Closes #N`, and only then calls
 `evolve_mark_roadmap_issue_applied(issue_number, pr_url)`. It never commits or
-pushes to `main`, and it never marks an issue applied without a real PR URL. A
-manual `evolve_apply_roadmap_issue(issue_number=N)` remains exact: it reports
-why that issue cannot start instead of silently switching to another issue.
+pushes to `main`, and it never marks an issue applied without a real PR URL. If
+that PR is later closed without merging, the parent reconciles the marker
+against GitHub PR state, records `roadmap_issue_requeued`, and lets the issue
+flow through the normal retry backoff/dead-letter gates again. A manual
+`evolve_apply_roadmap_issue(issue_number=N)` remains exact: it reports why that
+issue cannot start instead of silently switching to another issue.
 The queue fetch uses paginated GitHub REST reads in oldest-created order, then
 applies the documented roadmap/FIFO sort locally. A generous local candidate
 window is retained as a runaway guard; if it ever truncates, the applier logs

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -411,9 +411,15 @@ All daemon threads are cheap (ticks 0.5–30 s), no-op when env-knobs disable th
   failure instead of switching tasks. The PR body must include `Closes #N`;
   after `gh pr create` prints a real URL, the child calls
   `evolve_mark_roadmap_issue_applied(issue_number, pr_url)` so the daemon does
-  not pick it again while human review/merge is pending. **Issue/body safety
-  (#22):** the issue body and legacy evolve suggestions are embedded only inside
-  explicit data fences, and privileged evolve children get a PATH-prepended
+  not pick it again while human review/merge is pending.
+  **Applied-marker reconciliation (#51):** before honoring that marker for an
+  open issue, `_open_roadmap_issues()` checks the recorded applier PR state via
+  `gh pr list --state all`. Open PRs and merged PRs keep the issue suppressed;
+  a closed-unmerged PR records `roadmap_issue_requeued`, supersedes the marker,
+  and lets the issue pass through the existing retry backoff/dead-letter gates.
+  **Issue/body safety (#22):** the issue body and legacy evolve suggestions are
+  embedded only inside explicit data fences, and privileged evolve children get
+  a PATH-prepended
   `gh` wrapper. For `gh issue create`, `gh issue comment`, and `gh pr create`,
   the wrapper redacts `/Users/<name>/...` and `/home/<name>/...` paths plus
   common token shapes before the real GitHub CLI receives the body, refusing if

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -80,6 +80,11 @@ remains a live question.
   `blocked,needs-design,wontfix,question,discussion,help wanted`), reports
   exact-mode skips as `skipped: label X`, and surfaces skip telemetry in
   `evolve_apply_status()` / `mp_dashboard()`.
+- Evolve applier applied-marker reconciliation (#51): when an open issue has a
+  `roadmap_issue_applied` marker, the selector now checks the recorded PR state.
+  Open or merged PRs keep the issue out of the queue; a closed-unmerged PR
+  records `roadmap_issue_requeued`, supersedes the stale marker, and sends the
+  issue back through the existing retry backoff/dead-letter gates.
 - Config typo visibility (#88): startup and hot-config reload now warn on
   unknown `THREADKEEPER_*` process-env keys while preserving pydantic's
   `extra="ignore"` behavior, and `spawn_status()` surfaces unsupported spawn
@@ -776,12 +781,12 @@ return `skipped: label X` for a denylisted issue rather than switching to
 another issue. Skip telemetry is recorded as `roadmap_issue_skipped` and
 surfaced in `evolve_apply_status()` / `mp_dashboard()`. Scope was S.
 
-**Closed-unmerged applier PR strands its issue.** The child records a permanent
-`roadmap_issue_applied` marker once it opens a PR; if a human closes that PR
-without merging, GitHub leaves the issue open but the applier skips it forever.
-Reconcile applied-markers against PR merge state (re-queue closed-unmerged PRs
-with a bounded retry). Distinct from the shipped claim-leak / duplicate-PR
-guards (#23). (#51) Scope: S.
+**Closed-unmerged applier PR retry (done, #51).** `_open_roadmap_issues()` now
+reconciles a `roadmap_issue_applied` marker against the recorded applier PR
+state before skipping an open issue. Open or merged PRs still suppress the
+issue; a closed-unmerged PR records `roadmap_issue_requeued`, supersedes the
+stale marker, and re-enters the normal candidate flow subject to the existing
+retry backoff/dead-letter cap. Scope was S.
 
 **Destructive curator deletion recovery.** ✅ DONE (#41) —
 `lesson_remove` captures the exact removed lesson section plus usage row under

--- a/tests/test_evolve_applier.py
+++ b/tests/test_evolve_applier.py
@@ -416,6 +416,169 @@ def test_open_roadmap_issues_prioritizes_roadmap_and_skips_applied(
     assert [int(i["number"]) for i in issues] == [2, 3]
 
 
+def test_open_roadmap_issues_requeues_closed_unmerged_applied_marker(
+    tmp_path, monkeypatch,
+):
+    pkg = _bootstrap(tmp_path, monkeypatch)
+    conn = pkg["db"].get_db()
+    monkeypatch.setattr(
+        pkg["ea"], "_fetch_open_issues",
+        lambda repo_root=None: ([_issue(6, "Retry rejected PR")], ""),
+    )
+    pkg["ea"].mark_roadmap_issue_applied(
+        conn, 6, "https://github.com/o/r/pull/60"
+    )
+
+    class _Proc:
+        returncode = 0
+        stdout = json.dumps([
+            {
+                "number": 60,
+                "state": "CLOSED",
+                "mergedAt": None,
+                "headRefName": "roadmap/issue-6-retry-rejected-pr-abcdef",
+                "url": "https://github.com/o/r/pull/60",
+            }
+        ])
+        stderr = ""
+
+    calls = []
+
+    def _run_gh(cmd, **kwargs):
+        calls.append(cmd)
+        return _Proc()
+
+    monkeypatch.setattr(pkg["ea"], "_run_gh", _run_gh)
+
+    issues, err = pkg["ea"]._open_roadmap_issues(conn)
+
+    assert err == ""
+    assert [int(i["number"]) for i in issues] == [6]
+    assert pkg["ea"]._roadmap_issue_applied(conn, 6) is False
+    row = conn.execute(
+        "SELECT summary FROM events WHERE kind='roadmap_issue_requeued' "
+        "AND target='6'"
+    ).fetchone()
+    assert "closed_unmerged pr=#60" in row["summary"]
+    assert any("--state" in c and "all" in c for c in calls)
+
+
+def test_open_roadmap_issues_keeps_open_applied_pr_out(
+    tmp_path, monkeypatch,
+):
+    pkg = _bootstrap(tmp_path, monkeypatch)
+    conn = pkg["db"].get_db()
+    monkeypatch.setattr(
+        pkg["ea"], "_fetch_open_issues",
+        lambda repo_root=None: ([_issue(6, "Open PR")], ""),
+    )
+    pkg["ea"].mark_roadmap_issue_applied(
+        conn, 6, "https://github.com/o/r/pull/60"
+    )
+
+    class _Proc:
+        returncode = 0
+        stdout = json.dumps([
+            {
+                "number": 60,
+                "state": "OPEN",
+                "mergedAt": None,
+                "headRefName": "roadmap/issue-6-open-pr-abcdef",
+                "url": "https://github.com/o/r/pull/60",
+            }
+        ])
+        stderr = ""
+
+    monkeypatch.setattr(pkg["ea"], "_run_gh", lambda *a, **k: _Proc())
+
+    issues, err = pkg["ea"]._open_roadmap_issues(conn)
+
+    assert err == ""
+    assert issues == []
+    assert pkg["ea"]._roadmap_issue_applied(conn, 6) is True
+    row = conn.execute(
+        "SELECT 1 FROM events WHERE kind='roadmap_issue_requeued' "
+        "AND target='6'"
+    ).fetchone()
+    assert row is None
+
+
+def test_open_roadmap_issues_keeps_merged_applied_pr_out(
+    tmp_path, monkeypatch,
+):
+    pkg = _bootstrap(tmp_path, monkeypatch)
+    conn = pkg["db"].get_db()
+    monkeypatch.setattr(
+        pkg["ea"], "_fetch_open_issues",
+        lambda repo_root=None: ([_issue(6, "Merged PR")], ""),
+    )
+    pkg["ea"].mark_roadmap_issue_applied(
+        conn, 6, "https://github.com/o/r/pull/60"
+    )
+
+    class _Proc:
+        returncode = 0
+        stdout = json.dumps([
+            {
+                "number": 60,
+                "state": "MERGED",
+                "mergedAt": "2026-06-17T12:00:00Z",
+                "headRefName": "roadmap/issue-6-merged-pr-abcdef",
+                "url": "https://github.com/o/r/pull/60",
+            }
+        ])
+        stderr = ""
+
+    monkeypatch.setattr(pkg["ea"], "_run_gh", lambda *a, **k: _Proc())
+
+    issues, err = pkg["ea"]._open_roadmap_issues(conn)
+
+    assert err == ""
+    assert issues == []
+    assert pkg["ea"]._roadmap_issue_applied(conn, 6) is True
+
+
+def test_open_roadmap_issues_requeued_marker_obeys_attempt_cap(
+    tmp_path, monkeypatch,
+):
+    pkg = _bootstrap(tmp_path, monkeypatch)
+    conn = pkg["db"].get_db()
+    monkeypatch.setattr(pkg["ea"], "ROADMAP_ISSUE_MAX_ATTEMPTS", 1)
+    monkeypatch.setattr(
+        pkg["ea"], "_fetch_open_issues",
+        lambda repo_root=None: ([_issue(6, "Rejected too often")], ""),
+    )
+    _seed_attempts(conn, pkg["ea"], 6, 1, created_at=int(time.time()) - 999999)
+    pkg["ea"].mark_roadmap_issue_applied(
+        conn, 6, "https://github.com/o/r/pull/60"
+    )
+
+    class _Proc:
+        returncode = 0
+        stdout = json.dumps([
+            {
+                "number": 60,
+                "state": "CLOSED",
+                "mergedAt": None,
+                "headRefName": "roadmap/issue-6-rejected-too-often-abcdef",
+                "url": "https://github.com/o/r/pull/60",
+            }
+        ])
+        stderr = ""
+
+    monkeypatch.setattr(pkg["ea"], "_run_gh", lambda *a, **k: _Proc())
+
+    issues, err = pkg["ea"]._open_roadmap_issues(conn)
+
+    assert err == ""
+    assert issues == []
+    assert pkg["ea"]._roadmap_issue_applied(conn, 6) is False
+    state, attempts, _ = pkg["ea"]._classify_roadmap_issue(
+        conn, 6, time.time()
+    )
+    assert (state, attempts) == ("dead_letter", 1)
+
+
 def test_open_roadmap_issues_skips_active_issue_claim(
     tmp_path, monkeypatch,
 ):

--- a/threadkeeper/evolve_applier.py
+++ b/threadkeeper/evolve_applier.py
@@ -20,7 +20,9 @@ Primary path:
   `ROADMAP_ISSUE_MAX_ATTEMPTS` the issue is dead-lettered — a `blocked` label
   plus a one-time summary comment — and dropped from the auto-drain until a
   human intervenes. A successful child writes `roadmap_issue_applied` (checked
-  first everywhere), so only genuinely-failing issues accrue backoff.
+  first everywhere), but the selector reconciles that marker with PR state:
+  a closed-unmerged PR records `roadmap_issue_requeued` and lets the existing
+  backoff/dead-letter ledger bound retries.
 
 Fallback paths:
 
@@ -183,6 +185,7 @@ ROADMAP_ISSUE_CLAIM_HOST_KIND = "roadmap_issue_claim_host"
 # written when an issue crosses the attempt cap and is flagged for a human.
 ROADMAP_ISSUE_ATTEMPT_KIND = "roadmap_issue_attempt"
 ROADMAP_ISSUE_DEAD_LETTER_KIND = "roadmap_issue_dead_letter"
+ROADMAP_ISSUE_REQUEUED_KIND = "roadmap_issue_requeued"
 EVOLVE_GIT_SAFETY_KIND = "evolve_git_safety"
 ROADMAP_ISSUE_SKIPPED_KIND = "roadmap_issue_skipped"
 # Label applied to a dead-lettered issue so it is visibly excluded from the
@@ -1246,6 +1249,7 @@ def _comment_issue_claim(
 
 
 _COMMENT_URL_ID_RE = re.compile(r"issuecomment[-_](\d+)")
+_PR_URL_NUMBER_RE = re.compile(r"/pull/(\d+)(?:\b|/|$)")
 
 
 def _comment_url_to_id(url: str) -> str:
@@ -1318,6 +1322,175 @@ def _open_prs_for_issue(
     if not isinstance(data, list):
         return [], "gh_pr_list_bad_shape"
     return data, ""
+
+
+def _pr_number_from_url(value: object) -> Optional[int]:
+    m = _PR_URL_NUMBER_RE.search(str(value or ""))
+    if not m:
+        return None
+    try:
+        return int(m.group(1))
+    except ValueError:
+        return None
+
+
+def _list_prs_for_applied_marker(
+    issue_number: int,
+    marker_summary: str,
+    repo_root: Optional[Path] = None,
+) -> tuple[list[dict], str]:
+    """Fetch PR state for the PR recorded in a roadmap applied marker.
+
+    The marker summary is the PR URL written by the child. We query via
+    `gh pr list` (rather than `view`) so open/closed/merged states share one
+    shape and tests can stub the same command family as the duplicate-PR guard.
+    """
+    repo = str(repo_root or _repo_root())
+    fields = "number,state,mergedAt,headRefName,url"
+    marker_pr = _pr_number_from_url(marker_summary)
+    searches: list[str] = []
+    if marker_pr is not None:
+        searches.append(str(marker_pr))
+    searches.append(f"in:body Closes #{int(issue_number)}")
+
+    last_err = ""
+    for search in searches:
+        cmd = [
+            "gh", "pr", "list",
+            "--state", "all",
+            "--search", search,
+            "--json", fields,
+            "--limit", "20",
+        ]
+        try:
+            proc = _run_gh(cmd, cwd=repo, timeout=30)
+        except FileNotFoundError:
+            return [], "gh_not_found"
+        except subprocess.TimeoutExpired:
+            return [], "gh_pr_list_timeout"
+        except OSError as e:
+            return [], f"gh_pr_list_error: {e}"
+        if proc.returncode != 0:
+            err = (proc.stderr or proc.stdout or "").strip().splitlines()
+            msg = err[-1] if err else f"exit={proc.returncode}"
+            last_err = f"gh_pr_list_failed: {msg[:180]}"
+            continue
+        try:
+            data = json.loads(proc.stdout or "[]")
+        except json.JSONDecodeError as e:
+            return [], f"gh_pr_list_bad_json: {e}"
+        if not isinstance(data, list):
+            return [], "gh_pr_list_bad_shape"
+        prs = [p for p in data if isinstance(p, dict)]
+        if marker_pr is not None:
+            exact = [
+                p for p in prs
+                if int(p.get("number") or 0) == marker_pr
+            ]
+            if exact:
+                return exact, ""
+            continue
+        if prs:
+            return prs, ""
+    if last_err:
+        return [], last_err
+    return [], ""
+
+
+def _pr_is_closed_unmerged(pr: dict) -> bool:
+    state = str(pr.get("state") or "").upper()
+    return state == "CLOSED" and not (pr.get("mergedAt") or "")
+
+
+def _roadmap_issue_applied_marker(
+    conn: sqlite3.Connection, issue_number: int
+) -> Optional[dict]:
+    """Latest applied/requeued marker for an issue, or None when requeued.
+
+    `events` is append-only, so stale applied markers are superseded by a later
+    `roadmap_issue_requeued` event instead of being deleted.
+    """
+    try:
+        row = conn.execute(
+            "SELECT id, kind, summary, created_at FROM events "
+            "WHERE target=? AND kind IN (?, ?) "
+            "ORDER BY id DESC LIMIT 1",
+            (
+                str(int(issue_number)),
+                ROADMAP_ISSUE_APPLIED_KIND,
+                ROADMAP_ISSUE_REQUEUED_KIND,
+            ),
+        ).fetchone()
+    except sqlite3.OperationalError:
+        return None
+    if not row or row["kind"] != ROADMAP_ISSUE_APPLIED_KIND:
+        return None
+    return {
+        "id": int(row["id"]),
+        "summary": row["summary"] or "",
+        "created_at": int(row["created_at"] or 0),
+    }
+
+
+def _record_roadmap_issue_requeued(
+    conn: sqlite3.Connection,
+    issue_number: int,
+    marker: dict,
+    pr: dict,
+) -> None:
+    num = int(issue_number)
+    pr_num = pr.get("number")
+    head = str(pr.get("headRefName") or "")
+    summary = (
+        f"closed_unmerged pr=#{pr_num} head={head[:80]} "
+        f"supersedes_event={marker.get('id')} "
+        f"pr_url={str(marker.get('summary') or '')[:120]}"
+    )
+    try:
+        conn.execute(
+            "INSERT INTO events (session_id, kind, target, summary, created_at) "
+            "VALUES (?, ?, ?, ?, ?)",
+            (
+                identity._session_id or "",
+                ROADMAP_ISSUE_REQUEUED_KIND,
+                str(num),
+                summary[:300],
+                int(time.time()),
+            ),
+        )
+        conn.commit()
+    except sqlite3.OperationalError:
+        logger.debug(
+            "evolve_applier: failed to record roadmap issue requeue",
+            exc_info=True,
+        )
+
+
+def _roadmap_issue_applied_blocks_issue(
+    conn: sqlite3.Connection,
+    issue_number: int,
+    repo_root: Optional[Path] = None,
+) -> tuple[bool, str]:
+    """True when an active applied marker should still suppress the issue.
+
+    Open PRs and merged PRs keep the marker active. A closed-unmerged PR
+    supersedes the marker with `roadmap_issue_requeued` so the issue can move
+    through the normal label/trust/backoff/dead-letter gates again.
+    """
+    marker = _roadmap_issue_applied_marker(conn, issue_number)
+    if marker is None:
+        return False, ""
+    prs, err = _list_prs_for_applied_marker(
+        issue_number, str(marker.get("summary") or ""), repo_root
+    )
+    if err:
+        return True, err
+    if not prs:
+        return True, "roadmap_issue_applied_pr_not_found"
+    if any(not _pr_is_closed_unmerged(pr) for pr in prs):
+        return True, ""
+    _record_roadmap_issue_requeued(conn, issue_number, marker, prs[0])
+    return False, ""
 
 
 def _fetch_open_prs(repo_root: Optional[Path] = None) -> tuple[list[dict], str]:
@@ -1449,14 +1622,7 @@ def _resolve_claim_race(
 
 
 def _roadmap_issue_applied(conn: sqlite3.Connection, issue_number: int) -> bool:
-    try:
-        row = conn.execute(
-            "SELECT 1 FROM events WHERE kind=? AND target=? LIMIT 1",
-            (ROADMAP_ISSUE_APPLIED_KIND, str(int(issue_number))),
-        ).fetchone()
-    except sqlite3.OperationalError:
-        return False
-    return row is not None
+    return _roadmap_issue_applied_marker(conn, issue_number) is not None
 
 
 # ── Poison-issue failure backoff + dead-letter ──────────────────────────────
@@ -1759,6 +1925,7 @@ def _open_roadmap_issue_candidates(
         return [], err, []
     out: list[dict] = []
     claim_errors: list[str] = []
+    applied_errors: list[str] = []
     untrusted: list[int] = []
     label_skipped: list[tuple[int, str]] = []
     now_t = time.time()
@@ -1767,7 +1934,12 @@ def _open_roadmap_issue_candidates(
             num = int(issue.get("number"))
         except (TypeError, ValueError):
             continue
-        if _roadmap_issue_applied(conn, num):
+        applied_blocks, applied_err = _roadmap_issue_applied_blocks_issue(
+            conn, num, repo_root
+        )
+        if applied_err:
+            applied_errors.append(f"#{num}: {applied_err}")
+        if applied_blocks:
             continue
         skip_label = _roadmap_issue_skip_label(issue)
         if skip_label:
@@ -1807,10 +1979,15 @@ def _open_roadmap_issue_candidates(
             len(untrusted),
             ", ".join(f"#{n}" for n in untrusted[:20]),
         )
-    if not out and claim_errors:
-        return [], "roadmap_issue_claim_check_failed: " + "; ".join(
-            claim_errors
-        )[:240], label_skipped
+    if not out and (claim_errors or applied_errors):
+        parts = []
+        if applied_errors:
+            parts.append("roadmap_issue_applied_check_failed: "
+                         + "; ".join(applied_errors)[:240])
+        if claim_errors:
+            parts.append("roadmap_issue_claim_check_failed: "
+                         + "; ".join(claim_errors)[:240])
+        return [], " | ".join(parts), label_skipped
     return out, "", label_skipped
 
 

--- a/threadkeeper/tools/dashboard.py
+++ b/threadkeeper/tools/dashboard.py
@@ -15,9 +15,10 @@ so it never drifts from the menu-bar status surface (it covers every loop,
 including the paid-spawn dialectic_validate and evolve_apply daemons and the
 thread_janitor). Outcomes come from the action events: skill/tier changes,
 accept/reject_candidate, AND knowledge-store mutations (lesson_append /
-lesson_remove, curator_report_applied, roadmap_issue_applied, evolve_applied,
-dialectic_claim / _supersede), plus a `curator_net_change` line so a loop
-silently shrinking the lessons store is visible at a glance.
+lesson_remove, curator_report_applied, roadmap_issue_applied /
+roadmap_issue_requeued, evolve_applied, dialectic_claim / _supersede), plus a
+`curator_net_change` line so a loop silently shrinking the lessons store is
+visible at a glance.
 """
 
 from __future__ import annotations
@@ -224,6 +225,7 @@ _LOOP_TASK_PREFIXES: dict[str, str] = {
 #   lesson_append / lesson_remove   — curator + shadow lesson writes/prunes
 #   curator_report_applied          — evolve_applier applied a curator report
 #   roadmap_issue_applied           — evolve_applier opened a roadmap-issue PR
+#   roadmap_issue_requeued          — closed-unmerged PR made an issue retryable
 #   roadmap_issue_skipped           — evolve_applier refused human-gated issue
 #   evolve_applied                  — evolve_applier marked a suggestion done
 #   dialectic_claim / _supersede    — user-model claim mutations
@@ -240,6 +242,7 @@ _OUTCOME_KINDS = (
     ("curator_restore", "curator_restore"),
     ("curator_report_applied", "curator_report_applied"),
     ("roadmap_issue_applied", "roadmap_issue_applied"),
+    ("roadmap_issue_requeued", "roadmap_issue_requeued"),
     ("roadmap_issue_skipped", "roadmap_issue_skipped"),
     ("evolve_applied", "evolve_applied"),
     ("dialectic_claim", "dialectic_claim"),
@@ -475,8 +478,16 @@ def mp_dashboard(window_days: int = 7) -> str:
     if rm_attempted:
         rm_applied = _scalar(
             conn,
-            "SELECT COUNT(DISTINCT target) FROM events "
-            "WHERE kind='roadmap_issue_applied'",
+            "SELECT COUNT(*) FROM ("
+            "  SELECT e.target FROM events e "
+            "  JOIN ("
+            "    SELECT target, MAX(id) AS id FROM events "
+            "    WHERE kind IN ('roadmap_issue_applied', "
+            "                   'roadmap_issue_requeued') "
+            "    GROUP BY target"
+            "  ) latest ON latest.id=e.id "
+            "  WHERE e.kind='roadmap_issue_applied'"
+            ")",
         )
         rm_dead = _scalar(
             conn,
@@ -486,9 +497,16 @@ def mp_dashboard(window_days: int = 7) -> str:
         rm_stuck = _scalar(
             conn,
             "SELECT COUNT(*) FROM (SELECT target FROM events "
-            "WHERE kind='roadmap_issue_attempt' AND target NOT IN "
-            "(SELECT target FROM events WHERE kind='roadmap_issue_applied') "
-            "AND target NOT IN (SELECT target FROM events "
+            "WHERE kind='roadmap_issue_attempt' AND target NOT IN ("
+            "  SELECT e.target FROM events e "
+            "  JOIN ("
+            "    SELECT target, MAX(id) AS id FROM events "
+            "    WHERE kind IN ('roadmap_issue_applied', "
+            "                   'roadmap_issue_requeued') "
+            "    GROUP BY target"
+            "  ) latest ON latest.id=e.id "
+            "  WHERE e.kind='roadmap_issue_applied'"
+            ") AND target NOT IN (SELECT target FROM events "
             "WHERE kind='roadmap_issue_dead_letter') GROUP BY target)",
         )
         out.append("")

--- a/threadkeeper/tools/evolve_applier.py
+++ b/threadkeeper/tools/evolve_applier.py
@@ -252,7 +252,7 @@ def evolve_apply_status() -> str:
             "SELECT kind, created_at, summary FROM events "
             "WHERE kind IN ('evolve_apply_pass', 'curator_report_applied', "
             "'evolve_applied', 'roadmap_issue_applied', "
-            "'roadmap_issue_dead_letter') "
+            "'roadmap_issue_requeued', 'roadmap_issue_dead_letter') "
             "ORDER BY created_at DESC, id DESC LIMIT 5"
         ).fetchall()
     except Exception:


### PR DESCRIPTION
## Summary
- Reconcile roadmap applied markers against recorded applier PR state before skipping open issues.
- Supersede closed-unmerged PR markers with roadmap_issue_requeued so the issue can retry through existing backoff/dead-letter gates.
- Keep open/merged PRs suppressed and surface requeue telemetry in status/dashboard docs.

## Tests
- env -u THREADKEEPER_NO_EMBEDDINGS .venv/bin/python -m pytest -q (exit 0; configured quiet mode hid pass count)
- visible-summary full-suite rerun: 1087 passed, 1 skipped, 95 warnings

Closes #51