### PR TITLE
fix: require signed tag for PyPI publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,7 @@
 name: publish
 
-# Publish to PyPI on every annotated tag matching v*.
+# Publish to PyPI only from a maintainer-signed annotated tag matching v*
+# after the protected pypi environment admits the upload job.
 # Uses PyPI's Trusted Publisher OIDC flow — no API token in repo
 # secrets. Configure once on PyPI side: project → Settings → Publishing
 # → "Add a new pending publisher" with repo=po4erk91/thread-keeper,
@@ -11,11 +12,53 @@ on:
     tags:
       - "v*"
   # Manual trigger for re-publishing if a previous run failed (rare).
+  # Choose the already-pushed signed tag in the "Use workflow from" ref picker.
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
+  authorize:
+    name: Verify release authorization
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Require v* tag ref
+        env:
+          REF_NAME: ${{ github.ref_name }}
+          REF_TYPE: ${{ github.ref_type }}
+        run: |
+          if [ "$REF_TYPE" != "tag" ] || [[ "$REF_NAME" != v* ]]; then
+            echo "::error::publish.yml must run from a signed v* tag ref, not $REF_TYPE '$REF_NAME'."
+            exit 1
+          fi
+
+      - name: Verify signed annotated tag
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          ref_type="$(gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$TAG" --jq '.object.type')"
+          tag_sha="$(gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$TAG" --jq '.object.sha')"
+
+          if [ "$ref_type" != "tag" ]; then
+            echo "::error::$TAG must be an annotated tag; lightweight tags cannot publish."
+            exit 1
+          fi
+
+          verified="$(gh api "repos/$GITHUB_REPOSITORY/git/tags/$tag_sha" --jq '.verification.verified')"
+          reason="$(gh api "repos/$GITHUB_REPOSITORY/git/tags/$tag_sha" --jq '.verification.reason')"
+
+          if [ "$verified" != "true" ]; then
+            echo "::error::$TAG is not a verified signed tag (reason: $reason)."
+            exit 1
+          fi
+
   build:
     name: Build distribution
+    needs: authorize
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -29,6 +72,25 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install build
+
+      - name: Validate release metadata
+        env:
+          TAG: ${{ github.ref_name }}
+        run: |
+          version="$(python - <<'PY'
+          import tomllib
+
+          with open("pyproject.toml", "rb") as f:
+              print(tomllib.load(f)["project"]["version"])
+          PY
+          )"
+
+          if [ "$TAG" != "v$version" ]; then
+            echo "::error::Tag $TAG does not match pyproject.toml version $version."
+            exit 1
+          fi
+
+          grep -q "^## v${version} " CHANGELOG.md
 
       - name: Build sdist + wheel
         run: python -m build
@@ -52,6 +114,7 @@ jobs:
       name: pypi
       url: https://pypi.org/p/threadkeeper
     permissions:
+      contents: read
       # OIDC token for Trusted Publisher flow.
       id-token: write
     steps:
@@ -70,8 +133,8 @@ jobs:
     name: Create GitHub Release
     needs: publish-pypi
     runs-on: ubuntu-latest
-    # Auto-create the release on tag pushes and on explicit dispatches
-    # pointed at a tag ref (used by release-tag.yml after tests pass).
+    # Auto-create the release on signed tag pushes and on explicit dispatches
+    # pointed at the same tag ref.
     if: >
       (github.event_name == 'push' || github.event_name == 'workflow_dispatch') &&
       startsWith(github.ref, 'refs/tags/v')

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -1,4 +1,4 @@
-name: release tag
+name: release readiness
 
 on:
   workflow_run:
@@ -7,12 +7,11 @@ on:
     branches: [main]
 
 permissions:
-  contents: write
-  actions: write
+  contents: read
 
 jobs:
-  tag:
-    name: Tag successful main build
+  check:
+    name: Check release-ready main build
     runs-on: ubuntu-latest
     if: >
       github.event.workflow_run.conclusion == 'success' &&
@@ -48,23 +47,12 @@ jobs:
         run: |
           grep -q "^## v${VERSION} " CHANGELOG.md
 
