### PR TITLE
fix: unify daemon single-flight locks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,15 @@ version bumps follow semver per the policy in
 
 ### Fixed
 
+- **Unified single-flight dispatch locks (#53).** Spawning daemons now share
+  `helpers.single_flight_lock()` for their non-blocking `fcntl.flock` pidfiles
+  instead of carrying local copies. Shadow review, evolve reviewer, and probe
+  passes now lock their check-running-then-spawn critical sections, so racing
+  foreground MCP servers return a `... (single-flight lock)` status instead of
+  spawning duplicate children. Existing candidate reviewer, curator, evolve
+  applier, auto-update, skill-update, and menu-bar autolaunch locks now route
+  through the same helper.
+
 - **Watchdog timeout continuation retry.** A spawned child killed by the
   wall-clock watchdog no longer leaves its assignment merely interrupted. After
   `return_code` 124 is stamped and the old row releases single-flight, the

--- a/README.md
+++ b/README.md
@@ -517,8 +517,12 @@ autonomous child lineage (no self-pollution) and strips adapter
 `[tool_result]` / `[tool_call]` noise (the "clean context" rule). If
 ≥500 chars of meaningful signal remain, spawns a slim observer child
 that decides on class-level learning. It is single-flight across the shared
-DB: if any shadow observer task is already running, the daemon does not spawn
-another one and does not advance the cursor. Shadow observer children are
+DB: a non-blocking `helpers.single_flight_lock("shadow-review")` dispatch
+lock guards the running-child check and spawn, so if another MCP server is
+already in that critical section the daemon reports `shadow_child_running ...
+(single-flight lock)` and does not advance the cursor. If any shadow observer
+task is already running, the daemon also skips spawning another child and keeps
+the cursor unchanged. Shadow observer children are
 marked as spawned/background processes, so they cannot start their own shadow
 daemon even if a CLI drops the no-embeddings env. Idempotent through
 `events.kind='shadow_review_pass'`.
@@ -566,9 +570,17 @@ foreground-authored) skills off-limits. Closes the gap between
 heuristic harvest and SKILL.md materialization — previously pending
 candidates accumulated indefinitely waiting for an agent to call
 `accept_candidate()` manually. The loop is machine-wide single-flight:
-while one reviewer child is running, other foreground servers/ticks report
-`candidate_review_running` instead of spawning another child for the same
-queue.
+while one reviewer child is running, or while another process holds the shared
+dispatch lock, other foreground servers/ticks report `candidate_review_running`
+instead of spawning another child for the same queue.
+
+All spawning learning-loop daemons that enforce single-flight use the same
+non-blocking `helpers.single_flight_lock()` helper around the
+check-running-then-spawn section. The local `fcntl.flock` closes the same-host
+TOCTOU window; the tasks-table running-child check remains as the second layer
+for stale-pid cleanup and status visibility. The helper is also used by the
+side-effecting auto-update, skill-update, and menu-bar autolaunch dispatch
+locks.
 
 #### 5. Autonomous Curator
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -286,21 +286,38 @@ All daemon threads are cheap (ticks 0.5–30 s), no-op when env-knobs disable th
   JSON-parse guard and retried. Manual trigger `config_reload()`; diagnostics
   `config_watch_status()`. Embedding-backend / process-identity flags are
   intentionally not hot-reloaded.
+
+Spawning daemons that enforce single-flight share one non-blocking
+`helpers.single_flight_lock(name)` primitive around their local
+check-running-then-spawn critical section. The `fcntl.flock` pidfile under
+the DB directory closes the same-host TOCTOU window; the tasks-table
+running-child check remains for stale-pid cleanup and status visibility.
+
 - **shadow_review** — once per `SHADOW_REVIEW_INTERVAL_S` (default 0 = off),
-  scans a dialog window and, if needed, spawns a slim-child evaluator.
+  scans a dialog window and, if needed, spawns a slim-child evaluator behind
+  `shadow-review.lock` plus the running shadow-child check. Lock-busy passes
+  return `shadow_child_running ... (single-flight lock)` without advancing the
+  dialog cursor, so the same useful window is retried after the active pass.
 - **candidate_reviewer** — once per `CANDIDATE_REVIEW_INTERVAL_S` (default
   0 = off) reviews pending `extract_candidates` through one slim child. The
-  queue is machine-wide single-flight: running-task detection plus
-  `candidate-reviewer.lock` prevents multiple foreground MCP servers from
-  spawning duplicate reviewers for the same pending candidates.
+  queue is machine-wide single-flight through the shared helper's
+  `candidate-reviewer.lock` plus running-task detection, preventing multiple
+  foreground MCP servers from spawning duplicate reviewers for the same
+  pending candidates.
+- **probe_daemon** — once per `PROBE_INTERVAL_S` (default 0 = off) grades
+  finished probe answers, then spawns at most one due objective probe runner
+  behind `probe-daemon.lock` plus the running probe-child check. A busy lock
+  reports `probe_child_running ... (single-flight lock)` and never blocks a
+  daemon tick.
 - **curator** — once per `CURATOR_INTERVAL_S` (default 0 = off) audits the
   existing lessons / skills / concepts inventory through one slim child. Before
   spawning, it hashes the stable inventory state and compares it to the last
   recorded complete/endorsed pass; unchanged snapshots record an
   `unchanged_inventory` no-op event instead of re-deriving the same report.
