### PR TITLE
fix: stop daemon-cadence refire, net-negative reclaim, prose cost parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,43 @@ version bumps follow semver per the policy in
   before building the child prompt, releases those claims on spawn errors, and
   runs the dispatch section behind the shared `helpers.single_flight_lock()`.
 
+- **Cross-process daemon cadence gate (`daemon_state`).** Interval daemons now
+  persist their last-run timestamp in a shared `daemon_state` table and claim
+  each scheduled tick with one atomic upsert, so a freshly started MCP server
+  no longer considers every loop overdue and refires it. (Observed pre-fix:
+  an "every 3 days" curator ran 51 times in one day — one pass per new CLI
+  session — plus equivalent amplification for probe/shadow/extract loops, at
+  ~128 LLM children and ~2.8M tokens per day.) Single-flight flocks still
+  serialize concurrency; the gate governs frequency. Applies to shadow_review,
+  curator, candidate_reviewer, extract, dialectic miner/validator, probe,
+  thread_janitor, and retention (evolve reviewer/applier, skill_updater, and
+  auto_update already had their own due gates). Manual/tool-invoked passes
+  bypass the gate but record the run, pushing the next scheduled fire a full
+  interval out; scheduled ticks that lose the claim return `not_due`.
+
+- **Memory-reclaim guards (hot model + effectiveness back-off).** The RSS
+  guard's `reclaim_memory` no longer unloads an embedding model that was used
+  within `THREADKEEPER_MEMORY_GUARD_EMBED_HOT_S` (default 300s) — with an
+  active ingester the model reloads seconds later while the freed arenas are
+  still resident, which made reclaims net-negative (observed: +200–330MB per
+  reclaim, ~2,350 reclaims/week of synchronized thrash). A reclaim that frees
+  nothing now engages an exponential per-process back-off (30min → 4h max),
+  reset by the next effective trim. Manual `memory_guard_reclaim` calls bypass
+  both guards (`force=True`), and reclaim log/event lines now include
+  `freed=`.
+
+### Fixed
+
+- **Spawn usage parsing no longer ingests prose numbers as spend.**
+  `_spawn_wrap.parse_usage` scoped its regex fallbacks to the whole captured
+  output, so a child that merely *discussed* money recorded it as its own
+  cost (observed: a `$4,445` ad-spend figure landing in `cost_usd`, poisoning
+  the 24h budget-admission sums). Scanning is now bounded to the trailing
+  lines where CLI usage trailers actually print, the bare `$<amount>` pattern
+  is gone (an explicit `cost` label is required), number-before-label matches
+  must be same-line, and implausible values (cost > $500, tokens > 2×10⁸) are
+  dropped as mis-parses.
+
 - **Recoverable destructive curator passes (#40).** Destructive curator runs now
   fail closed unless a pre-mutation snapshot is written under
   `<curator_reports_dir>/snapshots/<pass-id>/`. Each snapshot includes

--- a/README.md
+++ b/README.md
@@ -959,6 +959,7 @@ The most-used env knobs (full list in `threadkeeper/config.py`):
 | `THREADKEEPER_MEMORY_GUARD_AGG_WARN_MB` | 2048 | notify/request trim when all server RSS crosses this |
 | `THREADKEEPER_MEMORY_GUARD_AGG_KILL_MB` | 3072 | under aggregate pressure, retire stale idle servers |
 | `THREADKEEPER_MEMORY_GUARD_RECLAIM_MB` | 1024 | local RSS floor before warn-triggered self trim |
+| `THREADKEEPER_MEMORY_GUARD_EMBED_HOT_S` | 300 | don't unload an embedding model used within this window (an active ingester reloads it seconds later, making the trim net-negative); ineffective reclaims also back off exponentially (30m→4h); 0 disables the hot guard |
 | `THREADKEEPER_MEMORY_GUARD_TARGET_SERVERS` | 1 | aggregate-pressure target after retiring stale idle servers |
 | `THREADKEEPER_MEMORY_GUARD_RETIRE_IDLE_S` | 900 | heartbeat age before a non-self server is retireable |
 | `THREADKEEPER_MEMORY_GUARD_RETIRE_LIVE` | "" (off) | allow retiring parent-alive MCP servers; off protects live clients |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -298,6 +298,19 @@ check-running-then-spawn critical section. The `fcntl.flock` pidfile under
 the DB directory closes the same-host TOCTOU window; the tasks-table
 running-child check remains for stale-pid cleanup and status visibility.
 
+Orthogonal to concurrency, **cadence** is persisted in the `daemon_state`
+table (`daemon_state.claim_pass`): each scheduled tick claims its slot with
+one atomic upsert keyed by loop name, so a freshly started MCP server does
+not treat every interval daemon as overdue and refire it (pre-fix, every new
+CLI session ran its own "overdue" curator/probe/shadow pass — the flock only
+stops *concurrent* passes, not *frequent sequential* ones). Scheduled ticks
+that lose the claim return `not_due`; manual / tool-invoked passes bypass
+the gate but still record the run, pushing the next scheduled fire a full
+interval out. Applies to shadow_review, curator, candidate_reviewer,
+extract, dialectic miner/validator, probe, thread_janitor, and retention;
+evolve reviewer/applier, skill_updater, and auto_update keep their own
+pre-existing due gates.
+
 - **shadow_review** — once per `SHADOW_REVIEW_INTERVAL_S` (default 0 = off),
   scans a dialog window and, if needed, spawns a slim-child evaluator behind
   `shadow-review.lock` plus the running shadow-child check. Lock-busy passes

--- a/tests/test_daemon_state.py
+++ b/tests/test_daemon_state.py
@@ -1,0 +1,94 @@
+"""Cross-process daemon cadence gate (`daemon_state.claim_pass`).
+
+Single-flight locks stop *concurrent* passes; this table stops *frequent
+sequential* ones — without it, every freshly started MCP server considers
+every interval daemon overdue and refires it (observed: an "every 3 days"
+curator running 51 times in one day, one pass per new CLI session).
+"""
+from __future__ import annotations
+
+import time
+
+
+def test_first_scheduled_claim_wins_second_skips(fresh_mp):
+    from threadkeeper import daemon_state
+
+    now = time.time()
+    assert daemon_state.claim_pass("loop_a", 3600, scheduled=True, now=now)
+    # A second server starting a moment later must NOT refire the loop.
+    assert not daemon_state.claim_pass(
+        "loop_a", 3600, scheduled=True, now=now + 5
+    )
+
+
+def test_scheduled_due_again_after_interval(fresh_mp):
+    from threadkeeper import daemon_state
+
+    now = time.time()
+    assert daemon_state.claim_pass("loop_b", 3600, scheduled=True, now=now)
+    # daemon_sleep jitters ±15%, so an early wake at 0.85×interval must still
+    # count as due (the gate's due-fraction is 0.8)...
+    assert daemon_state.claim_pass(
+        "loop_b", 3600, scheduled=True, now=now + 0.85 * 3600
+    )
+    # ...and the freshly recorded run gates the next tick again.
+    assert not daemon_state.claim_pass(
+        "loop_b", 3600, scheduled=True, now=now + 0.85 * 3600 + 5
+    )
+
+
+def test_manual_claim_bypasses_gate_and_resets_clock(fresh_mp):
+    from threadkeeper import daemon_state
+
+    now = time.time()
+    assert daemon_state.claim_pass("loop_c", 3600, scheduled=True, now=now)
+    # Manual / tool-invoked pass always runs...
+    assert daemon_state.claim_pass(
+        "loop_c", 3600, scheduled=False, now=now + 10
+    )
+    # ...and pushes the next scheduled fire out from itself: at +2000s the
+    # elapsed 1990s is under the 0.8×3600 due-gap, so the tick skips.
+    assert not daemon_state.claim_pass(
+        "loop_c", 3600, scheduled=True, now=now + 2000
+    )
+    assert daemon_state.claim_pass(
+        "loop_c", 3600, scheduled=True, now=now + 10 + 3600
+    )
+
+
+def test_cross_connection_claim_is_atomic(fresh_mp):
+    """Two servers waking at the same instant: exactly one wins the slot.
+    The claim is a single upsert with a WHERE gate, serialized by SQLite's
+    write lock — no flock needed for the frequency decision."""
+    from threadkeeper import daemon_state
+    from threadkeeper.db import get_db
+
+    c1, c2 = get_db(), get_db()
+    now = time.time()
+    r1 = daemon_state.claim_pass(
+        "loop_d", 600, scheduled=True, conn=c1, now=now
+    )
+    r2 = daemon_state.claim_pass(
+        "loop_d", 600, scheduled=True, conn=c2, now=now
+    )
+    assert (r1, r2) == (True, False)
+
+
+def test_last_run_at_roundtrip(fresh_mp):
+    from threadkeeper import daemon_state
+
+    assert daemon_state.last_run_at("loop_e") is None
+    daemon_state.claim_pass("loop_e", 60, scheduled=False, now=1_000_000)
+    assert daemon_state.last_run_at("loop_e") == 1_000_000
+
+
+def test_retention_pass_wired_to_gate(fresh_mp, monkeypatch):
+    """Integration: a daemon pass honors the gate only on scheduled ticks."""
+    from threadkeeper import retention
+
+    monkeypatch.setattr(retention, "RETENTION_INTERVAL_S", 3600.0)
+    first = retention.run_retention_pass(scheduled=True)
+    assert first.startswith("deleted")
+    assert retention.run_retention_pass(scheduled=True) == "not_due"
+    # Manual/forced invocation keeps working regardless of the gate.
+    assert retention.run_retention_pass(force=True).startswith("deleted")

--- a/tests/test_memory_guard.py
+++ b/tests/test_memory_guard.py
@@ -452,3 +452,77 @@ def test_maybe_notify_keeps_dict_bounded(monkeypatch):
         assert len(mg._last_notify_at) <= 1
     finally:
         mg._last_notify_at.clear()
+
+
+# ──────────────────────────────────────────────────────────────────────
+# reclaim_memory guards: hot-model skip + ineffective-reclaim back-off
+# ──────────────────────────────────────────────────────────────────────
+
+def test_reclaim_skips_hot_model(mp_with_cid, monkeypatch):
+    """A model used seconds ago is not unloaded — the ingester would reload
+    a fresh copy immediately, making the reclaim net-negative."""
+    mp_with_cid(_FAKE_CID)
+    import time as _time
+    from threadkeeper import embeddings, memory_guard as mg
+
+    monkeypatch.setattr(mg, "MEMORY_GUARD_EMBED_HOT_S", 300.0)
+    monkeypatch.setattr(mg, "_reclaim_backoff_until", 0.0)
+    monkeypatch.setattr(mg, "_reclaim_fail_streak", 0)
+    monkeypatch.setattr(mg, "_log_line", lambda *a, **k: None)
+    monkeypatch.setattr(embeddings, "model_loaded", lambda: True)
+    monkeypatch.setattr(embeddings, "last_used_at", lambda: _time.time())
+    unloaded: list[int] = []
+    monkeypatch.setattr(
+        embeddings, "unload_model", lambda: unloaded.append(1) or True
+    )
+
+    out = mg.reclaim_memory(reason="aggregate_warn")
+    assert out.get("skipped") == "model_hot"
+    assert out["freed_mb"] == 0
+    assert unloaded == []
+
+
+def test_reclaim_force_bypasses_hot_guard(mp_with_cid, monkeypatch):
+    """Manual tool invocations (force=True) trim regardless of the guards."""
+    mp_with_cid(_FAKE_CID)
+    import time as _time
+    from threadkeeper import embeddings, memory_guard as mg
+
+    monkeypatch.setattr(mg, "MEMORY_GUARD_EMBED_HOT_S", 300.0)
+    monkeypatch.setattr(mg, "_reclaim_backoff_until", _time.time() + 999)
+    monkeypatch.setattr(mg, "_reclaim_fail_streak", 3)
+    monkeypatch.setattr(mg, "_log_line", lambda *a, **k: None)
+    monkeypatch.setattr(mg, "_emit_event", lambda *a, **k: None)
+    monkeypatch.setattr(embeddings, "model_loaded", lambda: True)
+    monkeypatch.setattr(embeddings, "last_used_at", lambda: _time.time())
+    unloaded: list[int] = []
+    monkeypatch.setattr(
+        embeddings, "unload_model", lambda: unloaded.append(1) or True
+    )
+
+    out = mg.reclaim_memory(reason="manual:self", force=True)
+    assert "skipped" not in out
+    assert unloaded == [1]
+
+
+def test_reclaim_backs_off_after_ineffective_pass(mp_with_cid, monkeypatch):
+    """A reclaim that GREW RSS (after > before — the observed pathology)
+    engages an exponential back-off instead of thrash-repeating."""
+    mp_with_cid(_FAKE_CID)
+    from threadkeeper import embeddings, memory_guard as mg
+
+    monkeypatch.setattr(mg, "MEMORY_GUARD_EMBED_HOT_S", 300.0)
+    monkeypatch.setattr(mg, "_reclaim_backoff_until", 0.0)
+    monkeypatch.setattr(mg, "_reclaim_fail_streak", 0)
+    monkeypatch.setattr(mg, "_log_line", lambda *a, **k: None)
+    monkeypatch.setattr(mg, "_emit_event", lambda *a, **k: None)
+    monkeypatch.setattr(embeddings, "model_loaded", lambda: False)
+    rss = iter([100, 350])  # before=100 → after=350 (net-negative reclaim)
+    monkeypatch.setattr(mg, "_pid_rss_mb", lambda pid: next(rss, 350))
+
+    out = mg.reclaim_memory(reason="aggregate_warn")
+    assert out["freed_mb"] == 0
+    assert any(a.startswith("backoff=") for a in out["actions"])
+
+    out2 = mg.reclaim_memory(reason="aggregate_warn")
+    assert str(out2.get("skipped", "")).startswith("backoff")

--- a/tests/test_spawn_wrap.py
+++ b/tests/test_spawn_wrap.py
@@ -123,6 +123,37 @@ def test_parse_usage_codex_tokens_used_trailer(db_mod):
     assert usage.tokens_total == 44777
 
 
+def test_parse_usage_ignores_prose_dollar_amounts(db_mod):
+    """A child that merely DISCUSSES money must not record it as spend —
+    observed in production as a $4,445 ad-spend figure landing in cost_usd.
+    Only an explicit cost label counts."""
+    import threadkeeper._spawn_wrap as w
+    usage = w.parse_usage(
+        "the ad spend was $4,445 across campaigns\nfinal answer: done\n"
+    )
+    assert usage.cost_usd is None
+
+
+def test_parse_usage_ignores_trailer_lookalikes_far_from_end(db_mod):
+    """Usage trailers print at the END of a run; a lookalike buried deep in
+    the child's narrative output is not a trailer."""
+    import threadkeeper._spawn_wrap as w
+    filler = "\n".join(f"narrative line {i}" for i in range(200))
+    usage = w.parse_usage("tokens used\n9,876\n" + filler)
+    assert usage.tokens_total is None
+
+
+def test_parse_usage_drops_implausible_values(db_mod):
+    """Values beyond plausibility bounds are mis-parses, not measurements —
+    better NULL than poisoning the 24h budget-admission sums."""
+    import threadkeeper._spawn_wrap as w
+    usage = w.parse_usage(
+        "total cost: $99,999\ntokens used\n999,999,999,999\n"
+    )
+    assert usage.cost_usd is None
+    assert usage.tokens_total is None
+
+
 def test_record_persists_usage_and_duration(db_mod):
     db, db_path = db_mod
     _mk_task(db, "tk_usage")

--- a/threadkeeper/_spawn_wrap.py
+++ b/threadkeeper/_spawn_wrap.py
@@ -42,6 +42,19 @@ from dataclasses import dataclass
 
 _TAIL_LIMIT = 256 * 1024
 
+# Usage trailers print at the very END of a run, but the captured tail also
+# contains the child's own narrative output. Scanning all of it invites false
+# positives — a child that merely DISCUSSED ad spend once recorded "$4,445"
+# as its own cost_usd. So the JSON scan is bounded to the final result lines
+# and the loose regex fallbacks to the last few lines only.
+_JSON_SCAN_LINES = 120
+_REGEX_SCAN_LINES = 40
+# Parse-garbage bounds: one child cannot plausibly exceed these; a match
+# beyond them is a mis-parse, not a measurement — better NULL than noise
+# (budget admission sums these columns over a 24h window).
+_MAX_PLAUSIBLE_COST_USD = 500.0
+_MAX_PLAUSIBLE_TOKENS = 200_000_000
+
 
 @dataclass
 class Usage:
@@ -157,38 +170,54 @@ def parse_usage(text: str) -> Usage:
     Claude/Codex output formats are not a stable API, so this intentionally
     accepts both JSON result lines and human-readable summaries such as
     ``tokens used`` followed by a number. Missing fields remain ``None``.
+
+    Scanning is scoped to the END of the output (where trailers live): JSON
+    over the last ``_JSON_SCAN_LINES``, regex fallbacks over the last
+    ``_REGEX_SCAN_LINES``. Cost matches require an explicit ``cost`` label —
+    a bare dollar amount in the child's prose is not a spend record — and
+    implausibly large values are dropped as mis-parses.
     """
     text = text or ""
-    usage = _parse_json_usage(text)
+    all_lines = text.splitlines()
+    json_text = "\n".join(all_lines[-_JSON_SCAN_LINES:])
+    tail = "\n".join(all_lines[-_REGEX_SCAN_LINES:])
+    usage = _parse_json_usage(json_text)
     if usage.tokens_in is None:
         usage.tokens_in = _first_not_none(
-            _last_int(rf"\binput(?:\s+tokens?)?\s*[:=]\s*{_NUM}", text),
-            _last_int(rf"{_NUM}\s+input(?:\s+tokens?)?\b", text),
+            _last_int(rf"\binput(?:\s+tokens?)?\s*[:=]\s*{_NUM}", tail),
+            _last_int(rf"{_NUM}[ \t]+input(?:\s+tokens?)?\b", tail),
         )
     if usage.tokens_out is None:
         usage.tokens_out = _first_not_none(
-            _last_int(rf"\boutput(?:\s+tokens?)?\s*[:=]\s*{_NUM}", text),
-            _last_int(rf"{_NUM}\s+output(?:\s+tokens?)?\b", text),
+            _last_int(rf"\boutput(?:\s+tokens?)?\s*[:=]\s*{_NUM}", tail),
+            _last_int(rf"{_NUM}[ \t]+output(?:\s+tokens?)?\b", tail),
         )
     if usage.tokens_total is None:
         usage.tokens_total = _first_not_none(
-            _last_int(rf"(?m)^\s*total\s+tokens?\s*[:=]\s*{_NUM}", text),
-            _last_int(rf"(?m)^\s*tokens(?:\s+used)?\s*[:=]\s*{_NUM}", text),
-            _last_int(rf"{_NUM}\s+tokens\s+used\b", text),
+            _last_int(rf"(?m)^\s*total\s+tokens?\s*[:=]\s*{_NUM}", tail),
+            _last_int(rf"(?m)^\s*tokens(?:\s+used)?\s*[:=]\s*{_NUM}", tail),
+            # Same-line only: a number ending one line followed by a
+            # "tokens used" heading on the next is NOT a trailer pair.
+            _last_int(rf"{_NUM}[ \t]+tokens[ \t]+used\b", tail),
         )
     if usage.tokens_total is None:
-        lines = [ln.strip() for ln in text.splitlines()]
+        lines = [ln.strip() for ln in tail.splitlines()]
         for i, line in enumerate(lines[:-1]):
             if line.lower() == "tokens used":
                 usage.tokens_total = _intish(lines[i + 1])
     if usage.cost_usd is None:
-        usage.cost_usd = _first_not_none(
-            _last_float(
-                rf"\b(?:total[_\s-]*)?cost(?:[_\s-]*usd)?\s*[:=]\s*\$?\s*{_NUM}",
-                text,
-            ),
-            _last_float(rf"\$\s*{_NUM}\s*(?:usd)?", text),
+        usage.cost_usd = _last_float(
+            rf"\b(?:total[_\s-]*)?cost(?:[_\s-]*usd)?\s*[:=]\s*\$?\s*{_NUM}",
+            tail,
         )
+    for attr in ("tokens_in", "tokens_out", "tokens_total"):
+        v = getattr(usage, attr)
+        if v is not None and not (0 <= v <= _MAX_PLAUSIBLE_TOKENS):
+            setattr(usage, attr, None)
+    if usage.cost_usd is not None and not (
+        0 <= usage.cost_usd <= _MAX_PLAUSIBLE_COST_USD
+    ):
+        usage.cost_usd = None
     if usage.tokens_total is None and (
         usage.tokens_in is not None or usage.tokens_out is not None
     ):

--- a/threadkeeper/candidate_reviewer.py
+++ b/threadkeeper/candidate_reviewer.py
@@ -46,7 +46,7 @@ from .config import (
 )
 from .db import get_db
 from .helpers import daemon_sleep, single_flight_lock
-from . import identity
+from . import daemon_state, identity
 
 logger = logging.getLogger(__name__)
 
@@ -295,11 +295,13 @@ def _review_spawn_lock():
 # Synchronous pass + daemon loop
 # ──────────────────────────────────────────────────────────────────────
 
-def run_review_pass(force: bool = False) -> str:
+def run_review_pass(force: bool = False, *, scheduled: bool = False) -> str:
     """Execute one candidate review pass synchronously.
 
     Returns a short status string:
       - 'disabled'             — env knob off and not forced
+      - 'not_due'              — scheduled tick, but another server already
+                                 ran this loop within the interval
       - 'below_threshold n=X'  — fewer than CANDIDATE_REVIEW_MIN
                                  pending; skip the spawn
       - 'spawned task_id=…'    — reviewer child launched
@@ -307,6 +309,10 @@ def run_review_pass(force: bool = False) -> str:
     """
     if CANDIDATE_REVIEW_INTERVAL_S <= 0 and not force:
         return "disabled"
+    if not daemon_state.claim_pass(
+        "candidate_review", CANDIDATE_REVIEW_INTERVAL_S, scheduled=scheduled,
+    ):
+        return "not_due"
     with _review_spawn_lock() as locked:
         if not locked:
             return "candidate_review_running n=1 (single-flight lock)"
@@ -377,7 +383,7 @@ def _serve_loop() -> None:
     """Daemon body. Sleep → tick → sleep, until process dies."""
     while True:
         try:
-            run_review_pass()
+            run_review_pass(scheduled=True)
         except Exception:
             logger.debug("candidate_reviewer tick failed", exc_info=True)
         daemon_sleep(CANDIDATE_REVIEW_INTERVAL_S)

--- a/threadkeeper/config.py
+++ b/threadkeeper/config.py
@@ -243,6 +243,11 @@ class Settings(BaseSettings):
         ),
     )
     memory_guard_cooldown_s: int = 300
+    # Reclaim guard: skip unloading the embedding model when it was used
+    # within this window. An active ingester lazily reloads the model seconds
+    # after an unload, so trimming a hot model is net-negative (fresh copy
+    # resident while the freed arenas are still mapped). 0 disables the guard.
+    memory_guard_embed_hot_s: float = 300.0
 
     # ── Auto-review ──────────────────────────────────────────────────────────
     auto_review: bool = Field(
@@ -658,6 +663,7 @@ def _derive_constants(s: "Settings") -> dict:
         "MEMORY_GUARD_RETIRE_LIVE": s.memory_guard_retire_live,
         "MEMORY_GUARD_NOTIFY": s.memory_guard_notify,
         "MEMORY_GUARD_COOLDOWN_S": s.memory_guard_cooldown_s,
+        "MEMORY_GUARD_EMBED_HOT_S": s.memory_guard_embed_hot_s,
         "SHADOW_REVIEW_INTERVAL_S": s.shadow_review_interval_s,
         "SHADOW_REVIEW_WINDOW_S": s.shadow_review_window_s,
         "SHADOW_REVIEW_MIN_CHARS": s.shadow_review_min_chars,

--- a/threadkeeper/curator.py
+++ b/threadkeeper/curator.py
@@ -65,7 +65,7 @@ from .config import (
 )
 from .db import get_db
 from .helpers import daemon_sleep, single_flight_lock
-from . import identity, lessons
+from . import daemon_state, identity, lessons
 from .curator_snapshots import (
     PASS_ID_ENV,
     SNAPSHOT_DIR_ENV,
@@ -624,12 +624,14 @@ def _curator_spawn_lock():
 # Synchronous pass + daemon loop
 # ──────────────────────────────────────────────────────────────────────
 
-def run_curator_pass(force: bool = False) -> str:
+def run_curator_pass(force: bool = False, *, scheduled: bool = False) -> str:
     """Execute one curator pass synchronously. Used by the daemon AND
     by the MCP tool for manual triggering / testing.
 
     Returns a short status string for observability:
       - 'disabled'        — env knob off and not forced
+      - 'not_due'         — scheduled tick, but another server already ran
+                            this loop within the interval (daemon_state)
       - 'curator_running n=…' — a curator child is already running; skip
       - 'below_threshold' — fewer than CURATOR_MIN_LESSONS lessons; skip
       - 'unchanged_inventory' — latest complete inventory already reviewed
@@ -638,6 +640,10 @@ def run_curator_pass(force: bool = False) -> str:
     """
     if CURATOR_INTERVAL_S <= 0 and not force:
         return "disabled"
+    if not daemon_state.claim_pass(
+        "curator", CURATOR_INTERVAL_S, scheduled=scheduled,
+    ):
+        return "not_due"
 
     # Single-flight: the flock makes the running-children check + spawn atomic
     # across every MCP server process, so two ticks (or a tick racing a manual
@@ -828,7 +834,7 @@ def _serve_loop() -> None:
     """Daemon body. Sleep → tick → sleep, until process dies."""
     while True:
         try:
-            run_curator_pass()
+            run_curator_pass(scheduled=True)
         except Exception:
             logger.debug("curator tick failed", exc_info=True)
         daemon_sleep(CURATOR_INTERVAL_S)

--- a/threadkeeper/daemon_state.py
+++ b/threadkeeper/daemon_state.py
@@ -1,0 +1,97 @@
+"""Cross-process daemon cadence gate (persisted last-run per loop).
+
+Every MCP server process runs its own copy of each interval daemon, and each
+copy keeps its schedule in process memory. A freshly started server therefore
+considers every daemon "overdue" and fires it immediately — with several CLI
+sessions open, an "every 3 days" curator can run dozens of times a day (one
+pass per new server start), and the single-flight lock only stops *concurrent*
+passes, not frequent sequential ones.
+
+This module persists per-daemon last-run timestamps in the shared DB so the
+cadence survives process churn. The claim is one atomic upsert: whichever
+process claims first wins the slot; everyone else sees "not due" until the
+interval elapses. Scheduled loop ticks claim with `scheduled=True`; manual /
+tool-invoked passes bypass the gate but still record the run so the next
+scheduled fire lands a full interval later.
+"""
+from __future__ import annotations
+
+import logging
+import sqlite3
+import time
+
+logger = logging.getLogger(__name__)
+
+# A scheduled tick is due when the stored last run is at least this fraction
+# of the interval old. `daemon_sleep()` jitters ticks by ±15%, so requiring
+# the full interval would reject every early wake-up and drift the effective
+# cadence well past the knob; 0.8 absorbs the jitter while still collapsing
+# the every-new-server refire into one pass per interval.
+_DUE_FRACTION = 0.8
+
+
+def claim_pass(
+    name: str,
+    interval_s: float,
+    *,
+    scheduled: bool = False,
+    conn: sqlite3.Connection | None = None,
+    now: float | None = None,
+) -> bool:
+    """Record a pass start; for scheduled ticks, only when the interval elapsed.
+
+    Returns True when the caller should run the pass. The scheduled path is a
+    single atomic upsert (WAL serializes writers), so two servers waking at the
+    same moment cannot both win the slot. Fail-open: any storage error grants
+    the claim — worst case is the pre-gate behavior.
+    """
+    ts = int(now if now is not None else time.time())
+    try:
+        if conn is None:
+            from .db import get_db
+
+            conn = get_db()
+        if not scheduled:
+            conn.execute(
+                "INSERT INTO daemon_state(name, last_run_at) VALUES(?, ?) "
+                "ON CONFLICT(name) DO UPDATE SET "
+                "last_run_at=excluded.last_run_at",
+                (name, ts),
+            )
+            conn.commit()
+            return True
+        try:
+            gap = max(0.0, float(interval_s)) * _DUE_FRACTION
+        except (TypeError, ValueError):
+            gap = 0.0
+        cur = conn.execute(
+            "INSERT INTO daemon_state(name, last_run_at) VALUES(?, ?) "
+            "ON CONFLICT(name) DO UPDATE SET "
+            "last_run_at=excluded.last_run_at "
+            "WHERE excluded.last_run_at - daemon_state.last_run_at >= ?",
+            (name, ts, gap),
+        )
+        conn.commit()
+        return bool(cur.rowcount)
+    except sqlite3.Error:
+        logger.debug("daemon_state claim failed for %r", name, exc_info=True)
+        return True
+
+
+def last_run_at(
+    name: str, conn: sqlite3.Connection | None = None
+) -> int | None:
+    """Stored last-run timestamp for a loop, or None when it never ran."""
+    try:
+        if conn is None:
+            from .db import get_db
+
+            conn = get_db()
+        row = conn.execute(
+            "SELECT last_run_at FROM daemon_state WHERE name=?", (name,)
+        ).fetchone()
+    except sqlite3.Error:
+        return None
+    if row is None:
+        return None
+    return int(row[0])

--- a/threadkeeper/db.py
+++ b/threadkeeper/db.py
@@ -441,6 +441,15 @@ CREATE TABLE IF NOT EXISTS resource_controls (
     result        TEXT
 );
 
+-- Cross-process daemon cadence: persisted last-run per interval loop, so a
+-- freshly started server doesn't consider every daemon overdue and refire it.
+-- Claimed atomically by daemon_state.claim_pass(); single-flight locks handle
+-- concurrency, this table handles frequency.
+CREATE TABLE IF NOT EXISTS daemon_state (
+    name        TEXT PRIMARY KEY,
+    last_run_at INTEGER NOT NULL
+);
+
 -- Shared GitHub API rate-limit/cooldown ledger. Roadmap automation uses this
 -- across foreground status processes, reviewer/applier daemons, and spawned
 -- gh-wrapper children so one account-level throttle stops all workers.

--- a/threadkeeper/dialectic_miner.py
+++ b/threadkeeper/dialectic_miner.py
@@ -17,7 +17,7 @@ import time
 from .config import DIALECTIC_MINE_INTERVAL_S
 from .db import get_db
 from .helpers import daemon_sleep, resolve_ingest_watermark
-from . import identity
+from . import daemon_state, identity
 from .identity import _ensure_session, _emit
 
 logger = logging.getLogger(__name__)
@@ -345,12 +345,18 @@ def _preceding_context(conn: sqlite3.Connection, session_id: str,
     return row["content"][:_CONTEXT_MAX]
 
 
-def run_mine_pass(force: bool = False) -> str:
+def run_mine_pass(force: bool = False, *, scheduled: bool = False) -> str:
     """Capture new user replies since the cursor. Returns
-    'ok captured=N skipped=M' / 'no_user_dialog' / 'disabled'."""
+    'ok captured=N skipped=M' / 'no_user_dialog' / 'disabled' / 'not_due'
+    (scheduled tick, another server ran this loop within the interval)."""
     if DIALECTIC_MINE_INTERVAL_S <= 0 and not force:
         return "disabled"
     conn = get_db()
+    if not daemon_state.claim_pass(
+        "dialectic_mine", DIALECTIC_MINE_INTERVAL_S,
+        scheduled=scheduled, conn=conn,
+    ):
+        return "not_due"
     _ensure_session(conn)
     now = int(time.time())
     cursor = _last_mine_rowid(conn)
@@ -422,7 +428,7 @@ def run_mine_pass(force: bool = False) -> str:
 def _serve_loop() -> None:
     while True:
         try:
-            run_mine_pass()
+            run_mine_pass(scheduled=True)
         except Exception:
             logger.debug("dialectic_miner tick failed", exc_info=True)
         daemon_sleep(DIALECTIC_MINE_INTERVAL_S)

--- a/threadkeeper/dialectic_validator.py
+++ b/threadkeeper/dialectic_validator.py
@@ -25,7 +25,7 @@ from .config import (
 )
 from .db import get_db
 from .helpers import daemon_sleep, single_flight_lock
-from . import identity
+from . import daemon_state, identity
 from .identity import _ensure_session
 
 logger = logging.getLogger(__name__)
@@ -540,10 +540,17 @@ def _running_validator_children(conn: sqlite3.Connection) -> list[str]:
     return running
 
 
-def run_validate_pass(force: bool = False) -> str:
+def run_validate_pass(force: bool = False, *, scheduled: bool = False) -> str:
+    """One validate pass. A scheduled tick returns 'not_due' when another
+    server already ran this loop within the interval (daemon_state)."""
     if DIALECTIC_VALIDATE_INTERVAL_S <= 0 and not force:
         return "disabled"
     conn = get_db()
+    if not daemon_state.claim_pass(
+        "dialectic_validate", DIALECTIC_VALIDATE_INTERVAL_S,
+        scheduled=scheduled, conn=conn,
+    ):
+        return "not_due"
     _ensure_session(conn)
     now = int(time.time())
     _release_finished_claims(conn, now)
@@ -632,7 +639,7 @@ def run_validate_pass(force: bool = False) -> str:
 def _serve_loop() -> None:
     while True:
         try:
-            run_validate_pass()
+            run_validate_pass(scheduled=True)
         except Exception:
             logger.debug("dialectic_validator tick failed", exc_info=True)
         daemon_sleep(DIALECTIC_VALIDATE_INTERVAL_S)

--- a/threadkeeper/embeddings.py
+++ b/threadkeeper/embeddings.py
@@ -16,6 +16,7 @@ backfilled to vec0 lazily by the ingester.
 import logging
 import sqlite3
 import threading
+import time
 from typing import Optional
 
 from .config import (
@@ -69,6 +70,7 @@ def _vec_dim_ok(emb_blob: bytes) -> bool:
 
 _model = None
 _model_lock = threading.RLock()
+_last_used_at = 0.0
 
 def _get_model():
     """Lazily load and cache the embedding model for the active backend.
@@ -94,6 +96,16 @@ def model_loaded() -> bool:
     """True when this process currently holds the embedding model in RAM."""
     with _model_lock:
         return _model is not None
+
+
+def last_used_at() -> float:
+    """Wall-clock time of this process's last encode through the model.
+
+    Lets the memory guard tell a HOT model apart from a cold one: with an
+    active ingester, an unloaded model is lazily reloaded within seconds, so
+    trimming it is net-negative (fresh copy resident while the freed arenas
+    are still mapped). 0.0 when the model was never used."""
+    return _last_used_at
 
 
 def unload_model() -> bool:
@@ -125,10 +137,12 @@ def _encode(texts: list[str]):
     by the vec0 and legacy paths equals cosine similarity, regardless of
     whether the backend already normalizes.
     """
+    global _last_used_at
     with _model_lock:
         m = _get_model()
         if m is None:
             return None
+        _last_used_at = time.time()
         import numpy as np  # type: ignore
         if EMBED_BACKEND == "sentence-transformers":
             arr = np.asarray(m.encode(list(texts)), dtype="float32")

--- a/threadkeeper/extract_daemon.py
+++ b/threadkeeper/extract_daemon.py
@@ -32,7 +32,7 @@ import time
 from .config import EXTRACT_INTERVAL_S, EXTRACT_WINDOW_MIN
 from .db import get_db
 from .helpers import daemon_sleep
-from . import identity
+from . import daemon_state, identity
 
 logger = logging.getLogger(__name__)
 
@@ -71,17 +71,22 @@ def _record_extract_pass(conn: sqlite3.Connection,
         logger.debug("extract_daemon: failed to record pass", exc_info=True)
 
 
-def run_extract_pass(force: bool = False) -> str:
+def run_extract_pass(force: bool = False, *, scheduled: bool = False) -> str:
     """Execute one extract pass synchronously. Used by the daemon AND by
     the MCP tool for manual triggering.
 
     Returns the same status string `extract_recent` returns ("ok
     window=… scanned=… verbatim=… distill=… concept=… note=…
-    skipped_existing=…" or "no_dialog window=…m"). Plus advances the
-    `extract_pass` cursor for telemetry.
+    skipped_existing=…" or "no_dialog window=…m"), or 'not_due' for a
+    scheduled tick when another server already ran this loop within the
+    interval. Plus advances the `extract_pass` cursor for telemetry.
     """
     if EXTRACT_INTERVAL_S <= 0 and not force:
         return "disabled"
+    if not daemon_state.claim_pass(
+        "extract", EXTRACT_INTERVAL_S, scheduled=scheduled,
+    ):
+        return "not_due"
     # Late import — tools.extract registers MCP tools at import time, and
     # the daemon module loads before all tools are registered.
     from .tools.extract import extract_recent
@@ -100,7 +105,7 @@ def _serve_loop() -> None:
     """Daemon body. Sleep → tick → sleep, until process dies."""
     while True:
         try:
-            run_extract_pass()
+            run_extract_pass(scheduled=True)
         except Exception:
             logger.debug("extract_daemon tick failed", exc_info=True)
         daemon_sleep(EXTRACT_INTERVAL_S)

--- a/threadkeeper/memory_guard.py
+++ b/threadkeeper/memory_guard.py
@@ -23,6 +23,7 @@ from .config import (
     MEMORY_GUARD_AGG_KILL_MB,
     MEMORY_GUARD_AGG_WARN_MB,
     MEMORY_GUARD_COOLDOWN_S,
+    MEMORY_GUARD_EMBED_HOT_S,
     MEMORY_GUARD_KILL_MB,
     MEMORY_GUARD_NOTIFY,
     MEMORY_GUARD_POLL_S,
@@ -41,6 +42,18 @@ logger = logging.getLogger(__name__)
 
 _started = False
 _last_notify_at: dict[tuple[int, str], float] = {}
+
+# Reclaim effectiveness back-off. On this allocator stack (macOS +
+# fastembed/ONNX) an unload can be net-negative: gc.collect() re-faults
+# OS-compressed pages back to resident, and with an active ingester the model
+# reloads within seconds while the freed arenas are still mapped. Observed in
+# production as every reclaim ADDING 200-330MB, 2000+ times a week. When a
+# reclaim frees nothing, back off exponentially instead of thrash-repeating
+# on every cooldown tick; an effective reclaim resets the streak.
+_RECLAIM_BACKOFF_BASE_S = 1800.0
+_RECLAIM_BACKOFF_MAX_S = 4 * 3600.0
+_reclaim_backoff_until = 0.0
+_reclaim_fail_streak = 0
 
 
 def _rss_mb(p: dict) -> int:
@@ -206,13 +219,54 @@ def _empty_torch_caches() -> list[str]:
     return actions
 
 
-def reclaim_memory(reason: str = "manual") -> dict:
+def reclaim_memory(reason: str = "manual", force: bool = False) -> dict:
     """Best-effort local trim: unload embeddings, clear caches, run GC.
 
     This cannot guarantee RSS shrinkage because Python/PyTorch allocators may
     retain arenas for reuse. It does make heavyweight objects collectible and
     asks the OS allocator to release free pages where supported.
+
+    Two guards keep the trim from going net-negative: a HOT embedding model
+    (used within MEMORY_GUARD_EMBED_HOT_S) is never unloaded — an active
+    ingester would reload a fresh copy seconds later while the freed arenas
+    are still resident — and after a reclaim that freed nothing the process
+    backs off exponentially. `force=True` (manual tool calls) bypasses both.
     """
+    global _reclaim_backoff_until, _reclaim_fail_streak
+    now = time.time()
+    if not force:
+        skip = None
+        if now < _reclaim_backoff_until:
+            skip = (
+                f"backoff({int(_reclaim_backoff_until - now)}s_left"
+                f"_after_{_reclaim_fail_streak}_ineffective)"
+            )
+        else:
+            try:
+                from . import embeddings
+                if embeddings.model_loaded() and (
+                    now - embeddings.last_used_at() < MEMORY_GUARD_EMBED_HOT_S
+                ):
+                    skip = "model_hot"
+            except Exception:
+                logger.debug(
+                    "memory_guard: embed-hot check failed", exc_info=True
+                )
+        if skip:
+            rss = _pid_rss_mb(os.getpid())
+            _log_line(
+                f"{int(now)} reclaim_skip pid={os.getpid()} rss={rss}MB "
+                f"reason={reason} skip={skip}"
+            )
+            return {
+                "pid": os.getpid(),
+                "reason": reason,
+                "before_mb": rss,
+                "after_mb": rss,
+                "freed_mb": 0,
+                "actions": [f"skipped:{skip}"],
+                "skipped": skip,
+            }
     before = _pid_rss_mb(os.getpid())
     actions: list[str] = []
     try:
@@ -237,21 +291,33 @@ def reclaim_memory(reason: str = "manual") -> dict:
     actions.append(f"gc.collect={collected}")
     actions.extend(_allocator_pressure_relief())
     after = _pid_rss_mb(os.getpid())
+    freed = before - after
+    if freed <= 0 and before > 0:
+        _reclaim_fail_streak += 1
+        backoff = min(
+            _RECLAIM_BACKOFF_MAX_S,
+            _RECLAIM_BACKOFF_BASE_S * (2 ** (_reclaim_fail_streak - 1)),
+        )
+        _reclaim_backoff_until = time.time() + backoff
+        actions.append(f"backoff={int(backoff)}s")
+    else:
+        _reclaim_fail_streak = 0
+        _reclaim_backoff_until = 0.0
     result = {
         "pid": os.getpid(),
         "reason": reason,
         "before_mb": before,
         "after_mb": after,
-        "freed_mb": max(0, before - after),
+        "freed_mb": max(0, freed),
         "actions": actions,
     }
     _log_line(
         f"{int(time.time())} reclaim pid={os.getpid()} "
-        f"before={before}MB after={after}MB reason={reason}"
+        f"before={before}MB after={after}MB freed={freed}MB reason={reason}"
     )
     _emit_event(
         "memory_reclaim", os.getpid(),
-        f"before={before}MB after={after}MB reason={reason}",
+        f"before={before}MB after={after}MB freed={freed}MB reason={reason}",
     )
     return result
 

--- a/threadkeeper/probe_daemon.py
+++ b/threadkeeper/probe_daemon.py
@@ -34,7 +34,7 @@ from pathlib import Path
 
 from .config import PROBE_INTERVAL_S, PROBE_COOLDOWN_S, TASK_LOG_DIR
 from .db import get_db
-from . import identity
+from . import daemon_state, identity
 from .identity import _detect_self_cid, _emit
 from .helpers import alive, single_flight_lock
 
@@ -208,12 +208,14 @@ def _spawn_probe_child(probe: sqlite3.Row) -> str:
     )
 
 
-def run_probe_pass(force: bool = False) -> str:
+def run_probe_pass(force: bool = False, *, scheduled: bool = False) -> str:
     """One probe pass. Phase 1: grade finished children's answers. Phase 2:
     spawn the next due probe (unless one is already running).
 
     Status strings (for observability / tests):
       'disabled'                     — knob off and not forced
+      'not_due'                      — scheduled tick, another server already
+                                       ran this loop within the interval
       'graded=N no_due'              — nothing due to spawn this tick
       'graded=N probe_child_running' — a probe child is still in flight
       'graded=N spawned …'           — launched the next probe child
@@ -222,6 +224,10 @@ def run_probe_pass(force: bool = False) -> str:
     if PROBE_INTERVAL_S <= 0 and not force:
         return "disabled"
     conn = get_db()
+    if not daemon_state.claim_pass(
+        "probe", PROBE_INTERVAL_S, scheduled=scheduled, conn=conn,
+    ):
+        return "not_due"
     now_t = int(time.time())
     graded = _grade_pending(conn)
 
@@ -260,7 +266,7 @@ def run_probe_pass(force: bool = False) -> str:
 def _serve_loop() -> None:
     while True:
         try:
-            run_probe_pass()
+            run_probe_pass(scheduled=True)
         except Exception:
             logger.debug("probe_daemon tick failed", exc_info=True)
         daemon_sleep(PROBE_INTERVAL_S)

--- a/threadkeeper/retention.py
+++ b/threadkeeper/retention.py
@@ -14,7 +14,7 @@ import sqlite3
 import threading
 import time
 
-from . import identity
+from . import daemon_state, identity
 from .config import (
     BACKGROUND_DAEMONS_ALLOWED,
     DIALOG_RETENTION_DAYS,
@@ -182,17 +182,23 @@ def _record_pass(conn: sqlite3.Connection, summary: str) -> None:
         logger.debug("retention: failed to record pass", exc_info=True)
 
 
-def run_retention_pass(force: bool = False) -> str:
+def run_retention_pass(force: bool = False, *, scheduled: bool = False) -> str:
     """Run one retention/compaction pass.
 
     Returns a compact status string. Destructive table pruning runs only for
     windows whose day knob is >0. `force=True` bypasses the daemon interval
     switch for tests/manual calls, but does not override individual windows.
+    A scheduled tick returns 'not_due' when another server already ran this
+    loop within the interval (daemon_state).
     """
     if RETENTION_INTERVAL_S <= 0 and not force:
         return "disabled"
 
     conn = get_db()
+    if not daemon_state.claim_pass(
+        "retention", RETENTION_INTERVAL_S, scheduled=scheduled, conn=conn,
+    ):
+        return "not_due"
     now = int(time.time())
     counts = {
         "dialog": _prune_dialog(conn, _age_cutoff(now, DIALOG_RETENTION_DAYS)),
@@ -245,7 +251,7 @@ def run_retention_pass(force: bool = False) -> str:
 def _serve_loop() -> None:
     while True:
         try:
-            run_retention_pass()
+            run_retention_pass(scheduled=True)
         except Exception:
             logger.debug("retention tick failed", exc_info=True)
         daemon_sleep(RETENTION_INTERVAL_S)

--- a/threadkeeper/shadow_review.py
+++ b/threadkeeper/shadow_review.py
@@ -49,7 +49,7 @@ from .harvest import (
     SPAWNED_SESSION_MARKERS as _SPAWNED_SESSION_MARKERS,
     harvest_exclusion_cte,
 )
-from . import identity
+from . import daemon_state, identity
 
 logger = logging.getLogger(__name__)
 
@@ -511,12 +511,14 @@ def shadow_telemetry(conn: sqlite3.Connection,
             "log_dir": str(log_dir)}
 
 
-def run_shadow_pass(force: bool = False) -> str:
+def run_shadow_pass(force: bool = False, *, scheduled: bool = False) -> str:
     """Execute one shadow pass synchronously. Used by the daemon AND by
     the MCP tool for manual triggering / testing.
 
     Returns a short status string for observability:
       - 'disabled'        — env knob off and not forced
+      - 'not_due'         — scheduled tick, but another server already ran
+                            this loop within the interval (daemon_state)
       - 'no_window'       — no fresh dialog since last cursor
       - 'too_short'       — window exists but < MIN_CHARS
       - 'spawned task_id=…' — evaluator child launched
@@ -525,6 +527,11 @@ def run_shadow_pass(force: bool = False) -> str:
     if SHADOW_REVIEW_INTERVAL_S <= 0 and not force:
         return "disabled"
     conn = get_db()
+    if not daemon_state.claim_pass(
+        "shadow_review", SHADOW_REVIEW_INTERVAL_S,
+        scheduled=scheduled, conn=conn,
+    ):
+        return "not_due"
     floor = _last_shadow_rowid(conn)
     dump, high_water, n_chars = _collect_window(
         conn, floor, SHADOW_REVIEW_WINDOW_S,
@@ -598,7 +605,7 @@ def _serve_loop() -> None:
     """Daemon body. Sleep → tick → sleep, until process dies."""
     while True:
         try:
-            run_shadow_pass()
+            run_shadow_pass(scheduled=True)
         except Exception:
             logger.debug("shadow_review tick failed", exc_info=True)
         daemon_sleep(SHADOW_REVIEW_INTERVAL_S)

--- a/threadkeeper/thread_janitor.py
+++ b/threadkeeper/thread_janitor.py
@@ -35,7 +35,7 @@ import time
 from .config import THREAD_JANITOR_INTERVAL_S, THREAD_IDLE_CLOSE_DAYS
 from .db import get_db
 from .helpers import daemon_sleep
-from . import identity
+from . import daemon_state, identity
 
 logger = logging.getLogger(__name__)
 
@@ -79,18 +79,25 @@ def _stale_threads(conn: sqlite3.Connection, cutoff: int) -> list[sqlite3.Row]:
         return []
 
 
-def run_janitor_pass(force: bool = False) -> str:
+def run_janitor_pass(force: bool = False, *, scheduled: bool = False) -> str:
     """One janitor pass: close every thread idle past the threshold via
     close_thread() (which fires the auto-review hook). Returns a short
     status string for observability:
 
       'disabled'        — knob off and not forced
+      'not_due'         — scheduled tick, another server already ran this
+                          loop within the interval (daemon_state)
       'no_stale'        — nothing past the idle threshold
       'closed=N'        — closed N stale threads
     """
     if THREAD_JANITOR_INTERVAL_S <= 0 and not force:
         return "disabled"
     conn = get_db()
+    if not daemon_state.claim_pass(
+        "thread_janitor", THREAD_JANITOR_INTERVAL_S,
+        scheduled=scheduled, conn=conn,
+    ):
+        return "not_due"
     now = int(time.time())
     cutoff = now - int(max(0.0, THREAD_IDLE_CLOSE_DAYS) * 86400)
     stale = _stale_threads(conn, cutoff)
@@ -130,7 +137,7 @@ def run_janitor_pass(force: bool = False) -> str:
 def _serve_loop() -> None:
     while True:
         try:
-            run_janitor_pass()
+            run_janitor_pass(scheduled=True)
         except Exception:
             logger.debug("thread_janitor tick failed", exc_info=True)
         daemon_sleep(THREAD_JANITOR_INTERVAL_S)

--- a/threadkeeper/tools/memory_guard.py
+++ b/threadkeeper/tools/memory_guard.py
@@ -118,7 +118,7 @@ def memory_guard_reclaim(scope: str = "self") -> str:
     scope = (scope or "self").strip().lower()
     if scope not in {"self", "all"}:
         return "ERR bad_scope (use self|all)"
-    result = memory_guard.reclaim_memory(reason=f"manual:{scope}")
+    result = memory_guard.reclaim_memory(reason=f"manual:{scope}", force=True)
     out = [
         f"self pid={result['pid']} before={result['before_mb']}MB "
         f"after={result['after_mb']}MB freed={result['freed_mb']}MB",


### PR DESCRIPTION
Phase-0 sanitation from a full-system audit — three steady-state churn sources that burn RAM, tokens, and disk around the clock. All root-caused against the live runtime (10 servers, ~3.4GB RSS, 2,355 reclaims/week, curator firing 51×/day).

## Changes

**1. Cross-process daemon cadence gate** (`daemon_state` table + `claim_pass`)
Every MCP server kept its loop schedule in process memory, so a freshly started server considered every interval daemon overdue and refired it — the single-flight flock only stops *concurrent* passes, not *frequent sequential* ones. Measured: an "every 3 days" curator ran **51 passes in 24h** (one per new CLI session, each writing a 20MB destructive snapshot), with matching amplification across probe/shadow/extract — ~128 LLM children and ~2.8M tokens/day. Now each scheduled tick claims its slot with one atomic upsert keyed by loop name; losers return `not_due`. Manual/tool passes bypass the gate but record the run, pushing the next scheduled fire a full interval out. Wired into shadow_review, curator, candidate_reviewer, extract, dialectic miner/validator, probe, thread_janitor, retention.

**2. Memory-reclaim guards** (`memory_guard.reclaim_memory`)
On this allocator stack an unload was net-negative: `gc.collect()` re-faulted OS-compressed pages resident, and with the 3s ingester active the model reloaded seconds later while freed arenas were still mapped — every reclaim *added* 200-330MB, ~2,350×/week of synchronized cross-process thrash (`before=574MB after=850MB` in the logs). Now a model used within `THREADKEEPER_MEMORY_GUARD_EMBED_HOT_S` (default 300s) is never unloaded, and a reclaim that frees nothing backs off exponentially (30min→4h). Manual `memory_guard_reclaim` forces through both guards.

**3. Spawn usage parsing** (`_spawn_wrap.parse_usage`)
Regex fallbacks scanned the whole captured transcript, so a child that merely *discussed* money recorded it as spend — a `$4,445` ad-spend figure landed in `cost_usd`, poisoning the 24h budget-admission sums. Scanning is now bounded to the trailing lines where CLI usage trailers print, the bare `$N` pattern is gone (an explicit `cost` label is required), number-before-label matches must be same-line, and implausible values (cost > \$500, tokens > 2×10⁸) are dropped.

## Tests
New `tests/test_daemon_state.py` (atomic claim, due-after-interval, manual bypass, cross-connection race) + reclaim hot-skip/back-off cases in `test_memory_guard.py` + prose-dollar / trailer-lookalike / implausible-value cases in `test_spawn_wrap.py`. Full suite green under `pytest --forked` (the CI path).

## Docs
CHANGELOG (Added/Fixed), README env table (`MEMORY_GUARD_EMBED_HOT_S`), ARCHITECTURE daemon-cadence section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)