-      - name: Create annotated tag
+      - name: Report maintainer release action
         if: steps.existing.outputs.exists == 'false'
         env:
           TAG: ${{ steps.version.outputs.tag }}
           SHA: ${{ github.event.workflow_run.head_sha }}
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git tag -a "$TAG" "$SHA" -m "release: $TAG"
-          git push origin "refs/tags/$TAG"
-
-      - name: Dispatch publish workflow
-        if: steps.existing.outputs.exists == 'false'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG: ${{ steps.version.outputs.tag }}
-        run: |
-          # Tag pushes made with GITHUB_TOKEN do not reliably trigger new
-          # push-based workflow runs, so dispatch publish.yml explicitly.
-          gh workflow run publish.yml --ref "$TAG"
+          echo "::notice::Release metadata for $TAG is present on $SHA."
+          echo "::notice::Publishing now requires a maintainer-signed annotated tag:"
+          echo "::notice::git tag -s $TAG $SHA -m 'release: $TAG' && git push origin refs/tags/$TAG"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,13 @@ version bumps follow semver per the policy in
 
 ### Fixed
 
+- **PyPI release authorization gate (#57).** Merge-to-main release readiness is
+  now read-only: it validates version/changelog metadata but no longer creates
+  tags or dispatches `publish.yml`, and its permissions are reduced to
+  `contents: read`. Publishing now requires a GitHub-verified signed annotated
+  `v*` tag, matching release metadata, and the protected `pypi` environment
+  before the Trusted Publisher upload job can run.
+
 - **Unified single-flight dispatch locks (#53).** Spawning daemons now share
   `helpers.single_flight_lock()` for their non-blocking `fcntl.flock` pidfiles
   instead of carrying local copies. Shadow review, evolve reviewer, and probe

--- a/README.md
+++ b/README.md
@@ -64,6 +64,10 @@ Integrity API provenance from the expected GitHub Trusted Publisher. Dirty or
 diverged git checkouts are skipped rather than overwritten. Restarts are gated
 on install/setup success plus a subprocess import smoke check, so a broken or
 unverified update is recorded but the current server keeps running.
+Upstream PyPI publishing is intentionally gated: merge-to-main checks no longer
+dispatch uploads, and a release requires a maintainer-signed annotated `v*` tag
+plus the protected `pypi` GitHub Environment described in
+[docs/RELEASING.md](docs/RELEASING.md).
 
 They also run a twice-weekly installed-skill updater by default. It keeps all
 configured CLI skill roots in sync, adopts newer local copies installed into a

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -122,6 +122,11 @@ in-memory code. Set `THREADKEEPER_AUTO_UPDATE_INTERVAL_S=0` to opt out of the
 standing-consent update channel entirely; the provenance gate itself is
 controlled by `THREADKEEPER_AUTO_UPDATE_VERIFY_PROVENANCE` for break-glass
 mirrors.
+The upstream publish path is gated before that provenance exists: the
+post-test release readiness workflow is read-only and does not dispatch PyPI,
+while `publish.yml` requires a GitHub-verified signed annotated `v*` tag and
+the protected `pypi` environment before the Trusted Publisher upload job can
+run.
 The legacy monolith `server.py` at the repo root was removed in May 2026 — the
 runtime is fully on the package.
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,14 +1,17 @@
 # Releasing thread-keeper
 
-Publishing to PyPI is automated via GitHub Actions. A push to `main`
+Publishing to PyPI is deliberately split into two steps. A push to `main`
 runs `.github/workflows/test.yml`; when that run succeeds,
-`.github/workflows/release-tag.yml` creates an annotated `v*` tag from
-the version in `pyproject.toml` and dispatches
-`.github/workflows/publish.yml` on that tag ref. Manual annotated tags
-matching `v*` still trigger `publish.yml` directly.
+`.github/workflows/release-tag.yml` checks whether the version in
+`pyproject.toml` has matching changelog notes, but it does **not** create a tag,
+dispatch publishing, or hold write permissions. A maintainer then authorizes the
+release by pushing a signed annotated `v*` tag. `.github/workflows/publish.yml`
+verifies that signed tag, checks that it matches `pyproject.toml` and
+`CHANGELOG.md`, then pauses at the protected `pypi` GitHub Environment before
+uploading.
 
-PyPI upload uses Trusted Publisher OIDC — no PyPI API token is stored in
-the repository. The publish job explicitly uploads PyPI digital attestations
+PyPI upload uses Trusted Publisher OIDC — no PyPI API token is stored in the
+repository. The publish job explicitly uploads PyPI digital attestations
 (`attestations: true`), which is what the packaged auto-updater verifies before
 running future `pip install --upgrade` self-updates.
 
@@ -29,14 +32,29 @@ You need to do this **once**, before the first release.
 4. Save. The first successful publish from GitHub Actions will create
    the project on PyPI and convert the pending publisher to active.
 
-### 2. GitHub environment (optional but recommended)
+### 2. Protected GitHub environment
 
 In the repo: **Settings → Environments → New environment** → name
-`pypi`. You can optionally add required reviewers / wait timers if you
-want manual approval before each publish.
+`pypi`.
 
-If you skip this step the workflow still works — GitHub creates the
-environment on the fly when the job first runs.
+Configure it as a required approval gate:
+
+- Add at least one **Required reviewer**.
+- Disable admin bypass if the repository policy requires two-person release
+  control.
+- Leave deployment branches/tags unrestricted, or allow the `v*` release tags
+  used by `publish.yml`.
+
+Verify the environment before relying on the release workflow:
+
+```bash
+gh api repos/po4erk91/thread-keeper/environments/pypi \
+  --jq '.protection_rules'
+```
+
+The output must include a `required_reviewers` rule. Without that repository
+setting, the signed tag is still required by source control, but the PyPI upload
+job will not pause for a second human approval.
 
 ### 3. Verify locally before tagging (optional)
 
@@ -54,41 +72,55 @@ on GitHub.
 ## Per-release flow
 
 ```bash
-# 1. Bump version in pyproject.toml
+# 1. Bump version in pyproject.toml on a normal PR branch
 $EDITOR pyproject.toml         # version = "0.4.0" → "0.4.1"
 
 # 2. Add a matching CHANGELOG section: ## v0.4.1 — YYYY-MM-DD
 $EDITOR CHANGELOG.md
 
-# 3. Commit + push to main
+# 3. Commit, open a PR, and merge it to main after tests pass
 git commit -am "release: 0.4.1"
-git push origin main
 ```
 
 The workflows then:
 1. Run the full test matrix on `main`
-2. Create annotated tag `vX.Y.Z` if it does not already exist
-3. Dispatch `publish.yml` on that tag ref
-4. Build sdist + wheel (`python -m build`)
-5. Run `twine check dist/*`
-6. Upload artifacts to PyPI via `pypa/gh-action-pypi-publish` (OIDC,
+2. Check that an unreleased `vX.Y.Z` has a matching changelog section
+3. Stop and print the signed-tag command for the maintainer
+
+After the merge-to-main checks are green, publish with a signed annotated tag:
+
+```bash
+git fetch origin main --tags
+git tag -s v0.4.1 origin/main -m "release: v0.4.1"
+git push origin refs/tags/v0.4.1
+```
+
+The publish workflow then:
+
+1. Verifies the workflow is running from a `v*` tag ref
+2. Verifies the tag is annotated and GitHub reports its signature as valid
+3. Confirms the tag matches `pyproject.toml` and `CHANGELOG.md`
+4. Builds sdist + wheel (`python -m build`)
+5. Runs `twine check dist/*`
+6. Waits for the protected `pypi` environment approval
+7. Uploads artifacts to PyPI via `pypa/gh-action-pypi-publish` (OIDC,
    no token)
-7. Create a GitHub Release from the matching `CHANGELOG.md` section
+8. Creates a GitHub Release from the matching `CHANGELOG.md` section
 
 Watch progress at
 <https://github.com/po4erk91/thread-keeper/actions>.
 
-### Manual tag fallback
+### Manual re-run
 
-If the post-test tag workflow is disabled or needs to be bypassed, you
-can still publish by creating the annotated tag yourself:
+If a signed tag already exists and a publish run failed after authorization,
+re-run the workflow against the tag ref:
 
 ```bash
-git tag -a v0.4.1 -m "release: v0.4.1"
-git push origin v0.4.1
+gh workflow run publish.yml --ref v0.4.1
 ```
 
-Manual tag pushes trigger `publish.yml` directly.
+The re-run still verifies the signed tag and still waits at the `pypi`
+environment.
 
 ## Versioning
 
@@ -109,10 +141,9 @@ If a release ships broken, **don't try to overwrite**. PyPI rejects
 re-uploads of an existing version. Instead:
 
 ```bash
-# Bump patch + commit; the post-test release workflow tags it
+# Bump patch + commit; then publish with the signed-tag flow above
 $EDITOR pyproject.toml         # 0.4.1 → 0.4.2
 git commit -am "release: 0.4.2 (yank 0.4.1)"
-git push origin main
 ```
 
 Then yank 0.4.1 via PyPI UI:
@@ -126,9 +157,9 @@ Tag with PEP 440 suffix to publish to PyPI as a pre-release that
 `pip install threadkeeper` skips by default:
 
 ```bash
-git tag v0.5.0a1            # alpha
-git tag v0.5.0b1            # beta
-git tag v0.5.0rc1           # release candidate
+git tag -s v0.5.0a1 -m "release: v0.5.0a1"      # alpha
+git tag -s v0.5.0b1 -m "release: v0.5.0b1"      # beta
+git tag -s v0.5.0rc1 -m "release: v0.5.0rc1"    # release candidate
 ```
 
 Users opt in via `pip install --pre threadkeeper`.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -116,6 +116,12 @@ remains a live question.
   `THREADKEEPER_REDACT_DIALOG_SECRETS` knob can be disabled only for rare local
   debugging where raw transcript fidelity intentionally wins over durable
   secret protection.
+- PyPI release authorization gate (#57): merge-to-main release readiness now
+  runs with `contents: read` only, validates version/changelog metadata, and
+  stops before tag creation or workflow dispatch. Publishing is decoupled from
+  auto-tagging: `publish.yml` requires a GitHub-verified signed annotated `v*`
+  tag, matching release metadata, and the protected `pypi` environment before
+  the Trusted Publisher upload job can run.
 - Unified fcntl single-flight for spawning daemons (#53): the local
   check-running-then-spawn mutex now lives in `helpers.single_flight_lock()`.
   Shadow review, evolve reviewer, probe daemon, candidate reviewer, curator,

--- a/tests/test_release_workflows.py
+++ b/tests/test_release_workflows.py
@@ -1,0 +1,57 @@
+from pathlib import Path
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOWS = ROOT / ".github" / "workflows"
+
+
+def _workflow(name: str) -> dict:
+    return yaml.safe_load((WORKFLOWS / name).read_text())
+
+
+def _workflow_text(name: str) -> str:
+    return (WORKFLOWS / name).read_text()
+
+
+def test_release_readiness_is_read_only_and_does_not_publish():
+    data = _workflow("release-tag.yml")
+    text = _workflow_text("release-tag.yml")
+
+    assert data["permissions"] == {"contents": "read"}
+    assert "actions: write" not in text
+    assert "contents: write" not in text
+    assert "gh workflow run publish.yml" not in text
+    assert 'git push origin "refs/tags/$TAG"' not in text
+    assert "Report maintainer release action" in text
+
+
+def test_publish_requires_signed_tag_and_pypi_environment():
+    data = _workflow("publish.yml")
+    text = _workflow_text("publish.yml")
+    jobs = data["jobs"]
+
+    assert data["permissions"] == {"contents": "read"}
+    assert jobs["build"]["needs"] == "authorize"
+    assert jobs["publish-pypi"]["needs"] == "build"
+    assert jobs["publish-pypi"]["environment"]["name"] == "pypi"
+    assert jobs["publish-pypi"]["permissions"] == {
+        "contents": "read",
+        "id-token": "write",
+    }
+
+    assert "Require v* tag ref" in text
+    assert "Verify signed annotated tag" in text
+    assert ".verification.verified" in text
+    assert "must be an annotated tag" in text
+    assert "Validate release metadata" in text
+
+
+def test_releasing_docs_describe_the_approval_flow():
+    docs = (ROOT / "docs" / "RELEASING.md").read_text()
+
+    assert "does **not** create a tag" in docs
+    assert "Add at least one **Required reviewer**" in docs
+    assert "git tag -s v0.4.1 origin/main" in docs
+    assert "The output must include a `required_reviewers` rule" in docs


### PR DESCRIPTION
## Summary
- make release readiness read-only: validate release metadata and print the signed-tag command instead of creating tags or dispatching publish
- require publish.yml to run from a v* tag, verify a GitHub-signed annotated tag, validate pyproject/changelog metadata, and keep the pypi environment gate before upload
- document the protected-environment/signed-tag flow and add workflow invariant tests

## Tests
- env -u THREADKEEPER_NO_EMBEDDINGS .venv/bin/python -m pytest -q (exited 0)
- sh -c 'env -u THREADKEEPER_NO_EMBEDDINGS .venv/bin/python -m pytest -q; rc=0; echo PYTEST_EXIT=; exit ' (PYTEST_EXIT=0)

Closes #57