-  Wake-ups also coalesce behind a non-blocking `curator.lock` plus the running
-  curator-task check, so multiple foreground servers do not re-read and spawn
-  against the same snapshot. `curator_review_status()` exposes the last
+  Wake-ups also coalesce behind the shared helper's non-blocking
+  `curator.lock` plus the running curator-task check, so multiple foreground
+  servers do not re-read and spawn against the same snapshot.
+  `curator_review_status()` exposes the last
   endorsed `inventory_sha256` and the current inventory hash.
 - **evolve_reviewer** (`evolve_daemon.start_evolve_daemon`) — once per
   `EVOLVE_REVIEW_INTERVAL_S` (default 0 = off) it reviews thread-keeper itself
@@ -322,8 +339,9 @@ All daemon threads are cheap (ticks 0.5–30 s), no-op when env-knobs disable th
   not a newest-first 50-item `gh issue list` window, so older open issues remain
   visible as the backlog grows.
   Both phase prompts open with the same `"You are an EVOLVE REVIEWER"` line, so
-  the existing single-flight (`_running_evolve_children`) and shadow/extract
-  exclusion cover both. A full research → audit cycle spans two due passes.
+  the running-child check and shadow/extract exclusion cover both; dispatch is
+  serialized by `evolve-reviewer.lock`. A full research → audit cycle spans two
+  due passes.
 - **evolve_applier** (`evolve_applier.start_evolve_applier_daemon`) — once per
   `EVOLVE_APPLY_INTERVAL_S` (default 0 = off) first fetches open GitHub PRs via
   `gh pr list --json mergeStateStatus,mergeable,...` and repairs the oldest

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -106,6 +106,13 @@ remains a live question.
   `THREADKEEPER_REDACT_DIALOG_SECRETS` knob can be disabled only for rare local
   debugging where raw transcript fidelity intentionally wins over durable
   secret protection.
+- Unified fcntl single-flight for spawning daemons (#53): the local
+  check-running-then-spawn mutex now lives in `helpers.single_flight_lock()`.
+  Shadow review, evolve reviewer, probe daemon, candidate reviewer, curator,
+  evolve applier, auto-update, skill-update, and menu-bar autolaunch all use the
+  same non-blocking lock helper where they need a process-wide dispatch guard;
+  running-child table checks remain as the second layer for stale-pid cleanup
+  and status visibility.
 
 ---
 
@@ -460,11 +467,12 @@ the three bare-`time.sleep` loops onto it), pruning `_last_notify_at` of
 past-cooldown / dead-pid entries each `_maybe_notify`, and collapsing
 consecutive no-op janitor passes into a single recorded row. Scope: S.
 
