### PR TITLE
fix: dedup reviewer roadmap doc prs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,14 @@ version bumps follow semver per the policy in
 
 ### Fixed
 
+- **Evolve reviewer roadmap-doc PR dedup (#54).** Privileged reviewer audit
+  prompts now receive a parent-side `gh pr list --json ... files` preflight for
+  open automation-owned PRs touching `docs/ROADMAP.md`. The reviewer must append
+  to that PR or skip instead of opening a second roadmap-doc PR, and new
+  roadmap-doc PRs use/reuse a deterministic daily
+  `docs/roadmap-audit-YYYY-MM-DD` branch with a PR-body marker for future
+  passes.
+
 - **Watchdog timeout continuation retry.** A spawned child killed by the
   wall-clock watchdog no longer leaves its assignment merely interrupted. After
   `return_code` 124 is stamped and the old row releases single-flight, the

--- a/README.md
+++ b/README.md
@@ -684,6 +684,13 @@ shell/`bypassPermissions` to the same child:
 
 A full research → audit cycle therefore spans two due passes.
 
+Before an audit child can open a roadmap-doc PR, the parent preflights open PRs
+with `gh pr list --json ... files` and reports any automation-owned PR already
+touching `docs/ROADMAP.md`. The child must append to that PR or skip when no
+change is needed; otherwise it uses the deterministic daily
+`docs/roadmap-audit-YYYY-MM-DD` branch and reuses an existing local/remote branch
+with that name instead of minting overlapping roadmap PRs.
+
 The Evolve applier is the downstream implementer. `evolve_apply_roadmap_issue()`
 picks one open GitHub issue at a time (`roadmap` label first, then FIFO), but
 the automatic pass first scans already-open same-repo applier PRs for GitHub
@@ -781,7 +788,9 @@ Pin the agent/model with `THREADKEEPER_SPAWN__LOOP__EVOLVE_APPLIER` /
 `THREADKEEPER_SPAWN__MODEL__EVOLVE_APPLIER`. Single-flight (one applier child at
 a time, enforced by a short dispatch file lock plus running-task detection) and
 the shared git-writer guard keep code edits and roadmap PR writes from
-colliding.
+colliding. Reviewer roadmap-doc PRs also use a parent open-PR preflight and a
+daily deterministic `docs/roadmap-audit-YYYY-MM-DD` branch so repeated audit
+passes update or skip the existing roadmap PR rather than opening a second one.
 Automatic apply passes respect the configured interval so multiple foreground
 MCP server startups do not repeatedly spawn workers for the same open issue.
 Manual tools such as `evolve_apply_conflicted_pr()` and

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -320,7 +320,12 @@ All daemon threads are cheap (ticks 0.5–30 s), no-op when env-knobs disable th
   `<<<EVOLVE_RESEARCH_DATA … EVOLVE_RESEARCH_DATA` fence it must treat as data.
   Its duplicate-issue check uses a paginated oldest-first REST issue listing,
   not a newest-first 50-item `gh issue list` window, so older open issues remain
-  visible as the backlog grows.
+  visible as the backlog grows. Before that child can create a roadmap-doc PR,
+  the parent also checks open PRs for automation-owned changes touching
+  `docs/ROADMAP.md` and embeds the result in the audit prompt. Existing
+  roadmap-doc PRs are appended to or skipped; new ones use/reuse the
+  deterministic daily `docs/roadmap-audit-YYYY-MM-DD` branch and carry a
+  PR-body marker for future passes.
   Both phase prompts open with the same `"You are an EVOLVE REVIEWER"` line, so
   the existing single-flight (`_running_evolve_children`) and shadow/extract
   exclusion cover both. A full research → audit cycle spans two due passes.
@@ -455,7 +460,9 @@ All daemon threads are cheap (ticks 0.5–30 s), no-op when env-knobs disable th
   be running. The guard intentionally ignores untracked scratch files, matching
   `auto_update`'s dirty-check semantics. Child prompts then branch from a fetched
   base ref (`origin/main` by default, or `origin/<EVOLVE_REPO_BRANCH>`) instead
-  of arbitrary current `HEAD`.
+  of arbitrary current `HEAD`; reviewer roadmap-doc prompts additionally reuse
+  the daily `docs/roadmap-audit-YYYY-MM-DD` branch or an existing open
+  roadmap-doc PR branch so repeated audits do not collide.
 - **curator → evolve bridge** — the Curator's lessons/skills audit remains
   snapshot-first and report-first: destructive mode writes a recoverable
   snapshot before spawning the child, then the child writes its REPORT before

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -67,6 +67,11 @@ remains a live question.
   overlapping reviewer/applier git writers in the shared checkout, and prompts
   children to fetch and branch from `origin/main` / `origin/<EVOLVE_REPO_BRANCH>`
   instead of arbitrary current `HEAD`.
+- Evolve reviewer roadmap-doc PR dedup (#54): before spawning the privileged
+  audit child, the parent checks open PRs for automation-owned changes touching
+  `docs/ROADMAP.md`; the prompt tells the reviewer to append/skip when one
+  exists, and otherwise to reuse the deterministic daily
+  `docs/roadmap-audit-YYYY-MM-DD` branch instead of opening overlapping PRs.
 - Shared GitHub API budget/backoff across roadmap automation (#38): GitHub-
   consuming roadmap surfaces now share a SQLite `github_rate_budget` ledger.
   Parent-side applier reads/writes and the PATH `gh` wrapper used by privileged
@@ -434,6 +439,14 @@ spawning the implementer; a spawn failure or red-CI abort leaks the claim for a
 full 24h (TTL-only, no reaper), and a marker-write failure after `gh pr create`
 can open a duplicate PR. Add a claim reaper + open-PR dedup + the missing
 spawn-after-claim test. (#23) Scope: S.
+
+**Evolve reviewer roadmap-doc PR dedup (done, #54).** Reviewer audit passes now
+get a parent-side `gh pr list --json number,url,headRefName,title,author,body,files`
+preflight for open automation-owned PRs that touch `docs/ROADMAP.md`. The child
+prompt tells the reviewer to append to that PR or skip, never open a second
+roadmap-doc PR, and new PRs use/reuse the deterministic
+`docs/roadmap-audit-YYYY-MM-DD` branch plus a PR-body marker for future passes.
+Scope was S.
 
 **Poison-issue backoff + dead-letter (done, #82).** An issue whose implementer
 child repeatedly aborts without opening a PR used to be re-selected every ~24h

--- a/tests/test_evolve_daemon.py
+++ b/tests/test_evolve_daemon.py
@@ -7,6 +7,9 @@ monkeypatched; no real child is launched.
 """
 from __future__ import annotations
 
+from datetime import datetime, timezone
+import json
+import subprocess
 import sys
 import time
 from pathlib import Path
@@ -47,10 +50,15 @@ def _bootstrap(tmp_path, monkeypatch, interval="0", review_min="2"):
     from threadkeeper import _mcp, db, evolve_applier, evolve_daemon, identity
     orig = {
         "_git_worktree_precondition": evolve_daemon._git_worktree_precondition,
+        "_open_roadmap_doc_prs": evolve_daemon._open_roadmap_doc_prs,
     }
     monkeypatch.setattr(
         evolve_daemon, "_git_worktree_precondition",
         lambda conn, repo_root, actor: "",
+    )
+    monkeypatch.setattr(
+        evolve_daemon, "_open_roadmap_doc_prs",
+        lambda repo_root, branch: ([], ""),
     )
     return {
         "mcp": _mcp.mcp,
@@ -104,7 +112,76 @@ def test_audit_prompt_uses_paginated_issue_dedup(tmp_path, monkeypatch):
     assert "direction=asc" in prompt
     assert "pull_request" in prompt
     assert "git fetch origin {base_branch}" in prompt
-    assert "git checkout -b <branch> {base_ref}" in prompt
+    assert (
+        "git fetch origin {roadmap_branch}:refs/remotes/origin/{roadmap_branch}"
+        in prompt
+    )
+    assert "git checkout -b {roadmap_branch} {base_ref}" in prompt
+    assert "gh pr list --state open --json" in prompt
+    assert "docs/ROADMAP.md" in prompt
+    assert "append/skip" in prompt
+
+
+def test_roadmap_doc_branch_name_reuses_same_daily_branch(
+    tmp_path, monkeypatch,
+):
+    pkg = _bootstrap(tmp_path, monkeypatch)
+    ts1 = int(datetime(2026, 7, 5, 1, tzinfo=timezone.utc).timestamp())
+    ts2 = int(datetime(2026, 7, 5, 23, 59, tzinfo=timezone.utc).timestamp())
+    ts3 = int(datetime(2026, 7, 6, 0, tzinfo=timezone.utc).timestamp())
+
+    assert pkg["ed"].roadmap_doc_branch_name(ts1) == (
+        "docs/roadmap-audit-2026-07-05"
+    )
+    assert pkg["ed"].roadmap_doc_branch_name(ts2) == (
+        "docs/roadmap-audit-2026-07-05"
+    )
+    assert pkg["ed"].roadmap_doc_branch_name(ts3) == (
+        "docs/roadmap-audit-2026-07-06"
+    )
+
+
+def test_audit_prompt_reports_existing_roadmap_doc_pr(
+    tmp_path, monkeypatch,
+):
+    pkg = _bootstrap(tmp_path, monkeypatch, review_min="2")
+    conn = pkg["db"].get_db()
+    _seed_research(pkg, conn)
+    monkeypatch.setattr(
+        pkg["ed"], "_open_roadmap_doc_prs",
+        pkg["orig"]["_open_roadmap_doc_prs"],
+    )
+    seen = {}
+
+    def fake_run_gh(cmd, *, cwd, timeout=30):
+        seen["cmd"] = cmd
+        data = [{
+            "number": 123,
+            "url": "https://github.com/o/r/pull/123",
+            "headRefName": "docs/roadmap-audit-2026-07-05",
+            "title": "docs: update roadmap audit",
+            "author": {"login": "po4erk91"},
+            "body": "",
+            "files": [{"path": "docs/ROADMAP.md"}],
+        }]
+        return subprocess.CompletedProcess(cmd, 0, json.dumps(data), "")
+
+    monkeypatch.setattr(pkg["ed"], "_run_gh", fake_run_gh)
+    calls = {}
+    import threadkeeper.tools.spawn as spawn_mod
+    monkeypatch.setattr(spawn_mod, "spawn",
+                        lambda **kw: calls.update(kw) or "ok task=tk_ev pid=1")
+
+    out = pkg["ed"].run_evolve_pass(force=True)
+
+    assert out.startswith("spawned audit")
+    assert seen["cmd"][:4] == ["gh", "pr", "list", "--state"]
+    assert any("files" in part for part in seen["cmd"])
+    assert "Existing open reviewer roadmap-doc PR found: #123" in calls["prompt"]
+    assert "https://github.com/o/r/pull/123" in calls["prompt"]
+    assert "Use that branch; do not create a second roadmap-doc PR" in (
+        calls["prompt"]
+    )
 
 
 # ── pending selection ──────────────────────────────────────────────────
@@ -305,7 +382,11 @@ def test_run_evolve_pass_audit_phase_no_web_consumes_fenced_research(
     assert "untrusted data" in calls["prompt"].lower()
     assert pkg["ed"].EVOLVE_RESEARCH_FENCE in calls["prompt"]
     assert "git fetch origin main" in calls["prompt"]
-    assert "git checkout -b <branch> origin/main" in calls["prompt"]
+    assert "git checkout -b docs/roadmap-audit-" in calls["prompt"]
+    assert "origin/main" in calls["prompt"]
+    assert "No open reviewer roadmap-doc PR touching docs/ROADMAP.md" in (
+        calls["prompt"]
+    )
 
 
 def test_run_evolve_pass_audit_skips_dirty_worktree_and_records_event(

--- a/threadkeeper/evolve_daemon.py
+++ b/threadkeeper/evolve_daemon.py
@@ -26,8 +26,10 @@ issues one at a time.
 
 from __future__ import annotations
 
+import json
 import logging
 import sqlite3
+import subprocess
 import threading
 import time
 from pathlib import Path
@@ -41,6 +43,7 @@ from .evolve_applier import (
     _ensure_repo_ready,
     _git_worktree_precondition,
 )
+from .github_budget import run_gh
 from .helpers import daemon_sleep
 from . import identity
 
@@ -61,6 +64,10 @@ EVOLVE_PROMPT_PREFIX = "You are an EVOLVE REVIEWER"
 # never as instructions.
 EVOLVE_RESEARCH_FENCE = "EVOLVE_RESEARCH_DATA"
 EVOLVE_LEGACY_QUEUE_TAG = "evolve_legacy_suggestions_data"
+ROADMAP_DOC_PATH = "docs/ROADMAP.md"
+ROADMAP_DOC_BRANCH_PREFIX = "docs/roadmap-audit-"
+ROADMAP_DOC_PR_MARKER = "<!-- thread-keeper:evolve-reviewer-roadmap-pr -->"
+ROADMAP_DOC_PR_FETCH_LIMIT = 100
 
 # ── Phase 1: read-only web research ──────────────────────────────────────────
 # No shell, no bypassPermissions, no GitHub. WebSearch/WebFetch + read-only repo
@@ -153,9 +160,37 @@ OUTPUTS
    not bypass it with an absolute gh path.
 
 2. If docs/ROADMAP.md is stale, update it on a branch and open a PR. Do not
-   commit to main. Start the branch from an up-to-date mainline:
+   commit to main. Reviewer roadmap-doc PR dedup is mandatory:
+   - Parent preflight result:
+{roadmap_pr_context}
+   - Use the existing open roadmap-doc PR's head branch when the preflight
+     reports one. Append commits there, or skip if your audit finds no roadmap
+     change is still needed. Do not open a second roadmap PR.
+   - If no open roadmap-doc PR exists, use this deterministic branch name:
+       {roadmap_branch}
+     Reuse an existing local/remote branch with that name instead of inventing a
+     new branch for the same period.
+   - Immediately before `gh pr create`, rerun:
+       gh pr list --state open --json number,url,headRefName,title,author,body,files --limit {roadmap_pr_limit}
+     If an open automation-owned PR touches docs/ROADMAP.md, append/skip instead
+     of opening another PR.
+   - Include this marker in any roadmap-doc PR body so future passes can
+     identify it:
+       {roadmap_marker}
+   Start from an up-to-date mainline, reusing the deterministic branch when it
+   already exists:
      git fetch origin {base_branch}
-     git checkout -b <branch> {base_ref}
+     git fetch origin {roadmap_branch}:refs/remotes/origin/{roadmap_branch} || true
+     if git show-ref --verify --quiet refs/heads/{roadmap_branch}; then
+       git checkout {roadmap_branch}
+       if git show-ref --verify --quiet refs/remotes/origin/{roadmap_branch}; then
+         git pull --ff-only origin {roadmap_branch}
+       fi
+     elif git show-ref --verify --quiet refs/remotes/origin/{roadmap_branch}; then
+       git checkout -b {roadmap_branch} --track origin/{roadmap_branch}
+     else
+       git checkout -b {roadmap_branch} {base_ref}
+     fi
    Do not implement product/code fixes in reviewer; only roadmap documentation
    changes are allowed.
 
@@ -274,6 +309,123 @@ def _running_evolve_children(conn: sqlite3.Connection) -> list[str]:
     if touched:
         conn.commit()
     return running
+
+
+def roadmap_doc_branch_name(now_t: Optional[int] = None) -> str:
+    """Deterministic branch for reviewer-owned ROADMAP.md updates.
+
+    One branch per UTC day gives repeated passes in the same audit period a
+    stable rendezvous point instead of minting overlapping roadmap PRs.
+    """
+    ts = int(time.time() if now_t is None else now_t)
+    day = time.strftime("%Y-%m-%d", time.gmtime(ts))
+    return f"{ROADMAP_DOC_BRANCH_PREFIX}{day}"
+
+
+def _run_gh(
+    cmd: list[str],
+    *,
+    cwd: Path | str,
+    timeout: int = 30,
+) -> subprocess.CompletedProcess:
+    return run_gh(
+        cmd,
+        cwd=str(cwd),
+        text=True,
+        capture_output=True,
+        timeout=timeout,
+        check=False,
+        runner=subprocess.run,
+    )
+
+
+def _pr_file_path(item: object) -> str:
+    if isinstance(item, str):
+        return item
+    if isinstance(item, dict):
+        return str(item.get("path") or "")
+    return ""
+
+
+def _pr_touches_roadmap_doc(pr: dict) -> bool:
+    files = pr.get("files")
+    if not isinstance(files, list):
+        return False
+    return any(_pr_file_path(f) == ROADMAP_DOC_PATH for f in files)
+
+
+def _pr_looks_reviewer_owned(pr: dict, branch: str) -> bool:
+    head = str(pr.get("headRefName") or "")
+    body = str(pr.get("body") or "")
+    return (
+        head == branch
+        or head.startswith(ROADMAP_DOC_BRANCH_PREFIX)
+        or ROADMAP_DOC_PR_MARKER in body
+    )
+
+
+def _open_roadmap_doc_prs(
+    repo_root: Path,
+    branch: str,
+) -> tuple[list[dict], str]:
+    """Open automation-owned PRs that already touch docs/ROADMAP.md."""
+    cmd = [
+        "gh", "pr", "list",
+        "--state", "open",
+        "--json", "number,url,headRefName,title,author,body,files",
+        "--limit", str(ROADMAP_DOC_PR_FETCH_LIMIT),
+    ]
+    try:
+        proc = _run_gh(cmd, cwd=repo_root, timeout=30)
+    except FileNotFoundError:
+        return [], "gh_not_found"
+    except subprocess.TimeoutExpired:
+        return [], "gh_pr_list_timeout"
+    except OSError as e:
+        return [], f"gh_pr_list_error: {e}"
+    if proc.returncode != 0:
+        err = (proc.stderr or proc.stdout or "").strip().splitlines()
+        msg = err[-1] if err else f"exit={proc.returncode}"
+        return [], f"gh_pr_list_failed: {msg[:180]}"
+    try:
+        data = json.loads(proc.stdout or "[]")
+    except json.JSONDecodeError as e:
+        return [], f"gh_pr_list_bad_json: {e}"
+    if not isinstance(data, list):
+        return [], "gh_pr_list_bad_shape"
+    prs = [
+        pr for pr in data
+        if isinstance(pr, dict)
+        and _pr_touches_roadmap_doc(pr)
+        and _pr_looks_reviewer_owned(pr, branch)
+    ]
+    return prs, ""
+
+
+def _roadmap_doc_pr_context(repo_root: Path, now_t: int) -> tuple[str, str]:
+    """Return (branch, prompt-ready preflight text) for roadmap PR dedup."""
+    branch = roadmap_doc_branch_name(now_t)
+    prs, err = _open_roadmap_doc_prs(repo_root, branch)
+    if err:
+        return branch, (
+            f"     - Could not inspect open roadmap-doc PRs before spawn: {err}. "
+            "Run the `gh pr list` check yourself before creating a PR, and "
+            "append/skip if a reviewer-owned PR already touches docs/ROADMAP.md."
+        )
+    if prs:
+        pr = prs[0]
+        number = str(pr.get("number") or "?")
+        url = str(pr.get("url") or "")
+        head = str(pr.get("headRefName") or branch)
+        return branch, (
+            f"     - Existing open reviewer roadmap-doc PR found: #{number} "
+            f"{url} (head branch `{head}`). Use that branch; do not create a "
+            "second roadmap-doc PR."
+        )
+    return branch, (
+        "     - No open reviewer roadmap-doc PR touching docs/ROADMAP.md was "
+        f"found. Use `{branch}` if a roadmap-doc PR is needed."
+    )
 
 
 # ── Two-phase research/audit split (#79) ─────────────────────────────────────
@@ -398,9 +550,16 @@ def _spawn_audit(repo_root: Path, pending: list, research_text: str) -> str:
         )
         if pending else "(none)"
     )
+    roadmap_branch, roadmap_pr_context = _roadmap_doc_pr_context(
+        repo_root, int(time.time())
+    )
     prompt = EVOLVE_AUDIT_PROMPT.format(
         base_branch=_base_branch_name(),
         base_ref=_base_ref(),
+        roadmap_branch=roadmap_branch,
+        roadmap_marker=ROADMAP_DOC_PR_MARKER,
+        roadmap_pr_context=roadmap_pr_context,
+        roadmap_pr_limit=ROADMAP_DOC_PR_FETCH_LIMIT,
         fence=EVOLVE_RESEARCH_FENCE,
         research=_fence_research(research_text),
         queue=_fence_untrusted_data(EVOLVE_LEGACY_QUEUE_TAG, queue),


### PR DESCRIPTION
## Summary
- add a reviewer roadmap-doc PR preflight for open automation-owned PRs touching docs/ROADMAP.md
- give reviewer roadmap updates a deterministic daily branch and explicit branch reuse instructions
- document the reviewer PR dedup behavior and cover it in evolve daemon tests

## Tests
- env -u THREADKEEPER_NO_EMBEDDINGS .venv/bin/python -m pytest -q (exited 0; double-quiet suppressed the count)
- env -u THREADKEEPER_NO_EMBEDDINGS .venv/bin/python -m pytest --force-short-summary (1085 passed, 1 skipped, 95 warnings)

Closes #54