### PR TITLE
feat: menu-bar env editor lists the full spawn-routing surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ version bumps follow semver per the policy in
 
 ## [Unreleased]
 
+### Changed
+
+- **Menu-bar env editor lists the full Spawn Routing surface.** The Spawn
+  Routing panel previously showed a hand-picked subset (default CLI, one loop
+  CLI, four model pins). It now generates every knob from the spawn-role list:
+  a **Spawn Routing** section (Default CLI + a CLI selector for each of the 8
+  loop roles), a **Spawn Models (per CLI)** section (claude / codex /
+  antigravity / gemini / copilot), and a **Spawn Models (per role)** section (a
+  per-role model override). Each row carries a plain-language description of
+  what the role does and its exact `THREADKEEPER_SPAWN__*` key; an unset value
+  renders as "Default" and is not written to `.env`.
+
 ### Fixed
 
 - **Codex spawns pass `--skip-git-repo-check`.** `codex exec` refuses to run

--- a/apps/macos-agent-status/ThreadKeeperAgentStatus.swift
+++ b/apps/macos-agent-status/ThreadKeeperAgentStatus.swift
@@ -210,7 +210,120 @@ private let roleModelChoices = (
     }
 }
 
-private let envSettingDefinitions: [EnvSettingDefinition] = [
+// Every autonomous loop that actually spawns a child agent. The env key
+// suffix is the role token; `activity` fills the human-readable descriptions so
+// the Spawn Routing panel lists every role explicitly (CLI + model per role)
+// instead of a hand-picked subset. Keep in sync with spawn_config.SUMMARY_ROLES
+// (the roles that reach a spawn() call-site).
+private struct SpawnRole {
+    let token: String
+    let label: String
+    let activity: String
+}
+
+private let spawnRoles: [SpawnRole] = [
+    SpawnRole(token: "SHADOW_OBSERVER", label: "Shadow observer",
+              activity: "scans recent dialog for durable lessons and skills"),
+    SpawnRole(token: "ARCHIVIST", label: "Archivist",
+              activity: "materializes a closed thread into a skill"),
+    SpawnRole(token: "CURATOR", label: "Curator",
+              activity: "audits, dedups and prunes the lessons/skills library"),
+    SpawnRole(token: "CANDIDATE_REVIEWER", label: "Candidate reviewer",
+              activity: "triages the extract-candidate queue into skills"),
+    SpawnRole(token: "DIALECTIC_VALIDATOR", label: "Dialectic validator",
+              activity: "turns observations into user-model claims"),
+    SpawnRole(token: "PROBE_RUNNER", label: "Probe runner",
+              activity: "runs self-diagnostic reliability probes"),
+    SpawnRole(token: "EVOLVE_REVIEWER", label: "Evolve reviewer",
+              activity: "audits the repo and files roadmap issues"),
+    SpawnRole(token: "EVOLVE_APPLIER", label: "Evolve applier",
+              activity: "implements a roadmap issue and opens a PR"),
+]
+
+// The full Spawn Routing surface, generated so no knob is missing:
+//   • Spawn Routing            — Default CLI + which CLI runs each role
+//   • Spawn Models (per CLI)   — the model each CLI uses
+//   • Spawn Models (per role)  — optional per-role model override
+private let spawnRoutingDefinitions: [EnvSettingDefinition] =
+    [
+        EnvSettingDefinition(
+            group: "Spawn Routing",
+            key: "THREADKEEPER_SPAWN__DEFAULT",
+            title: "Default CLI",
+            detail: "Agent CLI for every role that has no explicit route below.",
+            defaultValue: "",
+            kind: .choice(cliChoices)
+        )
+    ]
+    + spawnRoles.map { role in
+        EnvSettingDefinition(
+            group: "Spawn Routing",
+            key: "THREADKEEPER_SPAWN__LOOP__\(role.token)",
+            title: "\(role.label) → CLI",
+            detail: "Which CLI runs the loop that \(role.activity). "
+                + "Default = the Default CLI above.",
+            defaultValue: "",
+            kind: .choice(cliChoices)
+        )
+    }
+    + [
+        EnvSettingDefinition(
+            group: "Spawn Models (per CLI)",
+            key: "THREADKEEPER_SPAWN__MODEL__CLAUDE",
+            title: "Claude model",
+            detail: "Model passed to Claude Code --model, for claude-routed roles.",
+            defaultValue: "",
+            kind: .choice(claudeModelChoices)
+        ),
+        EnvSettingDefinition(
+            group: "Spawn Models (per CLI)",
+            key: "THREADKEEPER_SPAWN__MODEL__CODEX",
+            title: "Codex model",
+            detail: "Base model passed to `codex exec -m`, for codex-routed roles.",
+            defaultValue: "",
+            kind: .choice(codexModelChoices)
+        ),
+        EnvSettingDefinition(
+            group: "Spawn Models (per CLI)",
+            key: "THREADKEEPER_SPAWN__MODEL__AGY",
+            title: "Antigravity model",
+            detail: "Model label from `agy models`; agy is the Antigravity executable.",
+            defaultValue: "",
+            kind: .choice(antigravityModelChoices)
+        ),
+        EnvSettingDefinition(
+            group: "Spawn Models (per CLI)",
+            key: "THREADKEEPER_SPAWN__MODEL__GEMINI",
+            title: "Gemini (legacy) model",
+            detail: "Model id or alias passed to the legacy gemini --model.",
+            defaultValue: "",
+            kind: .choice(geminiLegacyModelChoices)
+        ),
+        EnvSettingDefinition(
+            group: "Spawn Models (per CLI)",
+            key: "THREADKEEPER_SPAWN__MODEL__COPILOT",
+            title: "Copilot model",
+            detail: "Model passed to copilot --model, for copilot-routed roles.",
+            defaultValue: "",
+            kind: .text
+        )
+    ]
+    + spawnRoles.map { role in
+        EnvSettingDefinition(
+            group: "Spawn Models (per role)",
+            key: "THREADKEEPER_SPAWN__MODEL__\(role.token)",
+            title: "\(role.label) model",
+            detail: "Overrides this role's model; Default = its CLI's model. "
+                + "Must be valid for the CLI the role runs on.",
+            defaultValue: "",
+            kind: .choice(roleModelChoices)
+        )
+    }
+
+private let envSettingDefinitions: [EnvSettingDefinition] =
+    baseEnvSettingDefinitions + spawnRoutingDefinitions
+
+private let baseEnvSettingDefinitions: [EnvSettingDefinition] = [
     EnvSettingDefinition(
         group: "Core",
         key: disableBackgroundDaemonsKey,
@@ -397,72 +510,9 @@ private let envSettingDefinitions: [EnvSettingDefinition] = [
         defaultValue: "1",
         kind: .number
     ),
-
-    EnvSettingDefinition(
-        group: "Spawn Routing",
-        key: "THREADKEEPER_SPAWN__DEFAULT",
-        title: "Default CLI",
-        detail: "Fallback agent CLI when a role has no explicit route.",
-        defaultValue: "",
-        kind: .choice(cliChoices)
-    ),
-    EnvSettingDefinition(
-        group: "Spawn Routing",
-        key: "THREADKEEPER_SPAWN__LOOP__EVOLVE_APPLIER",
-        title: "Evolve applier CLI",
-        detail: "CLI used by the role that writes code and opens PRs.",
-        defaultValue: "claude",
-        kind: .choice(cliChoices)
-    ),
-    EnvSettingDefinition(
-        group: "Spawn Routing",
-        key: "THREADKEEPER_SPAWN__MODEL__CLAUDE",
-        title: "Claude model",
-        detail: "Model pin passed to Claude Code --model.",
-        defaultValue: "opus",
-        kind: .choice(claudeModelChoices)
-    ),
-    EnvSettingDefinition(
-        group: "Spawn Routing",
-        key: "THREADKEEPER_SPAWN__MODEL__CODEX",
-        title: "Codex model",
-        detail: "Model pin passed to codex exec -m.",
-        defaultValue: "gpt-5.5",
-        kind: .choice(codexModelChoices)
-    ),
-    EnvSettingDefinition(
-        group: "Spawn Routing",
-        key: "THREADKEEPER_SPAWN__MODEL__AGY",
-        title: "Antigravity model",
-        detail: "Model label from `agy models`; agy is the executable for Antigravity.",
-        defaultValue: "Gemini 3.1 Pro (High)",
-        kind: .choice(antigravityModelChoices)
-    ),
-    EnvSettingDefinition(
-        group: "Spawn Routing",
-        key: "THREADKEEPER_SPAWN__MODEL__GEMINI",
-        title: "Gemini legacy model",
-        detail: "Model id or routing alias passed to legacy gemini --model.",
-        defaultValue: "auto",
-        kind: .choice(geminiLegacyModelChoices)
-    ),
-    EnvSettingDefinition(
-        group: "Spawn Routing",
-        key: "THREADKEEPER_SPAWN__MODEL__EVOLVE_APPLIER",
-        title: "Evolve applier model",
-        detail: "Model pin for the code-writing evolve role.",
-        defaultValue: "opus",
-        kind: .choice(roleModelChoices)
-    ),
-    EnvSettingDefinition(
-        group: "Spawn Routing",
-        key: "THREADKEEPER_SPAWN__MODEL__DIALECTIC_VALIDATOR",
-        title: "Dialectic validator model",
-        detail: "Model pin for claim-validation work.",
-        defaultValue: "opus",
-        kind: .choice(roleModelChoices)
-    ),
 ]
+// Spawn Routing sections are generated in `spawnRoutingDefinitions` above so
+// every role/CLI/model knob is listed — see envSettingDefinitions.
 
 private var envSettingGroups: [String] {
     var groups: [String] = []

--- a/tests/test_menubar_app.py
+++ b/tests/test_menubar_app.py
@@ -127,7 +127,19 @@ def test_menubar_env_settings_window_edits_env_and_presets():
     assert "THREADKEEPER_DISABLE_BG_DAEMONS" in swift
     assert "setThreadKeeperDisabled(_ disabled: Bool, restart: Bool)" in swift
     assert "THREADKEEPER_EVOLVE_APPLY_INTERVAL_S" in swift
-    assert "THREADKEEPER_SPAWN__MODEL__EVOLVE_APPLIER" in swift
+    # Spawn routing is generated from the spawn-role list, so per-role keys are
+    # interpolated (THREADKEEPER_SPAWN__{LOOP,MODEL}__<token>) rather than
+    # literal. Assert the generators plus every role token, so the panel is
+    # verified to expose a CLI + model knob for all eight spawn roles.
+    assert "THREADKEEPER_SPAWN__LOOP__\\(role.token)" in swift
+    assert "THREADKEEPER_SPAWN__MODEL__\\(role.token)" in swift
+    for _role_token in (
+        "SHADOW_OBSERVER", "ARCHIVIST", "CURATOR", "CANDIDATE_REVIEWER",
+        "DIALECTIC_VALIDATOR", "PROBE_RUNNER", "EVOLVE_REVIEWER",
+        "EVOLVE_APPLIER",
+    ):
+        assert f'token: "{_role_token}"' in swift
+    assert "THREADKEEPER_SPAWN__MODEL__COPILOT" in swift
     assert 'Label("Save & Restart", systemImage: "arrow.clockwise.circle")' in swift
     assert 'process.arguments = ["-TERM", "-f", "threadkeeper.server"]' in swift
 

--- a/threadkeeper/assets/macos-agent-status/ThreadKeeperAgentStatus.swift
+++ b/threadkeeper/assets/macos-agent-status/ThreadKeeperAgentStatus.swift
@@ -210,7 +210,120 @@ private let roleModelChoices = (
     }
 }
 
-private let envSettingDefinitions: [EnvSettingDefinition] = [
+// Every autonomous loop that actually spawns a child agent. The env key
+// suffix is the role token; `activity` fills the human-readable descriptions so
+// the Spawn Routing panel lists every role explicitly (CLI + model per role)
+// instead of a hand-picked subset. Keep in sync with spawn_config.SUMMARY_ROLES
+// (the roles that reach a spawn() call-site).
+private struct SpawnRole {
+    let token: String
+    let label: String
+    let activity: String
+}
+
+private let spawnRoles: [SpawnRole] = [
+    SpawnRole(token: "SHADOW_OBSERVER", label: "Shadow observer",
+              activity: "scans recent dialog for durable lessons and skills"),
+    SpawnRole(token: "ARCHIVIST", label: "Archivist",
+              activity: "materializes a closed thread into a skill"),
+    SpawnRole(token: "CURATOR", label: "Curator",
+              activity: "audits, dedups and prunes the lessons/skills library"),
+    SpawnRole(token: "CANDIDATE_REVIEWER", label: "Candidate reviewer",
+              activity: "triages the extract-candidate queue into skills"),
+    SpawnRole(token: "DIALECTIC_VALIDATOR", label: "Dialectic validator",
+              activity: "turns observations into user-model claims"),
+    SpawnRole(token: "PROBE_RUNNER", label: "Probe runner",
+              activity: "runs self-diagnostic reliability probes"),
+    SpawnRole(token: "EVOLVE_REVIEWER", label: "Evolve reviewer",
+              activity: "audits the repo and files roadmap issues"),
+    SpawnRole(token: "EVOLVE_APPLIER", label: "Evolve applier",
+              activity: "implements a roadmap issue and opens a PR"),
+]
+
+// The full Spawn Routing surface, generated so no knob is missing:
+//   • Spawn Routing            — Default CLI + which CLI runs each role
+//   • Spawn Models (per CLI)   — the model each CLI uses
+//   • Spawn Models (per role)  — optional per-role model override
+private let spawnRoutingDefinitions: [EnvSettingDefinition] =
+    [
+        EnvSettingDefinition(
+            group: "Spawn Routing",
+            key: "THREADKEEPER_SPAWN__DEFAULT",
+            title: "Default CLI",
+            detail: "Agent CLI for every role that has no explicit route below.",
+            defaultValue: "",
+            kind: .choice(cliChoices)
+        )
+    ]
+    + spawnRoles.map { role in
+        EnvSettingDefinition(
+            group: "Spawn Routing",
+            key: "THREADKEEPER_SPAWN__LOOP__\(role.token)",
+            title: "\(role.label) → CLI",
+            detail: "Which CLI runs the loop that \(role.activity). "
+                + "Default = the Default CLI above.",
+            defaultValue: "",
+            kind: .choice(cliChoices)
+        )
+    }
+    + [
+        EnvSettingDefinition(
+            group: "Spawn Models (per CLI)",
+            key: "THREADKEEPER_SPAWN__MODEL__CLAUDE",
+            title: "Claude model",
+            detail: "Model passed to Claude Code --model, for claude-routed roles.",
+            defaultValue: "",
+            kind: .choice(claudeModelChoices)
+        ),
+        EnvSettingDefinition(
+            group: "Spawn Models (per CLI)",
+            key: "THREADKEEPER_SPAWN__MODEL__CODEX",
+            title: "Codex model",
+            detail: "Base model passed to `codex exec -m`, for codex-routed roles.",
+            defaultValue: "",
+            kind: .choice(codexModelChoices)
+        ),
+        EnvSettingDefinition(
+            group: "Spawn Models (per CLI)",
+            key: "THREADKEEPER_SPAWN__MODEL__AGY",
+            title: "Antigravity model",
+            detail: "Model label from `agy models`; agy is the Antigravity executable.",
+            defaultValue: "",
+            kind: .choice(antigravityModelChoices)
+        ),
+        EnvSettingDefinition(
+            group: "Spawn Models (per CLI)",
+            key: "THREADKEEPER_SPAWN__MODEL__GEMINI",
+            title: "Gemini (legacy) model",
+            detail: "Model id or alias passed to the legacy gemini --model.",
+            defaultValue: "",
+            kind: .choice(geminiLegacyModelChoices)
+        ),
+        EnvSettingDefinition(
+            group: "Spawn Models (per CLI)",
+            key: "THREADKEEPER_SPAWN__MODEL__COPILOT",
+            title: "Copilot model",
+            detail: "Model passed to copilot --model, for copilot-routed roles.",
+            defaultValue: "",
+            kind: .text
+        )
+    ]
+    + spawnRoles.map { role in
+        EnvSettingDefinition(
+            group: "Spawn Models (per role)",
+            key: "THREADKEEPER_SPAWN__MODEL__\(role.token)",
+            title: "\(role.label) model",
+            detail: "Overrides this role's model; Default = its CLI's model. "
+                + "Must be valid for the CLI the role runs on.",
+            defaultValue: "",
+            kind: .choice(roleModelChoices)
+        )
+    }
+
+private let envSettingDefinitions: [EnvSettingDefinition] =
+    baseEnvSettingDefinitions + spawnRoutingDefinitions
+
+private let baseEnvSettingDefinitions: [EnvSettingDefinition] = [
     EnvSettingDefinition(
         group: "Core",
         key: disableBackgroundDaemonsKey,
@@ -397,72 +510,9 @@ private let envSettingDefinitions: [EnvSettingDefinition] = [
         defaultValue: "1",
         kind: .number
     ),
-
-    EnvSettingDefinition(
-        group: "Spawn Routing",
-        key: "THREADKEEPER_SPAWN__DEFAULT",
-        title: "Default CLI",
-        detail: "Fallback agent CLI when a role has no explicit route.",
-        defaultValue: "",
-        kind: .choice(cliChoices)
-    ),
-    EnvSettingDefinition(
-        group: "Spawn Routing",
-        key: "THREADKEEPER_SPAWN__LOOP__EVOLVE_APPLIER",
-        title: "Evolve applier CLI",
-        detail: "CLI used by the role that writes code and opens PRs.",
-        defaultValue: "claude",
-        kind: .choice(cliChoices)
-    ),
-    EnvSettingDefinition(
-        group: "Spawn Routing",
-        key: "THREADKEEPER_SPAWN__MODEL__CLAUDE",
-        title: "Claude model",
-        detail: "Model pin passed to Claude Code --model.",
-        defaultValue: "opus",
-        kind: .choice(claudeModelChoices)
-    ),
-    EnvSettingDefinition(
-        group: "Spawn Routing",
-        key: "THREADKEEPER_SPAWN__MODEL__CODEX",
-        title: "Codex model",
-        detail: "Model pin passed to codex exec -m.",
-        defaultValue: "gpt-5.5",
-        kind: .choice(codexModelChoices)
-    ),
-    EnvSettingDefinition(
-        group: "Spawn Routing",
-        key: "THREADKEEPER_SPAWN__MODEL__AGY",
-        title: "Antigravity model",
-        detail: "Model label from `agy models`; agy is the executable for Antigravity.",
-        defaultValue: "Gemini 3.1 Pro (High)",
-        kind: .choice(antigravityModelChoices)
-    ),
-    EnvSettingDefinition(
-        group: "Spawn Routing",
-        key: "THREADKEEPER_SPAWN__MODEL__GEMINI",
-        title: "Gemini legacy model",
-        detail: "Model id or routing alias passed to legacy gemini --model.",
-        defaultValue: "auto",
-        kind: .choice(geminiLegacyModelChoices)
-    ),
-    EnvSettingDefinition(
-        group: "Spawn Routing",
-        key: "THREADKEEPER_SPAWN__MODEL__EVOLVE_APPLIER",
-        title: "Evolve applier model",
-        detail: "Model pin for the code-writing evolve role.",
-        defaultValue: "opus",
-        kind: .choice(roleModelChoices)
-    ),
-    EnvSettingDefinition(
-        group: "Spawn Routing",
-        key: "THREADKEEPER_SPAWN__MODEL__DIALECTIC_VALIDATOR",
-        title: "Dialectic validator model",
-        detail: "Model pin for claim-validation work.",
-        defaultValue: "opus",
-        kind: .choice(roleModelChoices)
-    ),
 ]
+// Spawn Routing sections are generated in `spawnRoutingDefinitions` above so
+// every role/CLI/model knob is listed — see envSettingDefinitions.
 
 private var envSettingGroups: [String] {
     var groups: [String] = []


### PR DESCRIPTION
The menu-bar Save & Restart env editor's **Spawn Routing** section showed only a hand-picked subset — default CLI, one loop CLI, and four model pins — so most of the routing surface was invisible and the shown fields weren't obviously complete (this is what surfaced the `curator=opus`-on-codex misconfig late).

Now every spawn knob is generated from the spawn-role list, split into three clearly-labeled sections:

- **Spawn Routing** — Default CLI + a CLI selector for each of the 8 loop roles (shadow_observer, archivist, curator, candidate_reviewer, dialectic_validator, probe_runner, evolve_reviewer, evolve_applier).
- **Spawn Models (per CLI)** — claude / codex / antigravity / gemini / copilot.
- **Spawn Models (per role)** — an optional per-role model override.

Each row carries a plain-language description of what that role does plus its exact `THREADKEEPER_SPAWN__*` key. An unset value renders as **"Default"** and, per the existing save logic, is *not* written to `.env` — so exposing 22 fields doesn't clutter the file; only values you actually set are persisted.

Both the source copy (`apps/macos-agent-status/`) and the bundled copy (`threadkeeper/assets/macos-agent-status/`) are updated in lockstep. `swiftc -typecheck` and the full `build.sh` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)