### PR TITLE
feat: hot-start retention daemon on config enable

### DIFF
--- a/tests/test_config_watcher.py
+++ b/tests/test_config_watcher.py
@@ -193,6 +193,31 @@ def test_enable_transition_starts_daemon(tmp_path, monkeypatch):
     assert calls == ["started"]
 
 
+def test_enable_transition_starts_retention_daemon(tmp_path, monkeypatch):
+    """Enabling retention live (0 → >0) hot-starts its daemon, same as the
+    other loops — no server restart needed to begin pruning."""
+    # Ensure a clean 0 baseline regardless of the runner's own environment:
+    # a host that already exports THREADKEEPER_RETENTION_INTERVAL_S (e.g. it's
+    # set in the developer's ~/.claude/settings.json) would otherwise make the
+    # 0→>0 transition invisible at import time.
+    monkeypatch.delenv("THREADKEEPER_RETENTION_INTERVAL_S", raising=False)
+    pkg = _bootstrap(tmp_path, monkeypatch, shadow="0")
+    w = pkg["watcher"]
+    w.run_config_watch_pass()  # initialize (retention disabled by default)
+
+    from threadkeeper import retention
+    calls = []
+    monkeypatch.setattr(
+        retention, "start_retention_daemon", lambda: calls.append("started")
+    )
+    _write_env(pkg["settings_json"],
+               {"THREADKEEPER_SHADOW_REVIEW_INTERVAL_S": "0",
+                "THREADKEEPER_RETENTION_INTERVAL_S": "86400"})
+    w.run_config_watch_pass()
+    assert calls == ["started"]
+    assert pkg["config"].RETENTION_INTERVAL_S == 86400.0
+
+
 def test_interval_change_does_not_restart_running_daemon(tmp_path, monkeypatch):
     """600 → 900 is not an enable transition; the running loop self-adjusts."""
     pkg = _bootstrap(tmp_path, monkeypatch, shadow="600")

--- a/threadkeeper/config_watcher.py
+++ b/threadkeeper/config_watcher.py
@@ -75,6 +75,7 @@ _DAEMON_FOR_INTERVAL: dict[str, tuple[str, str]] = {
         "dialectic_miner", "start_dialectic_miner_daemon"),
     "DIALECTIC_VALIDATE_INTERVAL_S": (
         "dialectic_validator", "start_dialectic_validator_daemon"),
+    "RETENTION_INTERVAL_S": ("retention", "start_retention_daemon"),
 }
 
 


### PR DESCRIPTION
Follow-up to #209. That PR was squash-merged from a slightly stale head, so this one-line completion didn't ride along.

Adds `RETENTION_INTERVAL_S` to `config_watcher._DAEMON_FOR_INTERVAL` so flipping retention `0 → >0` in settings.json starts the daemon live — matching every other interval loop. Without it, retention alone needs a server restart to begin pruning (it's still wired in `identity._ensure_session`, so a restart does activate it; this just makes the live-enable path consistent).

Test hardened to clear any inherited `THREADKEEPER_RETENTION_INTERVAL_S` before bootstrap, so the `0 → >0` transition is visible regardless of the runner's environment (Claude Code injects the settings.json `env` block into subprocesses, which otherwise pre-sets the var and masks the transition).

Green under `pytest --forked` (test_config_watcher: 16 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)