-**Daemon robustness under load.** Curator lacks the machine-wide single-flight
-every other spawning daemon has, and `candidate_reviewer`/`curator` dump an
-unbounded queue/inventory into the child prompt argv (the `E2BIG` class already
-fixed for `dialectic_validator`). Add curator single-flight + bound the
-prompts. (#24) Scope: S.
+**Daemon robustness under load.** ✅ PARTIAL (#24/#53). Curator single-flight
+has landed, and #53 unified the fcntl single-flight helper across the spawning
+daemon family. The remaining #24 work is bounding the
+`candidate_reviewer`/`curator` queue/inventory prompt payloads so a full dump
+cannot hit `E2BIG` (the class already fixed for `dialectic_validator`).
+Scope: S.
 
 **Spawn cost accounting.** ✅ DONE (#25, extends #6). The spawn budget now
 tracks more than child RSS: `_spawn_wrap.py` parses JSON or human-readable CLI

--- a/tests/test_evolve_daemon.py
+++ b/tests/test_evolve_daemon.py
@@ -8,6 +8,7 @@ monkeypatched; no real child is launched.
 from __future__ import annotations
 
 import sys
+import threading
 import time
 from pathlib import Path
 
@@ -444,6 +445,48 @@ def test_run_evolve_pass_single_flight(tmp_path, monkeypatch):
     import threadkeeper.tools.spawn as spawn_mod
     monkeypatch.setattr(spawn_mod, "spawn", _boom)
     assert "reviewer_running" in pkg["ed"].run_evolve_pass(force=True)
+
+
+def test_run_evolve_pass_single_flight_lock_race(tmp_path, monkeypatch):
+    pkg = _bootstrap(tmp_path, monkeypatch, review_min="1")
+    import threadkeeper.tools.spawn as spawn_mod
+
+    entered_spawn = threading.Event()
+    release_spawn = threading.Event()
+    results: list[str] = []
+    errors: list[BaseException] = []
+    calls: list[dict] = []
+
+    def fake_spawn(**kwargs):
+        calls.append(kwargs)
+        if len(calls) == 1:
+            entered_spawn.set()
+            assert release_spawn.wait(timeout=5)
+        return "ok task=tk_ev pid=1"
+
+    def run_pass():
+        try:
+            out = pkg["ed"].run_evolve_pass(force=True)
+            results.append(out)
+        except BaseException as e:  # pragma: no cover - surfaced below
+            errors.append(e)
+            release_spawn.set()
+
+    monkeypatch.setattr(spawn_mod, "spawn", fake_spawn)
+
+    t = threading.Thread(target=run_pass)
+    t.start()
+    assert entered_spawn.wait(timeout=5)
+    results.append(pkg["ed"].run_evolve_pass(force=True))
+    release_spawn.set()
+    t.join(timeout=5)
+    assert not t.is_alive()
+
+    assert not errors
+    assert len(calls) == 1
+    assert len(results) == 2
+    assert sum(r.startswith("spawned research") for r in results) == 1
+    assert results.count("reviewer_running n=1 (single-flight lock)") == 1
 
 
 # ── brief surfaces promoted ★ first, drops dismissed ───────────────────

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -69,6 +69,16 @@ def test_daemon_sleep_non_numeric_idles(monkeypatch):
     assert calls and calls[0] > 0
 
 
+def test_single_flight_lock_is_non_blocking(tmp_path):
+    with helpers.single_flight_lock("daemon-test", lock_dir=tmp_path) as first:
+        assert first is True
+        with helpers.single_flight_lock("daemon-test", lock_dir=tmp_path) as second:
+            assert second is False
+
+    with helpers.single_flight_lock("daemon-test", lock_dir=tmp_path) as after:
+        assert after is True
+
+
 def test_alive_returns_false_for_zombie_state(monkeypatch):
     """A pid that exists but reports ps state Z is not a live parent."""
     monkeypatch.setattr(helpers.os, "waitpid", lambda pid, flags: (0, 0))

--- a/tests/test_probe_daemon.py
+++ b/tests/test_probe_daemon.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import re
 import sys
+import threading
 import time
 from pathlib import Path
 
@@ -215,3 +216,49 @@ def test_run_probe_pass_single_flight(tmp_path, monkeypatch):
 
     out = pkg["pd"].run_probe_pass(force=True)
     assert "probe_child_running" in out
+
+
+def test_run_probe_pass_single_flight_lock_race(tmp_path, monkeypatch):
+    pkg = _bootstrap(tmp_path, monkeypatch)
+    conn = pkg["db"].get_db()
+    _add_probe(conn, "P022", "date_arithmetic", grader="regex", pattern="42")
+
+    entered_spawn = threading.Event()
+    release_spawn = threading.Event()
+    results: list[str] = []
+    errors: list[BaseException] = []
+    calls: list[str] = []
+
+    def fake_spawn(probe):
+        calls.append(probe["id"])
+        if len(calls) == 1:
+            entered_spawn.set()
+            assert release_spawn.wait(timeout=5)
+        return "ok task=tk_probe pid=4242"
+
+    def run_pass():
+        try:
+            out = pkg["pd"].run_probe_pass(force=True)
+            results.append(out)
+        except BaseException as e:  # pragma: no cover - surfaced below
+            errors.append(e)
+            release_spawn.set()
+
+    monkeypatch.setattr(pkg["pd"], "_spawn_probe_child", fake_spawn)
+
+    t = threading.Thread(target=run_pass)
+    t.start()
+    assert entered_spawn.wait(timeout=5)
+    results.append(pkg["pd"].run_probe_pass(force=True))
+    release_spawn.set()
+    t.join(timeout=5)
+    assert not t.is_alive()
+
+    assert not errors
+    assert calls == ["P022"]
+    assert len(results) == 2
+    assert sum("spawned" in r for r in results) == 1
+    assert (
+        results.count("graded=0 probe_child_running n=1 (single-flight lock)")
+        == 1
+    )

--- a/tests/test_shadow_review.py
+++ b/tests/test_shadow_review.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import time
 import sys
 import os
+import threading
 from pathlib import Path
 
 import pytest
@@ -451,6 +452,53 @@ def test_run_shadow_pass_single_flight_when_child_running(tmp_path, monkeypatch)
     assert out == "shadow_child_running n=1"
     # Cursor does not advance; retry the same window when the child exits.
     assert pkg["shadow_review"]._last_shadow_rowid(conn) == 0
+
+
+def test_run_shadow_pass_single_flight_lock_race(tmp_path, monkeypatch):
+    pkg = _bootstrap(tmp_path, monkeypatch, min_chars="100")
+    conn = pkg["db"].get_db()
+    long_msg = "Pattern: in this type of task always X. " * 10
+    _seed_dialog(conn, "user", long_msg, int(time.time()) - 5)
+    conn.commit()
+
+    import threadkeeper.tools.spawn as spawn_mod
+
+    entered_spawn = threading.Event()
+    release_spawn = threading.Event()
+    results: list[str] = []
+    errors: list[BaseException] = []
+    calls: list[dict] = []
+
+    def fake_spawn(**kwargs):
+        calls.append(kwargs)
+        if len(calls) == 1:
+            entered_spawn.set()
+            assert release_spawn.wait(timeout=5)
+        return "spawn task_id=fake-shadow-task pid=0"
+
+    def run_pass():
+        try:
+            out = pkg["shadow_review"].run_shadow_pass(force=True)
+            results.append(out)
+        except BaseException as e:  # pragma: no cover - surfaced below
+            errors.append(e)
+            release_spawn.set()
+
+    monkeypatch.setattr(spawn_mod, "spawn", fake_spawn)
+
+    t = threading.Thread(target=run_pass)
+    t.start()
+    assert entered_spawn.wait(timeout=5)
+    results.append(pkg["shadow_review"].run_shadow_pass(force=True))
+    release_spawn.set()
+    t.join(timeout=5)
+    assert not t.is_alive()
+
+    assert not errors
+    assert len(calls) == 1
+    assert len(results) == 2
+    assert any("fake-shadow-task" in r for r in results)
+    assert results.count("shadow_child_running n=1 (single-flight lock)") == 1
 
 
 def test_run_shadow_pass_idempotent_after_cursor_advance(tmp_path, monkeypatch):

--- a/threadkeeper/auto_update.py
+++ b/threadkeeper/auto_update.py
@@ -12,7 +12,6 @@ restart it against the newly installed code.
 from __future__ import annotations
 
 import base64
-from contextlib import contextmanager
 from dataclasses import dataclass
 import importlib.metadata
 import importlib.util
@@ -24,7 +23,7 @@ import subprocess
 import sys
 import threading
 import time
-from typing import Any, Iterator
+from typing import Any
 from urllib.error import HTTPError, URLError
 from urllib.parse import quote
 from urllib.request import Request, urlopen
@@ -39,9 +38,9 @@ from .config import (
     AUTO_UPDATE_TIMEOUT_S,
     AUTO_UPDATE_VERIFY_PROVENANCE,
     BACKGROUND_DAEMONS_ALLOWED,
-    DB_PATH,
 )
 from .db import get_db
+from .helpers import single_flight_lock
 from . import identity
 
 logger = logging.getLogger(__name__)
@@ -121,30 +120,8 @@ def _due(now: int | None = None) -> tuple[bool, int]:
     return last == 0 or age >= AUTO_UPDATE_INTERVAL_S, max(0, age)
 
 
-@contextmanager
-def _update_lock() -> Iterator[bool]:
-    lock_path = DB_PATH.parent / "auto-update.lock"
-    lock_path.parent.mkdir(parents=True, exist_ok=True)
-    with lock_path.open("w") as lock:
-        try:
-            import fcntl
-
-            fcntl.flock(lock.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
-        except ImportError:
-            yield True
-            return
-        except BlockingIOError:
-            yield False
-            return
-        try:
-            yield True
-        finally:
-            try:
-                import fcntl
-
-                fcntl.flock(lock.fileno(), fcntl.LOCK_UN)
-            except Exception:
-                pass
+def _update_lock():
+    return single_flight_lock("auto-update")
 
 
 def _package_root() -> Path:

--- a/threadkeeper/candidate_reviewer.py
+++ b/threadkeeper/candidate_reviewer.py
@@ -35,7 +35,6 @@ Hardstops:
 
 from __future__ import annotations
 
-from contextlib import contextmanager
 import logging
 import sqlite3
 import threading
@@ -44,10 +43,9 @@ import time
 from .config import (
     CANDIDATE_REVIEW_INTERVAL_S,
     CANDIDATE_REVIEW_MIN,
-    DB_PATH,
 )
 from .db import get_db
-from .helpers import daemon_sleep
+from .helpers import daemon_sleep, single_flight_lock
 from . import identity
 
 logger = logging.getLogger(__name__)
@@ -283,7 +281,6 @@ def _running_reviewer_children(conn: sqlite3.Connection) -> list[str]:
     return running
 
 
-@contextmanager
 def _review_spawn_lock():
     """Cross-process guard for check-running-then-spawn.
 
@@ -291,23 +288,7 @@ def _review_spawn_lock():
     processes. A short file lock prevents two daemon ticks from both observing
     no reviewer and spawning duplicate children for the same pending queue.
     """
-    try:
-        import fcntl
-    except ImportError:  # pragma: no cover - thread-keeper runs on Unix CLIs.
-        yield True
-        return
-    lock_path = DB_PATH.parent / "candidate-reviewer.lock"
-    lock_path.parent.mkdir(parents=True, exist_ok=True)
-    with lock_path.open("w") as lock:
-        try:
-            fcntl.flock(lock.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
-        except BlockingIOError:
-            yield False
-            return
-        try:
-            yield True
-        finally:
-            fcntl.flock(lock.fileno(), fcntl.LOCK_UN)
+    return single_flight_lock("candidate-reviewer")
 
 
 # ──────────────────────────────────────────────────────────────────────

--- a/threadkeeper/curator.py
+++ b/threadkeeper/curator.py
@@ -55,7 +55,6 @@ import re
 import sqlite3
 import threading
 import time
-from contextlib import contextmanager
 
 from .config import (
     CURATOR_INTERVAL_S,
@@ -63,10 +62,9 @@ from .config import (
     CURATOR_REPORTS_DIR,
     CURATOR_DESTRUCTIVE,
     CURATOR_SNAPSHOT_RETENTION,
-    DB_PATH,
 )
 from .db import get_db
-from .helpers import daemon_sleep
+from .helpers import daemon_sleep, single_flight_lock
 from . import identity, lessons
 from .curator_snapshots import (
     PASS_ID_ENV,
@@ -609,7 +607,6 @@ def _running_curator_children(conn: sqlite3.Connection) -> list[str]:
     return running
 
 
-@contextmanager
 def _curator_spawn_lock():
     """Cross-process guard for check-running-then-spawn.
 
@@ -620,23 +617,7 @@ def _curator_spawn_lock():
     Manual curator_run(force=True) bypasses the interval but still respects this
     lock.
     """
-    try:
-        import fcntl
-    except ImportError:  # pragma: no cover - thread-keeper runs on Unix CLIs.
-        yield True
-        return
-    lock_path = DB_PATH.parent / "curator.lock"
-    lock_path.parent.mkdir(parents=True, exist_ok=True)
-    with lock_path.open("w") as lock:
-        try:
-            fcntl.flock(lock.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
-        except BlockingIOError:
-            yield False
-            return
-        try:
-            yield True
-        finally:
-            fcntl.flock(lock.fileno(), fcntl.LOCK_UN)
+    return single_flight_lock("curator")
 
 
 # ──────────────────────────────────────────────────────────────────────

--- a/threadkeeper/evolve_applier.py
+++ b/threadkeeper/evolve_applier.py
@@ -70,7 +70,7 @@ from .config import (
 from .db import get_db
 from .github_budget import run_gh, split_gh_api_output, strip_gh_api_headers
 from .github_safety import GithubBodySafetyError, sanitize_public_github_body
-from .helpers import daemon_sleep
+from .helpers import daemon_sleep, single_flight_lock
 from . import identity
 
 logger = logging.getLogger(__name__)
@@ -1971,23 +1971,8 @@ def _apply_spawn_lock():
     can observe no running task before either spawn() inserts its row. This
     short file lock closes that race without holding a lock for the child run.
     """
-    try:
-        import fcntl
-    except ImportError:  # pragma: no cover - thread-keeper runs on Unix CLIs.
-        yield True
-        return
-    lock_path = DB_PATH.parent / "evolve-applier.lock"
-    lock_path.parent.mkdir(parents=True, exist_ok=True)
-    with lock_path.open("w") as lock:
-        try:
-            fcntl.flock(lock.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
-        except BlockingIOError:
-            yield False
-            return
-        try:
-            yield True
-        finally:
-            fcntl.flock(lock.fileno(), fcntl.LOCK_UN)
+    with single_flight_lock("evolve-applier") as locked:
+        yield locked
 
 
 def mark_applied(conn: sqlite3.Connection, evolve_id: int,

--- a/threadkeeper/evolve_daemon.py
+++ b/threadkeeper/evolve_daemon.py
@@ -41,7 +41,7 @@ from .evolve_applier import (
     _ensure_repo_ready,
     _git_worktree_precondition,
 )
-from .helpers import daemon_sleep
+from .helpers import daemon_sleep, single_flight_lock
 from . import identity
 
 logger = logging.getLogger(__name__)
@@ -447,39 +447,45 @@ def run_evolve_pass(force: bool = False) -> str:
     if not force and not _pass_due(conn, now_t):
         return "not_due"
 
-    running = _running_evolve_children(conn)
-    if running:
-        out = f"reviewer_running n={len(running)}"
+    with single_flight_lock("evolve-reviewer") as locked:
+        if not locked:
+            out = "reviewer_running n=1 (single-flight lock)"
+            _record_evolve_pass(conn, now_t, out)
+            return out
+
+        running = _running_evolve_children(conn)
+        if running:
+            out = f"reviewer_running n={len(running)}"
+            _record_evolve_pass(conn, now_t, out)
+            return out
+
+        repo_root, repo_err = _ensure_repo_ready()
+        if repo_err:
+            _record_evolve_pass(conn, now_t, repo_err)
+            return repo_err
+
+        # Alternate: audit follows a research pass; otherwise (re)research.
+        # The audit runs even when the digest is empty — auditing the repo is
+        # the valuable half and must not depend on web research succeeding.
+        do_audit = _last_spawn_phase(conn) == "research"
+        try:
+            if do_audit:
+                guard = _git_worktree_precondition(
+                    conn, repo_root, "evolve_reviewer_audit"
+                )
+                if guard:
+                    _record_evolve_pass(conn, now_t, guard)
+                    return guard
+                _, research_text = _latest_research(now_t)
+                out = _spawn_audit(repo_root, pending, research_text)
+            else:
+                out = _spawn_research(repo_root, now_t)
+        except Exception as e:  # noqa: BLE001 — never crash the daemon
+            out = f"spawn_error: {e}"
+            _record_evolve_pass(conn, now_t, out)
+            return out
         _record_evolve_pass(conn, now_t, out)
         return out
-
-    repo_root, repo_err = _ensure_repo_ready()
-    if repo_err:
-        _record_evolve_pass(conn, now_t, repo_err)
-        return repo_err
-
-    # Alternate: audit follows a research pass; otherwise (re)research. The audit
-    # runs even when the digest is empty — auditing the repo is the valuable half
-    # and must not depend on web research succeeding.
-    do_audit = _last_spawn_phase(conn) == "research"
-    try:
-        if do_audit:
-            guard = _git_worktree_precondition(
-                conn, repo_root, "evolve_reviewer_audit"
-            )
-            if guard:
-                _record_evolve_pass(conn, now_t, guard)
-                return guard
-            _, research_text = _latest_research(now_t)
-            out = _spawn_audit(repo_root, pending, research_text)
-        else:
-            out = _spawn_research(repo_root, now_t)
-    except Exception as e:  # noqa: BLE001 — never crash the daemon
-        out = f"spawn_error: {e}"
-        _record_evolve_pass(conn, now_t, out)
-        return out
-    _record_evolve_pass(conn, now_t, out)
-    return out
 
 
 def _serve_loop() -> None:

--- a/threadkeeper/helpers.py
+++ b/threadkeeper/helpers.py
@@ -2,13 +2,15 @@
 short-quoting, ID generation, process-aliveness check."""
 from __future__ import annotations
 
+from contextlib import contextmanager
 import os
+from pathlib import Path
 import random
 import secrets
 import sqlite3
 import subprocess
 import time
-from typing import Optional
+from typing import Iterator, Optional
 
 # ±15% wake-up jitter. Every always-on daemon (memory_guard, skill_watcher)
 # starts during `_ensure_session` bootstrap on every MCP instance, so with
@@ -45,6 +47,45 @@ def daemon_sleep(interval_s, idle_s: float = 30.0) -> None:
     except (TypeError, ValueError):
         interval = 0.0
     time.sleep(_jittered(interval if interval > 0 else idle_s))
+
+
+@contextmanager
+def single_flight_lock(
+    name: str,
+    lock_dir: os.PathLike[str] | str | None = None,
+) -> Iterator[bool]:
+    """Non-blocking process-wide file lock for daemon dispatch sections.
+
+    The lock is intentionally short-lived: callers hold it around the local
+    check-running-then-spawn critical section, not for the child lifetime.
+    """
+    try:
+        import fcntl
+    except ImportError:  # pragma: no cover - thread-keeper runs on Unix CLIs.
+        yield True
+        return
+
+    if not name or Path(name).name != name:
+        raise ValueError("single_flight_lock name must be a filename stem")
+    if lock_dir is None:
+        from .config import DB_PATH
+
+        lock_dir = DB_PATH.parent
+    lock_path = Path(lock_dir) / f"{name}.lock"
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    with lock_path.open("w") as lock:
+        try:
+            fcntl.flock(lock.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError:
+            yield False
+            return
+        try:
+            yield True
+        finally:
+            try:
+                fcntl.flock(lock.fileno(), fcntl.LOCK_UN)
+            except OSError:
+                pass
 
 
 def fmt_age(seconds: int) -> str:

--- a/threadkeeper/menubar_app.py
+++ b/threadkeeper/menubar_app.py
@@ -17,11 +17,13 @@ from datetime import datetime
 from pathlib import Path
 
 from .config import (
+    DB_PATH,
     MENUBAR_AUTO_LAUNCH,
     SPAWNED_CHILD,
     TASK_LOG_DIR,
     WRITE_ORIGIN,
 )
+from .helpers import single_flight_lock
 
 
 APP_NAME = "ThreadKeeperAgentStatus"
@@ -331,14 +333,11 @@ def ensure_menubar_app() -> None:
         return
 
     TASK_LOG_DIR.mkdir(parents=True, exist_ok=True)
-    lock_path = TASK_LOG_DIR / "menubar-autolaunch.lock"
     try:
-        import fcntl
-
-        with lock_path.open("w") as lock:
-            try:
-                fcntl.flock(lock.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
-            except OSError:
+        with single_flight_lock(
+            "menubar-autolaunch", lock_dir=DB_PATH.parent
+        ) as locked:
+            if not locked:
                 return
 
             app = _installed_app()

--- a/threadkeeper/probe_daemon.py
+++ b/threadkeeper/probe_daemon.py
@@ -36,7 +36,7 @@ from .config import PROBE_INTERVAL_S, PROBE_COOLDOWN_S, TASK_LOG_DIR
 from .db import get_db
 from . import identity
 from .identity import _detect_self_cid, _emit
-from .helpers import alive
+from .helpers import alive, single_flight_lock
 
 logger = logging.getLogger(__name__)
 
@@ -225,27 +225,36 @@ def run_probe_pass(force: bool = False) -> str:
     now_t = int(time.time())
     graded = _grade_pending(conn)
 
-    running = _running_probe_children(conn)
-    if running:
-        out = f"graded={graded} probe_child_running n={len(running)}"
-        _record_probe_pass(conn, now_t, out)
-        return out
+    with single_flight_lock("probe-daemon") as locked:
+        if not locked:
+            out = f"graded={graded} probe_child_running n=1 (single-flight lock)"
+            _record_probe_pass(conn, now_t, out)
+            return out
 
-    due = _due_probes(conn, now_t)
-    if not due:
-        out = f"graded={graded} no_due"
-        _record_probe_pass(conn, now_t, out)
-        return out
+        running = _running_probe_children(conn)
+        if running:
+            out = f"graded={graded} probe_child_running n={len(running)}"
+            _record_probe_pass(conn, now_t, out)
+            return out
 
-    try:
-        result = _spawn_probe_child(due[0])
-    except Exception as e:  # noqa: BLE001 — never crash the daemon
-        out = f"graded={graded} spawn_error: {e}"
+        due = _due_probes(conn, now_t)
+        if not due:
+            out = f"graded={graded} no_due"
+            _record_probe_pass(conn, now_t, out)
+            return out
+
+        try:
+            result = _spawn_probe_child(due[0])
+        except Exception as e:  # noqa: BLE001 — never crash the daemon
+            out = f"graded={graded} spawn_error: {e}"
+            _record_probe_pass(conn, now_t, out)
+            return out
+        out = (
+            f"graded={graded} spawned cat={due[0]['category']} "
+            f"{str(result)[:120]}"
+        )
         _record_probe_pass(conn, now_t, out)
         return out
-    out = f"graded={graded} spawned cat={due[0]['category']} {str(result)[:120]}"
-    _record_probe_pass(conn, now_t, out)
-    return out
 
 
 def _serve_loop() -> None:

--- a/threadkeeper/shadow_review.py
+++ b/threadkeeper/shadow_review.py
@@ -42,6 +42,7 @@ from .helpers import (
     daemon_sleep,
     dialog_rowid_at_or_before,
     resolve_ingest_watermark,
+    single_flight_lock,
 )
 from .harvest import (
     INTERNAL_PROMPT_PREFIXES as _INTERNAL_PROMPT_PREFIXES,
@@ -535,52 +536,62 @@ def run_shadow_pass(force: bool = False) -> str:
         _record_shadow_pass(conn, high_water, "too_short")
         return "too_short"
 
-    running = _running_shadow_children(conn)
-    if running:
-        outcome = f"shadow_child_running n={len(running)}"
-        # Do not advance high-water. Re-evaluate this window when the current
-        # evaluator exits instead of dropping potentially useful dialog.
-        _record_shadow_pass(conn, floor, outcome)
-        return outcome
+    with single_flight_lock("shadow-review") as locked:
+        if not locked:
+            outcome = "shadow_child_running n=1 (single-flight lock)"
+            # Do not advance high-water. Re-evaluate this window when the
+            # current evaluator exits instead of dropping useful dialog.
+            _record_shadow_pass(conn, floor, outcome)
+            return outcome
 
-    # Fence the observed window as data (issue #76). The dump mixes turns
-    # from every real session, including assistant turns that echo content
-    # read from untrusted web/files; the delimiters + DATA_FENCE in the
-    # header keep a crafted "always do X / ignore prior skills" turn from
-    # being lifted into an auto-loaded skill.
-    full_prompt = SHADOW_REVIEW_PROMPT + fence_observed(dump, "recent dialog")
+        running = _running_shadow_children(conn)
+        if running:
+            outcome = f"shadow_child_running n={len(running)}"
+            # Do not advance high-water. Re-evaluate this window when the
+            # current evaluator exits instead of dropping useful dialog.
+            _record_shadow_pass(conn, floor, outcome)
+            return outcome
 
-    # Late import — spawn module imports identity / config; importing it
-    # at module load time would create cycles.
-    from .tools.spawn import spawn  # type: ignore
-    try:
-        result = spawn(
-            prompt=full_prompt,
-            visible=False,
-            capture_output=True,
-            permission_mode="auto",
-            role="shadow_observer",
-            write_origin="shadow_review",
-            slim=True,
-            # De-privileged (issue #76): only the path-scoped skill/lesson
-            # tools — no bare Read/Write. Reference files go through
-            # skill_manage(action='write_file'); shrinks the blast radius
-            # if the data fence is ever bypassed.
-            extra_allowed_tools=(
-                "mcp__thread-keeper__lesson_append,"
-                "mcp__thread-keeper__lesson_list,"
-                "mcp__thread-keeper__lesson_get,"
-                "mcp__thread-keeper__skill_manage,"
-                "mcp__thread-keeper__skill_list,"
-                "mcp__thread-keeper__mark_skill_materialized"
-            ),
+        # Fence the observed window as data (issue #76). The dump mixes turns
+        # from every real session, including assistant turns that echo content
+        # read from untrusted web/files; the delimiters + DATA_FENCE in the
+        # header keep a crafted "always do X / ignore prior skills" turn from
+        # being lifted into an auto-loaded skill.
+        full_prompt = SHADOW_REVIEW_PROMPT + fence_observed(
+            dump, "recent dialog"
         )
-    except Exception as e:
-        _record_shadow_pass(conn, high_water, f"spawn_error: {e}")
-        return f"spawn_error: {e}"
 
-    _record_shadow_pass(conn, high_water, str(result)[:200])
-    return str(result)
+        # Late import — spawn module imports identity / config; importing it
+        # at module load time would create cycles.
+        from .tools.spawn import spawn  # type: ignore
+        try:
+            result = spawn(
+                prompt=full_prompt,
+                visible=False,
+                capture_output=True,
+                permission_mode="auto",
+                role="shadow_observer",
+                write_origin="shadow_review",
+                slim=True,
+                # De-privileged (issue #76): only the path-scoped skill/lesson
+                # tools — no bare Read/Write. Reference files go through
+                # skill_manage(action='write_file'); shrinks the blast radius
+                # if the data fence is ever bypassed.
+                extra_allowed_tools=(
+                    "mcp__thread-keeper__lesson_append,"
+                    "mcp__thread-keeper__lesson_list,"
+                    "mcp__thread-keeper__lesson_get,"
+                    "mcp__thread-keeper__skill_manage,"
+                    "mcp__thread-keeper__skill_list,"
+                    "mcp__thread-keeper__mark_skill_materialized"
+                ),
+            )
+        except Exception as e:
+            _record_shadow_pass(conn, high_water, f"spawn_error: {e}")
+            return f"spawn_error: {e}"
+
+        _record_shadow_pass(conn, high_water, str(result)[:200])
+        return str(result)
 
 
 def _serve_loop() -> None:

--- a/threadkeeper/skill_updater.py
+++ b/threadkeeper/skill_updater.py
@@ -12,7 +12,6 @@ overwritten.
 """
 from __future__ import annotations
 
-from contextlib import contextmanager
 from dataclasses import dataclass
 import hashlib
 import json
@@ -23,7 +22,6 @@ import shutil
 import tempfile
 import threading
 import time
-from typing import Iterator
 from urllib import request
 import zipfile
 
@@ -39,7 +37,7 @@ from .config import (
     SKILL_UPDATE_TIMEOUT_S,
 )
 from .db import get_db
-from .helpers import daemon_sleep
+from .helpers import daemon_sleep, single_flight_lock
 
 logger = logging.getLogger(__name__)
 
@@ -117,30 +115,8 @@ def _due(now: int | None = None) -> tuple[bool, int]:
     return last == 0 or age >= SKILL_UPDATE_INTERVAL_S, max(0, age)
 
 
-@contextmanager
-def _update_lock() -> Iterator[bool]:
-    lock_path = DB_PATH.parent / "skill-update.lock"
-    lock_path.parent.mkdir(parents=True, exist_ok=True)
-    with lock_path.open("w") as lock:
-        try:
-            import fcntl
-
-            fcntl.flock(lock.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
-        except ImportError:
-            yield True
-            return
-        except BlockingIOError:
-            yield False
-            return
-        try:
-            yield True
-        finally:
-            try:
-                import fcntl
-
-                fcntl.flock(lock.fileno(), fcntl.LOCK_UN)
-            except Exception:
-                pass
+def _update_lock():
+    return single_flight_lock("skill-update")
 
 
 def _short(text: str, limit: int = 120) -> str:


### PR DESCRIPTION
## Summary
- Add a shared non-blocking helpers.single_flight_lock() for fcntl dispatch locks.
- Wrap shadow_review, evolve_reviewer, and probe daemon check-running-then-spawn sections so racing passes return single-flight lock statuses instead of spawning duplicates.
- Migrate existing candidate reviewer, curator, evolve applier, auto-update, skill-update, and menu-bar autolaunch locks to the helper and update docs.

## Tests
- env -u THREADKEEPER_NO_EMBEDDINGS .venv/bin/python -m pytest -q
- env -u THREADKEEPER_NO_EMBEDDINGS .venv/bin/python -m pytest -o addopts='--strict-markers' -q -> 1087 passed, 1 skipped, 95 warnings

Closes #53