### PR TITLE
fix: make codex-routed autonomous loops launch reliably

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -143,6 +143,9 @@
 # THREADKEEPER_SPAWN__LOOP__PROBE_RUNNER=claude
 # THREADKEEPER_SPAWN__LOOP__DIALECTIC_VALIDATOR=claude
 #   model pin per CLI or per role: THREADKEEPER_SPAWN__MODEL__<KEY>=<model>
+#   NOTE: a model must be valid for the CLI it resolves to. Pinning a Claude
+#   model (opus/sonnet/haiku) onto a role that runs on codex/gemini/etc. is
+#   rejected by that provider at runtime (HTTP 400); the startup validator warns.
 # THREADKEEPER_SPAWN__MODEL__CLAUDE=opus
 # THREADKEEPER_SPAWN__MODEL__CODEX=gpt-5.5
 # THREADKEEPER_SPAWN__MODEL__AGY="Gemini 3.1 Pro (High)"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ version bumps follow semver per the policy in
 
 ## [Unreleased]
 
+### Fixed
+
+- **Codex spawns pass `--skip-git-repo-check`.** `codex exec` refuses to run
+  ("Not inside a trusted directory and --skip-git-repo-check was not
+  specified") whenever the spawn cwd is not a trusted git worktree. Because the
+  child inherits the host server's cwd, the autonomous loops (shadow_observer,
+  probe_runner, …) failed intermittently — passing on git-rooted hosts, failing
+  elsewhere. The codex adapter now always passes the flag, so codex-routed
+  loops launch deterministically regardless of where the server started.
+
+- **Startup validator warns on a Claude model routed to a non-Claude CLI.** A
+  model pin like `THREADKEEPER_SPAWN__MODEL__CURATOR=opus` while the role
+  resolves to codex is silently rejected by the provider at runtime (HTTP 400),
+  so the loop burns a spawn on every tick and never runs. `summary_table` /
+  `audit_threadkeeper` now flag a Claude-family model (`opus`/`sonnet`/`haiku`/
+  `claude*`) whose effective CLI is not `claude`, catching the misconfig at
+  validation instead of runtime.
+
 ### Added
 
 - **Reserve-before-spawn admission and dialectic leases (#58).** `spawn()` now

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -332,6 +332,30 @@ def test_codex_register_mcp_writes_toml(tmp_path, monkeypatch):
     assert 'approval_mode = "approve"' in body
 
 
+def test_codex_spawn_argv_skips_git_repo_check(tmp_path, monkeypatch):
+    """`codex exec` refuses to run outside a trusted git worktree unless
+    --skip-git-repo-check is passed. The spawn cwd is inherited from the host
+    server, so without the flag the autonomous loops fail intermittently."""
+    pkg = _bootstrap(tmp_path, monkeypatch)
+    import threadkeeper.adapters.codex as codex_mod
+    monkeypatch.setattr(codex_mod.shutil, "which", lambda _bin: "/usr/local/bin/codex")
+
+    argv = pkg["codex"].spawn_argv("hi", model="gpt-5.5")
+    assert argv is not None
+    assert argv[:3] == ["/usr/local/bin/codex", "exec", "--skip-git-repo-check"]
+    assert argv[-1] == "-"
+    assert "-m" in argv and "gpt-5.5" in argv
+    # Default (non-bypass) path still sandboxes.
+    assert "--sandbox" in argv and "workspace-write" in argv
+
+    # Flag is present on the bypass path too.
+    argv_bypass = pkg["codex"].spawn_argv(
+        "hi", permission_mode="bypassPermissions"
+    )
+    assert "--skip-git-repo-check" in argv_bypass
+    assert "--dangerously-bypass-approvals-and-sandbox" in argv_bypass
+
+
 def test_codex_iter_messages_filters_developer_turns(tmp_path, monkeypatch):
     pkg = _bootstrap(tmp_path, monkeypatch)
     fp = tmp_path / "rollout-2026-05-14T10-00-00.jsonl"

--- a/tests/test_spawn_config.py
+++ b/tests/test_spawn_config.py
@@ -342,3 +342,47 @@ def test_summary_table_warns_unused_model_key(tmp_path, monkeypatch):
     assert "model=sonnet" in out
     assert "THREADKEEPER_SPAWN__MODEL__CLAUD='opus'" in out
     assert "not used by a supported CLI or startup role" in out
+
+
+def test_summary_table_warns_claude_model_on_non_claude_cli(tmp_path, monkeypatch):
+    """The exact misconfig that broke the live curator loop: a Claude model
+    pinned to a role that resolves to codex → provider 400 at runtime, which we
+    now surface as a startup warning."""
+    sc = _reset(monkeypatch, tmp_path, env={
+        "THREADKEEPER_SPAWN__DEFAULT": "codex",
+        "THREADKEEPER_SPAWN__MODEL__CURATOR": "opus",
+    })
+    out = sc.summary_table("codex")
+    assert "THREADKEEPER_SPAWN__MODEL__CURATOR='opus'" in out
+    assert "Claude-family model" in out
+    assert "codex" in out
+
+
+def test_summary_table_warns_claude_model_on_cli_keyed_pin(tmp_path, monkeypatch):
+    sc = _reset(monkeypatch, tmp_path, env={
+        "THREADKEEPER_SPAWN__MODEL__CODEX": "sonnet",
+    })
+    out = sc.summary_table("codex")
+    assert "THREADKEEPER_SPAWN__MODEL__CODEX='sonnet'" in out
+    assert "Claude-family model" in out
+
+
+def test_summary_table_no_mismatch_for_codex_model_on_codex(tmp_path, monkeypatch):
+    """The fixed config: a codex-valid model on codex draws no warning."""
+    sc = _reset(monkeypatch, tmp_path, env={
+        "THREADKEEPER_SPAWN__DEFAULT": "codex",
+        "THREADKEEPER_SPAWN__MODEL__CURATOR": "gpt-5.5",
+        "THREADKEEPER_SPAWN__MODEL__PROBE_RUNNER": "gpt-5.5",
+    })
+    out = sc.summary_table("codex")
+    assert "warning:" not in out
+
+
+def test_summary_table_no_mismatch_for_claude_model_on_claude(tmp_path, monkeypatch):
+    """opus on the claude CLI is correct — must NOT warn."""
+    sc = _reset(monkeypatch, tmp_path, env={
+        "THREADKEEPER_SPAWN__LOOP__CURATOR": "claude",
+        "THREADKEEPER_SPAWN__MODEL__CURATOR": "opus",
+    })
+    out = sc.summary_table("claude")
+    assert "warning:" not in out

--- a/threadkeeper/adapters/codex.py
+++ b/threadkeeper/adapters/codex.py
@@ -223,11 +223,20 @@ class CodexAdapter(CLIAdapter):
 
     def spawn_argv(self, prompt, *, model="", permission_mode="auto",
                    extra_allowed_tools="", mcp_config_path=None):
-        """Codex non-interactive: `codex exec [-m MODEL] -`.
+        """Codex non-interactive: `codex exec --skip-git-repo-check [-m MODEL] -`.
         Codex reads MCP servers from ~/.codex/config.toml which the
         thread-keeper-setup installer already wires up — no
         per-invocation MCP config file needed. Prompt text is supplied via
         stdin so large autonomous-loop inventories do not hit ARG_MAX.
+
+        `--skip-git-repo-check` is required because `codex exec` refuses to run
+        ("Not inside a trusted directory and --skip-git-repo-check was not
+        specified") whenever the spawn cwd is not a trusted git worktree. The
+        cwd is inherited from the spawning server, so without this flag the
+        autonomous loops fail intermittently — depending on where the host
+        server happened to launch — while `git`-rooted hosts pass. The child
+        is already isolated by the sandbox flag below and by the thread-keeper
+        permission model, so the repo-trust gate adds nothing here.
 
         Code-evolve children need to create branches/commits. Codex's default
         sandbox can write ordinary workspace files but blocks `.git` refs, so
@@ -237,7 +246,7 @@ class CodexAdapter(CLIAdapter):
         bin_path = shutil.which("codex")
         if not bin_path:
             return None
-        argv = [bin_path, "exec"]
+        argv = [bin_path, "exec", "--skip-git-repo-check"]
         if model:
             argv += ["-m", model]
         if permission_mode == "bypassPermissions":

--- a/threadkeeper/spawn_config.py
+++ b/threadkeeper/spawn_config.py
@@ -21,9 +21,21 @@ dialectic_validator. Resolution is case-insensitive.
 """
 from __future__ import annotations
 
+import re
 from typing import Optional
 
 from . import config
+
+# A model name that clearly belongs to Anthropic's Claude family. Used only to
+# warn when such a model is routed to a non-Claude CLI (e.g. `opus` on codex),
+# which a provider silently rejects at runtime with a 400 rather than at
+# config-validation time. Deliberately narrow to avoid false positives on
+# provider-neutral names.
+_CLAUDE_MODEL_RE = re.compile(r"^(?:opus|sonnet|haiku|claude)\b", re.IGNORECASE)
+
+
+def _looks_like_claude_model(model: str) -> bool:
+    return bool(isinstance(model, str) and _CLAUDE_MODEL_RE.match(model.strip()))
 
 SUPPORTED_CLIS = ("claude", "codex", "antigravity", "gemini", "copilot")
 CLI_ALIASES = {
@@ -155,6 +167,28 @@ def _spawn_warnings(active_cli: Optional[str]) -> list[str]:
                 f"{_env_suffix('THREADKEEPER_SPAWN__MODEL__', key)}="
                 f"{model!r} is not used by a supported CLI or startup role"
             )
+            continue
+        # Provider mismatch: a Claude-family model pinned onto a non-Claude CLI
+        # is silently rejected at runtime (e.g. `opus` on codex → HTTP 400). The
+        # effective CLI is the role's resolved agent for a role-keyed pin, or the
+        # key itself for a CLI-keyed pin. Surface it at validation instead.
+        if _looks_like_claude_model(model):
+            if role_key in {r.lower() for r in SUMMARY_ROLES} | set(
+                PREDEFINED_ROLE_PROMPTS
+            ):
+                effective_cli = resolve_agent(role_key, active_cli)
+            elif model_key in SUPPORTED_CLIS:
+                effective_cli = model_key
+            else:
+                effective_cli = ""
+            if effective_cli and effective_cli != "claude":
+                warnings.append(
+                    "  warning: "
+                    f"{_env_suffix('THREADKEEPER_SPAWN__MODEL__', key)}="
+                    f"{model!r} is a Claude-family model but resolves to CLI "
+                    f"{effective_cli!r}; that provider will reject it at "
+                    "runtime — pin a model that CLI supports"
+                )
     return warnings
 
 


### PR DESCRIPTION
The autonomous learning loops run on codex but were failing on **every tick** — found live while investigating "what are these running tasks": 15 loop children spawned by one session in 2h, almost all `rc=1`. Two independent root causes.

## 1. Codex trusted-directory failure (intermittent)
`codex exec` refuses to run with *"Not inside a trusted directory and --skip-git-repo-check was not specified"* whenever the spawn cwd isn't a trusted git worktree. The child inherits the host server's cwd, so loops passed on git-rooted hosts and failed elsewhere — non-deterministic by design. The codex adapter now always passes `--skip-git-repo-check` (on both the sandbox and bypass paths). The child is already isolated by the sandbox flag + thread-keeper's permission model, so the repo-trust gate added nothing.

## 2. Claude model pinned onto a codex role (silent 400)
`THREADKEEPER_SPAWN__MODEL__CURATOR=opus` while the role resolves to codex → the provider rejects `opus` at runtime with HTTP 400, so the curator loop never ran and re-spawned a dead child every pass. Routing was already fully env-driven, but nothing validated model↔CLI compatibility. `summary_table` / `audit_threadkeeper` now warn when a Claude-family model (`opus`/`sonnet`/`haiku`/`claude*`) resolves to a non-Claude CLI — catching it at config time instead of runtime.

The operator's live `.env` is corrected separately (curator + probe_runner repinned from `opus` / `"codex"` — the latter a CLI name, not a model — to `gpt-5.5`); verified it now resolves every role to codex/gpt-5.5 with zero warnings.

## Tests
- codex `spawn_argv` includes `--skip-git-repo-check` on sandbox and bypass paths (new).
- validator warns on claude-model→non-claude-cli (role-keyed and CLI-keyed), and stays silent for codex-model→codex and the correct claude-model→claude case (new).
- Full spawn/adapter suite green under `pytest --forked` (65 passed).

Activates on the next server restart, same as the phase-0 fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)