### PR TITLE
fix: isolate evolve loops in a dedicated managed checkout (#164)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -106,8 +106,8 @@
 # THREADKEEPER_EVOLVE_REVIEW_INTERVAL_S=0
 # THREADKEEPER_EVOLVE_REVIEW_MIN=2
 # THREADKEEPER_EVOLVE_APPLY_INTERVAL_S=0       # applier tick (s); applies latest complete Curator report first, then promoted evolve PR work. 0=off (manual tools still work)
-# THREADKEEPER_EVOLVE_REPO_ROOT=               # pin the thread-keeper checkout the reviewer/applier branch+test+PR against. Empty=auto: package parent (editable install.sh) else an auto-cloned managed checkout under the DB dir
-# THREADKEEPER_EVOLVE_AUTO_CLONE=1             # auto-provision (clone + .venv with [semantic,dev]) a managed checkout on PyPI/site-packages installs so the evolve loops work by default. 0=disable (then needs an editable install or EVOLVE_REPO_ROOT)
+# THREADKEEPER_EVOLVE_REPO_ROOT=               # pin the thread-keeper checkout the reviewer/applier branch+test+PR against. Empty=auto: a dedicated managed checkout under the DB dir (~/.threadkeeper/evolve-repo), isolated from your own working tree (#164) so the loops never branch-switch it
+# THREADKEEPER_EVOLVE_AUTO_CLONE=1             # auto-provision (clone + .venv with [semantic,dev]) the managed checkout so the evolve loops work by default without touching your checkout. 0=disable: falls back to in-place on an editable install (pre-isolation behaviour), else needs EVOLVE_REPO_ROOT
 # THREADKEEPER_EVOLVE_REPO_URL=https://github.com/po4erk91/thread-keeper   # git URL the managed checkout is cloned from
 # THREADKEEPER_EVOLVE_REPO_BRANCH=main         # branch the managed checkout tracks
 # THREADKEEPER_ROADMAP_CLAIM_RACE_WINDOW_S=3   # multi-host TOCTOU window: after posting a claim, wait this long before re-fetching to detect a competing claim. 0=skip race detection (single-host setups)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ version bumps follow semver per the policy in
 
 ### Changed
 
+- **Evolve loops run in a dedicated managed checkout by default (#164
+  isolation).** The reviewer and applier resolve their working checkout to
+  `~/.threadkeeper/evolve-repo` even on an editable install, instead of the
+  package-parent checkout. The loops branch-switch, merge and hard-reset the
+  tree they work in, and on a dev install the package-parent is the user's own
+  working tree — running there flipped its branch out from under in-progress
+  edits (observed this session: the applier left the shared checkout on a
+  `roadmap/issue-*` branch mid-session). The managed checkout is auto-cloned +
+  venv-provisioned on first use (unchanged machinery) and gives the issue → PR
+  flow a clean origin-tracking base. `THREADKEEPER_EVOLVE_AUTO_CLONE=0` keeps
+  the old in-place behaviour on editable installs; `THREADKEEPER_EVOLVE_REPO_ROOT`
+  still pins an explicit checkout.
+
 - **Menu-bar env editor lists the full Spawn Routing surface.** The Spawn
   Routing panel previously showed a hand-picked subset (default CLI, one loop
   CLI, four model pins). It now generates every knob from the spawn-role list:

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -495,20 +495,27 @@ pre-existing due gates.
   `evolve_format` suggestions. Both the reviewer and the code/PR applier paths
   operate on a real git checkout, resolved by `_ensure_repo_ready()` in this
   order: (1) an explicit `EVOLVE_REPO_ROOT` (`THREADKEEPER_EVOLVE_REPO_ROOT`);
-  (2) the package's parent dir when it carries a `.git` entry — the
-  editable-from-checkout `install.sh`; (3) otherwise a **managed checkout**
-  under the DB dir (`~/.threadkeeper/evolve-repo`). On a PyPI/site-packages
-  install where no source tree exists, the managed checkout is **auto-cloned on
-  first use** (from `EVOLVE_REPO_URL`/`EVOLVE_REPO_BRANCH`, defaulting to the
-  upstream repo) and given its own `.venv` with the `[semantic,dev]` extras so
-  the children can branch, run the suite, and open PRs. This makes the loops
-  work by default with no configuration. Set `THREADKEEPER_EVOLVE_AUTO_CLONE=0`
-  to disable provisioning — then a non-checkout install reports
-  `ERR evolve_repo_unavailable=<path>` until an editable install or an explicit
-  `EVOLVE_REPO_ROOT` is provided. An explicit override that is not itself a
-  checkout is never auto-cloned into and reports `ERR repo_root_not_git`.
-  Provisioning is serialized by `evolve-repo-provision.lock`. Curator report
-  apply needs no git tree and runs regardless.
+  (2) by default, a dedicated **managed checkout** under the DB dir
+  (`~/.threadkeeper/evolve-repo`), **auto-cloned on first use** (from
+  `EVOLVE_REPO_URL`/`EVOLVE_REPO_BRANCH`, defaulting to the upstream repo) and
+  given its own `.venv` with the `[semantic,dev]` extras so the children can
+  branch, run the suite, and open PRs; (3) only when auto-clone is disabled does
+  the package's parent dir (when it carries a `.git` entry — the
+  editable-from-checkout `install.sh`) serve as an in-place fallback. The
+  managed checkout is the default even for editable installs on purpose
+  (**isolation, #164**): the loops branch-switch, merge and hard-reset the tree
+  they work in, and the editable package-parent is the user's own working tree —
+  running there would flip its branch out from under an in-progress edit. It
+  also gives the issue → PR flow a clean origin-tracking base. This makes the
+  loops work by default with no configuration and without touching your
+  checkout. Set `THREADKEEPER_EVOLVE_AUTO_CLONE=0` to disable provisioning and
+  keep the pre-isolation in-place behaviour on an editable install; on a
+  non-checkout install with auto-clone off the loops report
+  `ERR evolve_repo_unavailable=<path>` until an explicit `EVOLVE_REPO_ROOT` is
+  provided. An explicit override that is not itself a checkout is never
+  auto-cloned into and reports `ERR repo_root_not_git`. Provisioning is
+  serialized by `evolve-repo-provision.lock`. Curator report apply needs no git
+  tree and runs regardless.
 
   Before the privileged reviewer audit or any code/PR applier child is spawned,
   the parent enforces local git safety on that checkout: `git status

--- a/tests/test_evolve_applier.py
+++ b/tests/test_evolve_applier.py
@@ -289,6 +289,12 @@ def test_apply_curator_report_builds_evolve_applier_spawn(
     tmp_path, monkeypatch,
 ):
     pkg = _bootstrap(tmp_path, monkeypatch)
+    # Isolation default resolves to the (unprovisioned) managed checkout; pin a
+    # ready tmp checkout so the spawn path runs without a real clone.
+    repo = tmp_path / "evolve-repo"
+    repo.mkdir()
+    monkeypatch.setattr(pkg["ea"], "_resolve_repo_root", lambda: repo)
+    monkeypatch.setattr(pkg["ea"], "_is_git_repo", lambda p: True)
     report = _write_report(pkg)
     calls = {}
     _mock_spawn(monkeypatch, calls)
@@ -1903,13 +1909,26 @@ def test_repo_root_prefers_env_override(tmp_path, monkeypatch):
     assert pkg["ea"]._repo_root() == external
 
 
-def test_repo_root_defaults_to_package_checkout(tmp_path, monkeypatch):
-    """With no override, an editable-from-checkout install resolves to the
-    package's parent dir (which carries a .git entry)."""
+def test_repo_root_defaults_to_managed_checkout(tmp_path, monkeypatch):
+    """Isolation (#164): with no override and auto-clone on (the default), the
+    loops resolve to the dedicated managed checkout under the DB dir — NOT the
+    editable package-parent, which for a dev install is the user's own working
+    tree that must never be branch-switched by the applier."""
     pkg = _bootstrap(tmp_path, monkeypatch)
+    assert pkg["ea"]._repo_root() == pkg["ea"]._managed_repo_dir()
+
+
+def test_repo_root_falls_back_in_place_when_autoclone_off(tmp_path, monkeypatch):
+    """The escape hatch: THREADKEEPER_EVOLVE_AUTO_CLONE=0 keeps the pre-isolation
+    in-place behaviour, resolving to the editable package-parent checkout."""
+    pkg = _bootstrap(tmp_path, monkeypatch)
+    monkeypatch.setattr(pkg["ea"], "EVOLVE_AUTO_CLONE", False)
     from pathlib import Path as _P
-    expected = _P(pkg["ea"].__file__).resolve().parent.parent
-    assert pkg["ea"]._repo_root() == expected
+    pkg_parent = _P(pkg["ea"].__file__).resolve().parent.parent
+    if (pkg_parent / ".git").exists():
+        assert pkg["ea"]._repo_root() == pkg_parent
+    else:  # installed non-editable → no in-place checkout, still managed
+        assert pkg["ea"]._repo_root() == pkg["ea"]._managed_repo_dir()
 
 
 def test_managed_repo_dir_is_under_db_dir(tmp_path, monkeypatch):
@@ -1922,9 +1941,10 @@ def test_managed_repo_dir_is_under_db_dir(tmp_path, monkeypatch):
 
 
 def test_ensure_repo_ready_uses_existing_checkout(tmp_path, monkeypatch):
-    """The common path: the resolved root is already a git tree (editable
-    install / dev checkout) → ready, no provisioning."""
+    """The steady-state path: the resolved managed checkout is already a git
+    tree (provisioned on a prior pass) → ready, no re-provisioning."""
     pkg = _bootstrap(tmp_path, monkeypatch)
+    monkeypatch.setattr(pkg["ea"], "_is_git_repo", lambda path: True)
 
     def _no_provision(dest):
         raise AssertionError("must not provision when a checkout exists")

--- a/tests/test_evolve_daemon.py
+++ b/tests/test_evolve_daemon.py
@@ -473,6 +473,12 @@ def test_run_evolve_pass_runs_reviewer_in_repo_root(tmp_path, monkeypatch):
     pkg = _bootstrap(tmp_path, monkeypatch, review_min="1")
     conn = pkg["db"].get_db()
     _add_evolve(conn, "s1")
+    # Pin a ready checkout (the isolation default resolves to an unprovisioned
+    # managed dir) so the reviewer reaches spawn; the point of the test is that
+    # cwd is the resolved checkout, not the host CLI's working dir.
+    repo = tmp_path / "evolve-repo"
+    repo.mkdir()
+    monkeypatch.setattr(pkg["ed"], "_ensure_repo_ready", lambda: (repo, ""))
     calls = {}
     import threadkeeper.tools.spawn as spawn_mod
     monkeypatch.setattr(spawn_mod, "spawn",
@@ -481,8 +487,7 @@ def test_run_evolve_pass_runs_reviewer_in_repo_root(tmp_path, monkeypatch):
     out = pkg["ed"].run_evolve_pass(force=True)
 
     assert out.startswith("spawned research")
-    expected = str(Path(pkg["ed"].__file__).resolve().parent.parent)
-    assert calls["cwd"] == expected
+    assert calls["cwd"] == str(repo)
 
 
 def test_run_evolve_pass_blocks_when_repo_unavailable(tmp_path, monkeypatch):
@@ -530,6 +535,9 @@ def test_run_evolve_pass_single_flight(tmp_path, monkeypatch):
 
 def test_run_evolve_pass_single_flight_lock_race(tmp_path, monkeypatch):
     pkg = _bootstrap(tmp_path, monkeypatch, review_min="1")
+    repo = tmp_path / "evolve-repo"
+    repo.mkdir()
+    monkeypatch.setattr(pkg["ed"], "_ensure_repo_ready", lambda: (repo, ""))
     import threadkeeper.tools.spawn as spawn_mod
 
     entered_spawn = threading.Event()

--- a/threadkeeper/evolve_applier.py
+++ b/threadkeeper/evolve_applier.py
@@ -473,17 +473,27 @@ def _resolve_repo_root() -> Path:
     """Pure repo-root resolution — no network, no git subprocess.
 
     Order:
-      1. explicit EVOLVE_REPO_ROOT override;
-      2. the package's parent dir when it is itself a checkout (editable
-         install.sh), detected cheaply by a `.git` entry;
-      3. the managed checkout under the DB dir (PyPI/site-packages installs),
-         which `_ensure_repo_ready()` auto-provisions on first use."""
+      1. explicit EVOLVE_REPO_ROOT override — the operator pinned a checkout;
+      2. a dedicated managed checkout under the DB dir (the DEFAULT). The evolve
+         loops branch-switch, merge, and reset the tree they work in, so they
+         must NOT run inside the editable package-parent checkout — for a dev
+         install that is the user's own working tree, and the loops would flip
+         its branch out from under an in-progress edit (isolation, #164). The
+         managed checkout is auto-provisioned by `_ensure_repo_ready()` and
+         tracks origin, which is also the correct base for the issue → PR flow;
+      3. only when auto-clone is disabled does an editable package-parent
+         checkout serve as the in-place fallback (no clone is permitted then).
+
+    Set THREADKEEPER_EVOLVE_REPO_ROOT to run against a specific checkout, or
+    THREADKEEPER_EVOLVE_AUTO_CLONE=0 to keep the pre-isolation in-place
+    behaviour on an editable install."""
     override = (EVOLVE_REPO_ROOT or "").strip()
     if override:
         return Path(override).expanduser()
-    pkg_parent = Path(__file__).resolve().parent.parent
-    if (pkg_parent / ".git").exists():
-        return pkg_parent
+    if not EVOLVE_AUTO_CLONE:
+        pkg_parent = Path(__file__).resolve().parent.parent
+        if (pkg_parent / ".git").exists():
+            return pkg_parent
     return _managed_repo_dir()
 
 


### PR DESCRIPTION
The evolve **reviewer** and **applier** resolved their working checkout to the package-parent on an editable install — which for a dev setup is the user's own working tree. The loops branch-switch, merge and hard-reset the tree they operate in, so a running applier flips the user's branch out from under an in-progress edit.

This isn't hypothetical: **during this session the applier left the shared `/Users/dmytro/ai-memory` checkout parked on a `roadmap/issue-59` branch mid-work**, and my edits landed on top of its branch until I noticed and moved them to an isolated worktree. That's the exact collision this fixes (audit item #164).

## Change
`_resolve_repo_root()` now defaults to the dedicated **managed checkout** under the DB dir (`~/.threadkeeper/evolve-repo`) even for editable installs, reusing the existing auto-clone + `.venv` provisioning (unchanged machinery — clone, lock, idempotency). Consequences:
- The loops **never touch the user's working checkout**.
- The issue → PR flow gets a clean **origin-tracking base** instead of the user's local WIP.

Escape hatches preserved:
- `THREADKEEPER_EVOLVE_AUTO_CLONE=0` → in-place fallback to the editable package-parent (pre-isolation behaviour).
- `THREADKEEPER_EVOLVE_REPO_ROOT=<path>` → explicit pinned checkout.

## Tests
- Repo-root resolution: default now asserts the managed checkout; new case for the auto-clone-off in-place fallback; `_ensure_repo_ready` steady-state updated.
- Three flow tests that implicitly relied on the package-parent being a live git tree now pin a ready tmp checkout (curator-report spawn, reviewer-runs-in-repo-root, single-flight lock race).
- Full evolve suite green from the branch worktree: **104 passed** under `pytest --forked`.

## Docs
CHANGELOG, ARCHITECTURE (evolve-repo resolution), `.env.example` (EVOLVE_REPO_ROOT / EVOLVE_AUTO_CLONE).

🤖 Generated with [Claude Code](https://claude.com/claude-code)