### PR TITLE
fix: gate sqlite migrations by user version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,13 @@ version bumps follow semver per the policy in
 
 ### Fixed
 
+- **SQLite schema migrations are version-gated (#59).** `get_db()` now uses
+  `PRAGMA user_version` and a `BEGIN IMMEDIATE` migration transaction so the
+  legacy column-migration list runs once per database version instead of on
+  every connection. Duplicate-column `ALTER TABLE` failures remain harmless,
+  but other migration `OperationalError`s are logged and raised instead of
+  being silently swallowed.
+
 - **Spawn usage parsing no longer ingests prose numbers as spend.**
   `_spawn_wrap.parse_usage` scoped its regex fallbacks to the whole captured
   output, so a child that merely *discussed* money recorded it as its own

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,6 +55,21 @@ python -m pytest
 Test isolation uses a tempdir DB per test, all daemons disabled via env
 (`THREADKEEPER_*_INTERVAL_S=0`). See `tests/conftest.py`.
 
+## Schema migrations
+
+SQLite schema changes live in `threadkeeper/db.py` and must be versioned with
+`CURRENT_SCHEMA_VERSION`.
+
+1. Add new baseline tables/indexes to `SCHEMA` for fresh installs.
+2. Add upgrade DDL/data backfills to the version-gated migration path, then
+   bump `CURRENT_SCHEMA_VERSION`.
+3. Keep migrations idempotent by intent. For legacy `ALTER TABLE ... ADD
+   COLUMN`, only duplicate-column errors may be ignored; any other
+   `sqlite3.OperationalError` should be logged and raised so a partial schema
+   does not masquerade as healthy.
+4. Add tests for v0 upgrade, version stamping, and any concurrency or data
+   backfill behavior the migration relies on.
+
 ## Adding a new CLI adapter
 
 1. Create `threadkeeper/adapters/<name>.py` exporting `ADAPTER`

--- a/README.md
+++ b/README.md
@@ -1130,6 +1130,12 @@ mode for multi-writer concurrency. Optional `notes_vec` / `dialog_vec`
 HNSW indexes through `sqlite-vec` for sub-linear semantic search;
 fallback to Python-side cosine when the extension is missing.
 
+Schema bootstrap uses SQLite `PRAGMA user_version`: a current database skips
+legacy `ALTER TABLE` migrations on later `get_db()` calls, while an old or
+fresh v0 database migrates once under a writer transaction and records the
+current version. Duplicate-column migrations are treated as the only expected
+no-op; other DDL errors are logged and raised.
+
 On POSIX systems, startup and `get_db()` harden the default local store
 best-effort: `~/.threadkeeper` is `0700`, while `db.sqlite`, SQLite
 `-wal`/`-shm` sidecars, `~/.threadkeeper/.env`, curator `REPORT-*.md`

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -16,7 +16,7 @@ threadkeeper/
 ├── _mcp.py            FastMCP singleton (shared @mcp.tool / .resource / .prompt registrar)
 ├── server.py          entry point: import all tools/ → mcp.run() (stdio)
 ├── config.py          pydantic-settings Settings ← ~/.threadkeeper/.env (DB_PATH, …)
-├── db.py              SCHEMA + migrations + WAL-knobs + sqlite-vec loader
+├── db.py              SCHEMA + user_version migrations + WAL-knobs + sqlite-vec loader
 ├── identity.py        per-process session + self-cid + daemon launchers
 ├── ingest.py          live ingest of jsonl transcripts + skill_usage backfill
 ├── verify_ingest.py   cross-CLI production verification — slot coverage + PASS/PARTIAL/FAIL verdict (issue #1)
@@ -137,6 +137,17 @@ startup and `get_db()` best-effort harden the default store:
 `~/.threadkeeper` is `0700`, while `db.sqlite`, SQLite `-wal`/`-shm`
 sidecars, `~/.threadkeeper/.env`, and curator `REPORT-*.md` files are
 `0600`. Logically six levels:
+
+`get_db()` gates baseline schema setup and legacy column migrations with
+SQLite `PRAGMA user_version`. Databases at the current version skip the
+historical `ALTER TABLE` list entirely; v0 databases acquire a
+`BEGIN IMMEDIATE` writer transaction, create baseline tables/indexes, apply
+legacy columns, run data backfills, then set `user_version` to the code's
+`CURRENT_SCHEMA_VERSION`. A second process that waited on the writer lock
+re-checks `user_version` before doing work, so only one process performs the
+migration. Duplicate-column `ALTER TABLE` failures are the only swallowed
+migration errors; any other `OperationalError` is logged and raised with the
+version left unchanged for a retry.
 
 1. **threads + notes** — the main state machine of working memory.
    Thread = an open question; note = a move in it (`move`/`failed`/`insight`/`open_q`).

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -136,6 +136,12 @@ remains a live question.
   claims the exact observation batch before constructing the prompt, releases
   claims on spawn errors, and relies on the existing stale-claim lease requeue
   after parent crashes.
+- SQLite schema versioning (#59): `get_db()` now gates baseline schema setup
+  and legacy column migrations on `PRAGMA user_version`, runs v0 upgrades under
+  a `BEGIN IMMEDIATE` writer transaction, re-checks the version after waiting
+  for another migrator, and records `CURRENT_SCHEMA_VERSION` on success.
+  Duplicate-column `ALTER TABLE` errors remain the only swallowed migration
+  no-op; other migration `OperationalError`s are logged and raised.
 
 ---
 
@@ -788,8 +794,8 @@ deduplicated against the issues above):
   confused (injection-prone) child can mass-create skills in one pass (#98).
 
 Also extended existing issues with verified file:line detail rather than filing
-anew: `get_db` re-runs the full schema + ~25 migrations per call and leaks
-connections (→ #59); the `project='subagents'` exclusion is dead across six
+anew: the `get_db` per-call migration issue was closed by schema versioning
+(#59); the `project='subagents'` exclusion is dead across six
 modules (→ #36); pid-reuse also hits `task_kill`/`_reap_finished_tasks` (→ #66);
 a SIGKILL'd `_spawn_wrap` leaves a budget row pinned (→ #64); applied markers key
 on issue number, not PR url (→ #51); the roadmap apply pass double-fetches the

--- a/tests/test_db_schema.py
+++ b/tests/test_db_schema.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+import logging
+import os
+import sqlite3
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+
+def test_get_db_sets_user_version_and_skips_legacy_alters(
+    fresh_mp, monkeypatch
+):
+    db = fresh_mp["db"]
+
+    conn = db.get_db()
+    assert conn.execute("PRAGMA user_version").fetchone()[0] == (
+        db.CURRENT_SCHEMA_VERSION
+    )
+    conn.close()
+
+    def fail_if_called(*_args, **_kwargs):
+        raise AssertionError("legacy column migration should be version-gated")
+
+    monkeypatch.setattr(db, "_apply_column_migration", fail_if_called)
+    conn = db.get_db()
+    assert conn.execute("PRAGMA user_version").fetchone()[0] == (
+        db.CURRENT_SCHEMA_VERSION
+    )
+    conn.close()
+
+
+def test_non_duplicate_column_migration_error_surfaces(
+    fresh_mp, monkeypatch, caplog
+):
+    db = fresh_mp["db"]
+    bad_ddl = "ALTER TABLE missing_table ADD COLUMN bad_column TEXT"
+    monkeypatch.setattr(db, "LEGACY_COLUMN_MIGRATIONS", (bad_ddl,))
+
+    with caplog.at_level(logging.WARNING, logger="threadkeeper.db"):
+        with pytest.raises(sqlite3.OperationalError, match="no such table"):
+            db.get_db()
+
+    assert "SQLite schema migration DDL failed" in caplog.text
+    assert bad_ddl in caplog.text
+
+
+def _subprocess_env(tmp_path: Path) -> dict[str, str]:
+    repo = Path(__file__).resolve().parents[1]
+    env = os.environ.copy()
+    env.update(
+        {
+            "THREADKEEPER_DB": str(tmp_path / "concurrent.sqlite"),
+            "CLAUDE_PROJECTS_DIR": str(tmp_path / "fake_claude_projects"),
+            "THREADKEEPER_DISABLE_BG_DAEMONS": "1",
+            "THREADKEEPER_AUTO_UPDATE_INTERVAL_S": "0",
+            "THREADKEEPER_SKILL_UPDATE_INTERVAL_S": "0",
+            "THREADKEEPER_INGEST_INTERVAL_S": "0",
+            "THREADKEEPER_INGEST_CAP": "0",
+            "THREADKEEPER_TASK_LOG_DIR": str(tmp_path / "tasks"),
+            "THREADKEEPER_CLIENT": "pytest",
+        }
+    )
+    env["PYTHONPATH"] = os.pathsep.join(
+        [str(repo), env["PYTHONPATH"]] if env.get("PYTHONPATH") else [str(repo)]
+    )
+    return env
+
+
+def test_concurrent_get_db_schema_migration_is_safe(tmp_path):
+    code = """
+import os
+import time
+from threadkeeper import db
+
+if os.environ.get("TK_SLOW_SCHEMA") == "1":
+    original = db._run_schema_migrations
+
+    def slow_schema_migrations(conn, from_version):
+        time.sleep(0.5)
+        return original(conn, from_version)
+
+    db._run_schema_migrations = slow_schema_migrations
+
+conn = db.get_db()
+version = conn.execute("PRAGMA user_version").fetchone()[0]
+retry_col = conn.execute(
+    "SELECT COUNT(*) FROM pragma_table_info('tasks') "
+    "WHERE name='retry_attempt'"
+).fetchone()[0]
+print(f"version={version} retry_attempt={retry_col}")
+"""
+    env = _subprocess_env(tmp_path)
+    repo = Path(__file__).resolve().parents[1]
+    slow_env = {**env, "TK_SLOW_SCHEMA": "1"}
+
+    first = subprocess.Popen(
+        [sys.executable, "-c", code],
+        cwd=repo,
+        env=slow_env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    time.sleep(0.1)
+    second = subprocess.Popen(
+        [sys.executable, "-c", code],
+        cwd=repo,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+
+    first_out, first_err = first.communicate(timeout=10)
+    second_out, second_err = second.communicate(timeout=10)
+
+    assert first.returncode == 0, first_err
+    assert second.returncode == 0, second_err
+    assert "retry_attempt=1" in first_out
+    assert "retry_attempt=1" in second_out
+
+    raw = sqlite3.connect(env["THREADKEEPER_DB"])
+    assert raw.execute("PRAGMA user_version").fetchone()[0] == 1
+    assert raw.execute("PRAGMA integrity_check").fetchone()[0] == "ok"
+    raw.close()

--- a/threadkeeper/db.py
+++ b/threadkeeper/db.py
@@ -2,6 +2,7 @@
 Imported by every tool module that needs DB access."""
 from __future__ import annotations
 
+from collections.abc import Iterator
 import logging
 import sqlite3
 
@@ -16,7 +17,15 @@ logger = logging.getLogger(__name__)
 # different dimension, set THREADKEEPER_EMBED_DIM AND drop & recreate the
 # *_vec tables; embeddings._vec_dim_ok warns loudly if a vector's width
 # doesn't match this. Re-exported here for callers that import db.EMBED_DIM.
-__all__ = ["EMBED_DIM", "get_db", "vec_available", "SCHEMA"]
+__all__ = [
+    "CURRENT_SCHEMA_VERSION",
+    "EMBED_DIM",
+    "get_db",
+    "vec_available",
+    "SCHEMA",
+]
+
+CURRENT_SCHEMA_VERSION = 1
 
 # sqlite-vec extension state. We probe once at first get_db() call and
 # cache the verdict. _VEC_AVAILABLE = True means vec0 virtual tables work
@@ -522,6 +531,197 @@ CREATE TRIGGER IF NOT EXISTS notes_fts_ad AFTER DELETE ON notes BEGIN
 END;
 """
 
+# Historical column migrations layered on top of the baseline SCHEMA.
+# Some columns are already present in new-table definitions; duplicate column
+# errors are the only expected no-op.
+LEGACY_COLUMN_MIGRATIONS = (
+    "ALTER TABLE threads ADD COLUMN claimed_at INTEGER",
+    "ALTER TABLE threads ADD COLUMN claimed_by_cid TEXT",
+    "ALTER TABLE signals ADD COLUMN task_id TEXT",
+    "ALTER TABLE sessions ADD COLUMN write_origin "
+    "TEXT NOT NULL DEFAULT 'foreground'",
+    "ALTER TABLE tasks ADD COLUMN rss_kb INTEGER",
+    "ALTER TABLE tasks ADD COLUMN rss_updated_at INTEGER",
+    "ALTER TABLE tasks ADD COLUMN tokens_in INTEGER",
+    "ALTER TABLE tasks ADD COLUMN tokens_out INTEGER",
+    "ALTER TABLE tasks ADD COLUMN tokens_total INTEGER",
+    "ALTER TABLE tasks ADD COLUMN cost_usd REAL",
+    "ALTER TABLE tasks ADD COLUMN duration_s INTEGER",
+    "ALTER TABLE tasks ADD COLUMN role TEXT",
+    "ALTER TABLE tasks ADD COLUMN write_origin TEXT",
+    "ALTER TABLE tasks ADD COLUMN permission_mode TEXT",
+    "ALTER TABLE tasks ADD COLUMN extra_allowed_tools TEXT",
+    "ALTER TABLE tasks ADD COLUMN capture_output INTEGER",
+    "ALTER TABLE tasks ADD COLUMN visible INTEGER",
+    "ALTER TABLE tasks ADD COLUMN slim INTEGER",
+    "ALTER TABLE tasks ADD COLUMN model TEXT",
+    "ALTER TABLE tasks ADD COLUMN effort TEXT",
+    "ALTER TABLE tasks ADD COLUMN append_system TEXT",
+    "ALTER TABLE tasks ADD COLUMN chosen_cli TEXT",
+    "ALTER TABLE tasks ADD COLUMN retry_of TEXT",
+    "ALTER TABLE tasks ADD COLUMN retry_root TEXT",
+    "ALTER TABLE tasks ADD COLUMN retry_attempt INTEGER NOT NULL DEFAULT 0",
+    "ALTER TABLE tasks ADD COLUMN timeout_respawned_as TEXT",
+    # Tier promotion machinery: discrete state machine over claims and skills.
+    "ALTER TABLE user_dialectic ADD COLUMN tier "
+    "TEXT NOT NULL DEFAULT 'hypothesis'",
+    "ALTER TABLE user_dialectic ADD COLUMN tier_changed_at INTEGER",
+    "ALTER TABLE user_dialectic ADD COLUMN valid_from INTEGER",
+    "ALTER TABLE user_dialectic ADD COLUMN valid_to INTEGER",
+    "ALTER TABLE skill_usage ADD COLUMN tier "
+    "TEXT NOT NULL DEFAULT 'hypothesis'",
+    "ALTER TABLE skill_usage ADD COLUMN tier_changed_at INTEGER",
+    # Weighted use counter on skills: foreground use counts separately from
+    # system-authored review-fork activity.
+    "ALTER TABLE skill_usage ADD COLUMN foreground_use_count "
+    "INTEGER NOT NULL DEFAULT 0",
+    "ALTER TABLE skill_usage ADD COLUMN wrong_count "
+    "INTEGER NOT NULL DEFAULT 0",
+    "ALTER TABLE skill_usage ADD COLUMN last_wrong_at INTEGER",
+    # Embedding backend tag. NULL = legacy sentence-transformers vectors.
+    "ALTER TABLE notes ADD COLUMN embed_backend TEXT",
+    "ALTER TABLE dialog_messages ADD COLUMN embed_backend TEXT",
+    # Dialectic validator lease columns.
+    "ALTER TABLE dialectic_observations ADD COLUMN claimed_at INTEGER",
+    "ALTER TABLE dialectic_observations ADD COLUMN claimed_by_task TEXT",
+    # Evolve triage state.
+    "ALTER TABLE evolve ADD COLUMN status TEXT NOT NULL DEFAULT 'pending'",
+    "ALTER TABLE evolve ADD COLUMN reviewed_at INTEGER",
+    "ALTER TABLE evolve ADD COLUMN review_reason TEXT",
+    # Concept dedup-on-write embedding columns.
+    "ALTER TABLE concepts ADD COLUMN embedding BLOB",
+    "ALTER TABLE concepts ADD COLUMN embed_backend TEXT",
+)
+
+POST_SCHEMA_INDEXES = (
+    "CREATE INDEX IF NOT EXISTS idx_dialectic_tier "
+    "ON user_dialectic(tier)",
+    "CREATE INDEX IF NOT EXISTS idx_dialectic_validity "
+    "ON user_dialectic(valid_from, valid_to)",
+    "CREATE INDEX IF NOT EXISTS idx_dialectic_obs_claimed "
+    "ON dialectic_observations(status, claimed_at)",
+    "CREATE INDEX IF NOT EXISTS idx_skill_usage_tier "
+    "ON skill_usage(tier)",
+    "CREATE INDEX IF NOT EXISTS idx_tasks_retry_root "
+    "ON tasks(retry_root)",
+    "CREATE INDEX IF NOT EXISTS idx_tasks_retry_of "
+    "ON tasks(retry_of)",
+)
+
+
+def _iter_sql_statements(script: str) -> Iterator[str]:
+    """Yield complete SQLite statements without breaking trigger bodies."""
+    buf: list[str] = []
+    for line in script.splitlines():
+        if not line.strip() and not buf:
+            continue
+        buf.append(line)
+        statement = "\n".join(buf).strip()
+        if sqlite3.complete_statement(statement):
+            yield statement
+            buf.clear()
+    if any(line.strip() for line in buf):
+        raise ValueError("incomplete schema SQL statement")
+
+
+def _user_version(conn: sqlite3.Connection) -> int:
+    row = conn.execute("PRAGMA user_version").fetchone()
+    return int(row[0])
+
+
+def _set_user_version(conn: sqlite3.Connection, version: int) -> None:
+    conn.execute(f"PRAGMA user_version = {int(version)}")
+
+
+def _is_duplicate_column_error(exc: sqlite3.OperationalError) -> bool:
+    return "duplicate column name" in str(exc).lower()
+
+
+def _apply_column_migration(conn: sqlite3.Connection, ddl: str) -> None:
+    try:
+        conn.execute(ddl)
+    except sqlite3.OperationalError as exc:
+        if _is_duplicate_column_error(exc):
+            return
+        logger.warning("SQLite schema migration DDL failed: %s", ddl)
+        raise
+
+
+def _backfill_schema_data(conn: sqlite3.Connection) -> None:
+    conn.execute(
+        "UPDATE user_dialectic SET valid_from=created_at "
+        "WHERE valid_from IS NULL"
+    )
+    conn.execute(
+        "UPDATE user_dialectic "
+        "SET valid_to=("
+        "  SELECT COALESCE(new.valid_from, new.created_at) "
+        "  FROM user_dialectic AS new "
+        "  WHERE new.id=user_dialectic.superseded_by"
+        ") "
+        "WHERE state='superseded' "
+        "  AND superseded_by IS NOT NULL "
+        "  AND valid_to IS NULL "
+        "  AND EXISTS ("
+        "    SELECT 1 FROM user_dialectic AS new "
+        "    WHERE new.id=user_dialectic.superseded_by"
+        "  )"
+    )
+
+
+def _run_schema_migrations(conn: sqlite3.Connection, from_version: int) -> None:
+    if from_version != 0:
+        raise RuntimeError(
+            f"unsupported SQLite schema version {from_version}; "
+            f"expected 0..{CURRENT_SCHEMA_VERSION}"
+        )
+
+    for statement in _iter_sql_statements(SCHEMA):
+        conn.execute(statement)
+    for ddl in LEGACY_COLUMN_MIGRATIONS:
+        _apply_column_migration(conn, ddl)
+    _backfill_schema_data(conn)
+    for idx in POST_SCHEMA_INDEXES:
+        conn.execute(idx)
+    _set_user_version(conn, CURRENT_SCHEMA_VERSION)
+
+
+def _ensure_schema(conn: sqlite3.Connection) -> None:
+    version = _user_version(conn)
+    if version == CURRENT_SCHEMA_VERSION:
+        return
+    if version > CURRENT_SCHEMA_VERSION:
+        raise RuntimeError(
+            f"database schema version {version} is newer than this "
+            f"thread-keeper build supports ({CURRENT_SCHEMA_VERSION})"
+        )
+
+    conn.execute("BEGIN IMMEDIATE")
+    try:
+        # Re-check after taking the writer lock. A concurrent process may have
+        # completed the migration while this connection waited.
+        version = _user_version(conn)
+        if version < CURRENT_SCHEMA_VERSION:
+            _run_schema_migrations(conn, version)
+        elif version > CURRENT_SCHEMA_VERSION:
+            raise RuntimeError(
+                f"database schema version {version} is newer than this "
+                f"thread-keeper build supports ({CURRENT_SCHEMA_VERSION})"
+            )
+        conn.commit()
+    except sqlite3.OperationalError:
+        logger.warning(
+            "SQLite schema migration failed; user_version remains below %s",
+            CURRENT_SCHEMA_VERSION,
+            exc_info=True,
+        )
+        conn.rollback()
+        raise
+    except Exception:
+        conn.rollback()
+        raise
+
+
 def get_db() -> sqlite3.Connection:
     global _VEC_AVAILABLE
     harden_storage_paths(
@@ -546,7 +746,7 @@ def get_db() -> sqlite3.Connection:
     vec_loaded = _try_load_vec(conn)
     if _VEC_AVAILABLE is None:
         _VEC_AVAILABLE = vec_loaded
-    conn.executescript(SCHEMA)
+    _ensure_schema(conn)
     if vec_loaded:
         # Create vec0 virtual tables side-by-side with the BLOB-embedding
         # ones. Existing data in notes.embedding / dialog_messages.embedding
@@ -574,136 +774,7 @@ def get_db() -> sqlite3.Connection:
             )
         except sqlite3.OperationalError as e:
             logger.debug("vec0 table creation skipped: %s", e)
-    # Lightweight column migrations. ALTER TABLE ADD COLUMN is idempotent-safe
-    # if we swallow OperationalError ("duplicate column name").
-    for ddl in (
-        "ALTER TABLE threads ADD COLUMN claimed_at INTEGER",
-        "ALTER TABLE threads ADD COLUMN claimed_by_cid TEXT",
-        "ALTER TABLE signals ADD COLUMN task_id TEXT",
-        "ALTER TABLE sessions ADD COLUMN write_origin "
-        "TEXT NOT NULL DEFAULT 'foreground'",
-        "ALTER TABLE tasks ADD COLUMN rss_kb INTEGER",
-        "ALTER TABLE tasks ADD COLUMN rss_updated_at INTEGER",
-        "ALTER TABLE tasks ADD COLUMN tokens_in INTEGER",
-        "ALTER TABLE tasks ADD COLUMN tokens_out INTEGER",
-        "ALTER TABLE tasks ADD COLUMN tokens_total INTEGER",
-        "ALTER TABLE tasks ADD COLUMN cost_usd REAL",
-        "ALTER TABLE tasks ADD COLUMN duration_s INTEGER",
-        "ALTER TABLE tasks ADD COLUMN role TEXT",
-        "ALTER TABLE tasks ADD COLUMN write_origin TEXT",
-        "ALTER TABLE tasks ADD COLUMN permission_mode TEXT",
-        "ALTER TABLE tasks ADD COLUMN extra_allowed_tools TEXT",
-        "ALTER TABLE tasks ADD COLUMN capture_output INTEGER",
-        "ALTER TABLE tasks ADD COLUMN visible INTEGER",
-        "ALTER TABLE tasks ADD COLUMN slim INTEGER",
-        "ALTER TABLE tasks ADD COLUMN model TEXT",
-        "ALTER TABLE tasks ADD COLUMN effort TEXT",
-        "ALTER TABLE tasks ADD COLUMN append_system TEXT",
-        "ALTER TABLE tasks ADD COLUMN chosen_cli TEXT",
-        "ALTER TABLE tasks ADD COLUMN retry_of TEXT",
-        "ALTER TABLE tasks ADD COLUMN retry_root TEXT",
-        "ALTER TABLE tasks ADD COLUMN retry_attempt INTEGER NOT NULL DEFAULT 0",
-        "ALTER TABLE tasks ADD COLUMN timeout_respawned_as TEXT",
-        # Tier promotion machinery — discrete state machine over claims
-        # and skills. Independent of the continuous confidence/state
-        # columns; tier is what gates downstream behavior (brief framing,
-        # curator archival, auto-action thresholds).
-        "ALTER TABLE user_dialectic ADD COLUMN tier "
-        "TEXT NOT NULL DEFAULT 'hypothesis'",
-        "ALTER TABLE user_dialectic ADD COLUMN tier_changed_at INTEGER",
-        "ALTER TABLE user_dialectic ADD COLUMN valid_from INTEGER",
-        "ALTER TABLE user_dialectic ADD COLUMN valid_to INTEGER",
-        "ALTER TABLE skill_usage ADD COLUMN tier "
-        "TEXT NOT NULL DEFAULT 'hypothesis'",
-        "ALTER TABLE skill_usage ADD COLUMN tier_changed_at INTEGER",
-        # Weighted use counter on skills: a foreground 'use' counts 1.0,
-        # background_review/shadow_review/curator 'use' counts 0.5. Lets
-        # tier promotion ignore self-generated activity (skills the
-        # system-itself used through review-forks).
-        "ALTER TABLE skill_usage ADD COLUMN foreground_use_count "
-        "INTEGER NOT NULL DEFAULT 0",
-        "ALTER TABLE skill_usage ADD COLUMN wrong_count "
-        "INTEGER NOT NULL DEFAULT 0",
-        "ALTER TABLE skill_usage ADD COLUMN last_wrong_at INTEGER",
-        # Embedding backend tag. NULL = legacy (sentence-transformers, pre-ONNX
-        # migration). New/recomputed rows carry 'onnx' or 'sentence-transformers'
-        # so `tk-migrate-embeddings` can find stale vectors and skip done ones.
-        "ALTER TABLE notes ADD COLUMN embed_backend TEXT",
-        "ALTER TABLE dialog_messages ADD COLUMN embed_backend TEXT",
-        # Dialectic validator lease: rows are still status='pending' until the
-        # child resolves them, but claimed rows are no longer visible backlog.
-        # If the child dies, the validator requeues stale claims by clearing
-        # these columns.
-        "ALTER TABLE dialectic_observations ADD COLUMN claimed_at INTEGER",
-        "ALTER TABLE dialectic_observations ADD COLUMN claimed_by_task TEXT",
-        # Evolve triage: the autonomous evolve reviewer moves a suggestion
-        # from 'pending' to 'promoted' (still relevant, surface it sharply
-        # for the foreground agent / human to APPLY) or 'dismissed' (dup /
-        # superseded / stale). The legacy `applied` flag stays for the human
-        # "I implemented this" mark. status default 'pending' so existing
-        # rows enter the queue.
-        "ALTER TABLE evolve ADD COLUMN status TEXT NOT NULL DEFAULT 'pending'",
-        "ALTER TABLE evolve ADD COLUMN reviewed_at INTEGER",
-        "ALTER TABLE evolve ADD COLUMN review_reason TEXT",
-        # Concept dedup-on-write: store the description embedding so the
-        # register/extract path can re-corroborate an equivalent invariant
-        # (cosine over `description`) and bump last_evidence_at instead of
-        # inserting a near-duplicate row. embed_backend tags the vector the
-        # same way notes/dialog_messages are tagged (NULL = no embedding).
-        "ALTER TABLE concepts ADD COLUMN embedding BLOB",
-        "ALTER TABLE concepts ADD COLUMN embed_backend TEXT",
-    ):
-        try:
-            conn.execute(ddl)
-        except sqlite3.OperationalError:
-            pass
-
-    try:
-        conn.execute(
-            "UPDATE user_dialectic SET valid_from=created_at "
-            "WHERE valid_from IS NULL"
-        )
-        conn.execute(
-            "UPDATE user_dialectic "
-            "SET valid_to=("
-            "  SELECT COALESCE(new.valid_from, new.created_at) "
-            "  FROM user_dialectic AS new "
-            "  WHERE new.id=user_dialectic.superseded_by"
-            ") "
-            "WHERE state='superseded' "
-            "  AND superseded_by IS NOT NULL "
-            "  AND valid_to IS NULL "
-            "  AND EXISTS ("
-            "    SELECT 1 FROM user_dialectic AS new "
-            "    WHERE new.id=user_dialectic.superseded_by"
-            "  )"
-        )
-    except sqlite3.OperationalError:
-        pass
-
-    # Indexes for tier-aware queries. Safe to repeat (IF NOT EXISTS).
-    for idx in (
-        "CREATE INDEX IF NOT EXISTS idx_dialectic_tier "
-        "ON user_dialectic(tier)",
-        "CREATE INDEX IF NOT EXISTS idx_dialectic_validity "
-        "ON user_dialectic(valid_from, valid_to)",
-        "CREATE INDEX IF NOT EXISTS idx_dialectic_obs_claimed "
-        "ON dialectic_observations(status, claimed_at)",
-        "CREATE INDEX IF NOT EXISTS idx_skill_usage_tier "
-        "ON skill_usage(tier)",
-        "CREATE INDEX IF NOT EXISTS idx_tasks_retry_root "
-        "ON tasks(retry_root)",
-        "CREATE INDEX IF NOT EXISTS idx_tasks_retry_of "
-        "ON tasks(retry_of)",
-    ):
-        try:
-            conn.execute(idx)
-        except sqlite3.OperationalError:
-            pass
-    try:
-        conn.commit()
-    except sqlite3.OperationalError:
-        pass
+    conn.commit()
     harden_storage_paths(
         DB_PATH,
         env_file=_ENV_FILE,


### PR DESCRIPTION
## Summary
- add CURRENT_SCHEMA_VERSION / PRAGMA user_version gating for schema bootstrap and legacy column migrations
- run v0 migrations under BEGIN IMMEDIATE with a post-lock version recheck, and only swallow duplicate-column ALTER errors
- document migration discipline and add focused schema-versioning regression tests

## Tests
- env -u THREADKEEPER_NO_EMBEDDINGS .venv/bin/python -m pytest -q (exit 0; project double-quiet config suppresses pass-count summary)
- env -u THREADKEEPER_NO_EMBEDDINGS .venv/bin/python -m pytest -o addopts='--strict-markers' (1117 passed, 1 skipped, 95 warnings)

Closes #59