### PR TITLE
fix: gate auto-update setup rewrites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,13 @@ version bumps follow semver per the policy in
 
 ### Fixed
 
+- **Auto-update no longer silently rewrites CLI setup config (#87).**
+  Post-update setup now defaults to a dry-run check
+  (`THREADKEEPER_AUTO_UPDATE_SETUP=check`) that records unchanged vs pending
+  MCP/hook/instruction rewrites without applying them. Users can opt into the
+  previous full setup writer with `THREADKEEPER_AUTO_UPDATE_SETUP=apply`, or
+  disable the setup subprocess with `skip`.
+
 - **Codex spawns pass `--skip-git-repo-check`.** `codex exec` refuses to run
   ("Not inside a trusted directory and --skip-git-repo-check was not
   specified") whenever the spawn cwd is not a trusted git worktree. Because the

--- a/README.md
+++ b/README.md
@@ -351,13 +351,14 @@ By default it checks once per day (`THREADKEEPER_AUTO_UPDATE_INTERVAL_S=86400`):
 
 - editable git checkout: skip if tracked files are dirty, otherwise fetch the
   tracked remote branch, fast-forward with `git pull --ff-only`, reinstall the
-  editable package, and rerun `threadkeeper._setup`;
+  editable package, and run the configured post-update setup check;
 - installed package: run `pip install --upgrade threadkeeper` or
   `threadkeeper[semantic]` in the current interpreter environment, preserving
   semantic extras when they are already installed, but only after the candidate
   PyPI release's non-yanked files have PyPI Integrity API provenance from the
   expected GitHub Trusted Publisher (`po4erk91/thread-keeper`, `publish.yml`,
-  environment `pypi`), then rerun setup when the installed version changes.
+  environment `pypi`), then run the configured post-update setup check when the
+  installed version changes.
 
 Auto-update is standing consent for thread-keeper to fetch and run future
 maintainer code. A packaged update whose provenance is missing, whose publisher
@@ -368,6 +369,14 @@ daemon exits the current MCP process by default so the host can restart it on
 the new code. Before scheduling that exit, it imports `threadkeeper.server` in a
 subprocess; install/setup/import failures are recorded as `auto_update_pass`
 with `restart=suppressed`, and the current known-working process stays alive.
+Post-update setup defaults to `THREADKEEPER_AUTO_UPDATE_SETUP=check`, which runs
+`thread-keeper-setup --dry-run` only. It records `setup=checked
+status=unchanged` when configs already match and logs/records
+`status=changes_pending` if MCP registrations, hooks, or managed instruction
+blocks would be rewritten; it does not re-add config the user removed. Set
+`THREADKEEPER_AUTO_UPDATE_SETUP=apply` to give standing consent for auto-update
+to run the full setup writer after future successful updates, or `skip` to avoid
+even the dry-run check.
 Disable restart with
 `THREADKEEPER_AUTO_UPDATE_RESTART=0`, or disable the updater entirely with
 `THREADKEEPER_AUTO_UPDATE_INTERVAL_S=0`. The provenance gate is on by default;
@@ -918,6 +927,7 @@ The most-used env knobs (full list in `threadkeeper/config.py`):
 | `THREADKEEPER_AUTO_UPDATE_INTERVAL_S` | 86400 | MCP self-update check interval; 0 disables |
 | `THREADKEEPER_AUTO_UPDATE_RESTART` | "1" | exit MCP process after an update passes setup/import smoke checks so the host restarts on new code |
 | `THREADKEEPER_AUTO_UPDATE_TIMEOUT_S` | 600 | max seconds for git/pip update commands |
+| `THREADKEEPER_AUTO_UPDATE_SETUP` | `check` | post-update setup mode: `check` runs `thread-keeper-setup --dry-run` and logs pending CLI config rewrites without applying them; `apply` gives standing consent to rewrite MCP/hooks/instruction config after updates; `skip` disables the setup step |
 | `THREADKEEPER_AUTO_UPDATE_VERIFY_PROVENANCE` | true | require PyPI Integrity API provenance before packaged `pip` self-upgrades |
 | `THREADKEEPER_AUTO_UPDATE_PYPI_BASE_URL` | `https://pypi.org` | PyPI base URL used for JSON metadata and Integrity API checks |
 | `THREADKEEPER_AUTO_UPDATE_EXPECTED_PUBLISHER_REPOSITORY` | `po4erk91/thread-keeper` | expected GitHub Trusted Publisher repository for packaged self-upgrades |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -113,14 +113,19 @@ bundle for `po4erk91/thread-keeper` from `publish.yml` in environment `pypi`,
 and checks the attested subject filename/SHA-256 against PyPI metadata before
 `pip` is invoked. Missing provenance, mismatched publisher identity, or digest
 mismatch returns `refused mode=pip ...` and records an `auto_update_pass` without
-restarting. Successful updates optionally exit the current MCP process
+restarting. After a successful install, `THREADKEEPER_AUTO_UPDATE_SETUP` governs
+the setup step: `check` (default) runs `thread-keeper-setup --dry-run`, records
+`setup=checked status=unchanged` or `status=changes_pending`, and logs when the
+dry-run would rewrite MCP registrations, hook wiring, or managed instruction
+blocks; `apply` is standing consent to run the full setup writer; `skip` avoids
+the setup subprocess. Successful updates optionally exit the current MCP process
 (`THREADKEEPER_AUTO_UPDATE_RESTART` default true) so the host reconnects to the
-new code, but only after setup and a subprocess import smoke check both pass.
-Install/setup/import failures are recorded on the `auto_update_pass` event with
-`restart=suppressed`, and the already-running process stays alive on its current
-in-memory code. Set `THREADKEEPER_AUTO_UPDATE_INTERVAL_S=0` to opt out of the
-standing-consent update channel entirely; the provenance gate itself is
-controlled by `THREADKEEPER_AUTO_UPDATE_VERIFY_PROVENANCE` for break-glass
+new code, but only after setup check/apply and a subprocess import smoke check
+both pass. Install/setup/import failures are recorded on the `auto_update_pass`
+event with `restart=suppressed`, and the already-running process stays alive on
+its current in-memory code. Set `THREADKEEPER_AUTO_UPDATE_INTERVAL_S=0` to opt
+out of the standing-consent update channel entirely; the provenance gate itself
+is controlled by `THREADKEEPER_AUTO_UPDATE_VERIFY_PROVENANCE` for break-glass
 mirrors.
 The upstream publish path is gated before that provenance exists: the
 post-test release readiness workflow is read-only and does not dispatch PyPI,
@@ -1376,6 +1381,7 @@ unsupported CLI overrides still fall through to the next priority, and
 | `THREADKEEPER_AUTO_UPDATE_INTERVAL_S` | 86400 | MCP self-update check interval; 0 disables |
 | `THREADKEEPER_AUTO_UPDATE_RESTART` | true | exit MCP process after an update passes setup/import smoke checks |
 | `THREADKEEPER_AUTO_UPDATE_TIMEOUT_S` | 600 | max seconds for git/pip update commands |
+| `THREADKEEPER_AUTO_UPDATE_SETUP` | `check` | post-update setup mode: `check` dry-runs and logs pending CLI config rewrites; `apply` writes setup config; `skip` disables setup |
 | `THREADKEEPER_AUTO_UPDATE_VERIFY_PROVENANCE` | true | require PyPI Integrity API provenance before packaged `pip` self-upgrades |
 | `THREADKEEPER_AUTO_UPDATE_PYPI_BASE_URL` | `https://pypi.org` | PyPI base URL used for JSON metadata and Integrity API checks |
 | `THREADKEEPER_AUTO_UPDATE_EXPECTED_PUBLISHER_REPOSITORY` | `po4erk91/thread-keeper` | expected GitHub Trusted Publisher repository for packaged self-upgrades |

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -56,6 +56,11 @@ remains a live question.
   `threadkeeper.server` import smoke check. Failures are recorded on
   `auto_update_pass` with `restart=suppressed`, and the current process stays
   alive on its already-loaded code.
+- Auto-update setup consent gate (#87): post-update setup now defaults to
+  `THREADKEEPER_AUTO_UPDATE_SETUP=check`, a dry-run that records unchanged vs
+  pending CLI config rewrites without re-adding removed MCP entries, hooks, or
+  managed instruction blocks. `apply` is explicit standing consent for the old
+  full setup writer, and `skip` disables the setup subprocess.
 - Evolve roadmap issue pagination (#81): reviewer dedup and applier pickup use
   paginated, oldest-first GitHub REST issue reads instead of a newest-first
   50-item window. The applier still prioritizes `roadmap` labels then FIFO by

--- a/tests/test_auto_update.py
+++ b/tests/test_auto_update.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import base64
 import json
+import logging
 import sys
 import time
 from pathlib import Path
@@ -287,6 +288,107 @@ def test_git_checkout_with_dirty_tracked_files_is_skipped(tmp_path, monkeypatch)
     assert (
         pkg["auto_update"]._update_git_checkout(tmp_path)
         == "skipped_dirty_checkout mode=git"
+    )
+
+
+def test_auto_update_setup_check_noops_when_config_already_matches(
+    tmp_path,
+    monkeypatch,
+):
+    pkg = _bootstrap(tmp_path, monkeypatch)
+    calls: list[list[str]] = []
+    stdout = """thread-keeper setup (dry-run)
+  [dir] ~/.threadkeeper: already exists
+  [mcp_server[codex]] codex: already current
+  [instructions[codex]] AGENTS.md: managed block already current
+  [hooks] hooks: tk-brief.sh already current
+
+Done. Restart connected CLIs for instructions + MCP changes to take effect.
+"""
+
+    def fake_run(args, *, cwd=None, timeout=None):
+        calls.append(args)
+        return SimpleNamespace(returncode=0, stdout=stdout, stderr="")
+
+    monkeypatch.setattr(pkg["auto_update"], "_run", fake_run)
+
+    out = pkg["auto_update"]._run_setup()
+
+    assert out == " setup=checked status=unchanged"
+    assert calls == [[sys.executable, "-m", "threadkeeper._setup", "--dry-run"]]
+
+
+def test_auto_update_setup_check_logs_pending_config_rewrite(
+    tmp_path,
+    monkeypatch,
+    caplog,
+):
+    pkg = _bootstrap(tmp_path, monkeypatch)
+    caplog.set_level(logging.WARNING, logger="threadkeeper.auto_update")
+    stdout = """thread-keeper setup (dry-run)
+  [mcp_server[codex]] codex: would create config.toml with mcp section
+  [instructions[codex]] AGENTS.md: would prepend managed block
+
+Done. Restart connected CLIs for instructions + MCP changes to take effect.
+"""
+
+    monkeypatch.setattr(
+        pkg["auto_update"],
+        "_run",
+        lambda args, *, cwd=None, timeout=None: SimpleNamespace(
+            returncode=0,
+            stdout=stdout,
+            stderr="",
+        ),
+    )
+
+    out = pkg["auto_update"]._run_setup()
+
+    assert out == " setup=checked status=changes_pending"
+    assert any(
+        "setup dry-run found pending CLI config changes" in rec.getMessage()
+        for rec in caplog.records
+        if rec.name == "threadkeeper.auto_update"
+    )
+
+
+def test_auto_update_setup_apply_mode_runs_full_setup(tmp_path, monkeypatch):
+    pkg = _bootstrap(tmp_path, monkeypatch)
+    calls: list[list[str]] = []
+
+    def fake_run(args, *, cwd=None, timeout=None):
+        calls.append(args)
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(pkg["auto_update"], "AUTO_UPDATE_SETUP", "apply")
+    monkeypatch.setattr(pkg["auto_update"], "_run", fake_run)
+
+    out = pkg["auto_update"]._run_setup()
+
+    assert out == " setup=ok"
+    assert calls == [[sys.executable, "-m", "threadkeeper._setup"]]
+
+
+def test_auto_update_setup_skip_mode_avoids_subprocess(tmp_path, monkeypatch):
+    pkg = _bootstrap(tmp_path, monkeypatch)
+
+    monkeypatch.setattr(pkg["auto_update"], "AUTO_UPDATE_SETUP", "skip")
+    monkeypatch.setattr(
+        pkg["auto_update"],
+        "_run",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("setup subprocess should not run")
+        ),
+    )
+
+    assert pkg["auto_update"]._run_setup() == " setup=skipped mode=skip"
+
+
+def test_setup_dry_run_detects_legacy_migration_status(tmp_path, monkeypatch):
+    pkg = _bootstrap(tmp_path, monkeypatch)
+
+    assert pkg["auto_update"]._setup_dry_run_would_change(
+        "  [mcp_server[copilot]] copilot: migrated legacy schema + updated thread-keeper\n"
     )
 
 

--- a/tests/test_config_settings.py
+++ b/tests/test_config_settings.py
@@ -38,6 +38,7 @@ def test_defaults_match(monkeypatch):
     assert c.SPAWN_TIMEOUT_RETRY_DELAY_S == 0.0
     assert c.AUTO_UPDATE_INTERVAL_S == 86400
     assert c.AUTO_UPDATE_RESTART is True
+    assert c.AUTO_UPDATE_SETUP == "check"
     assert c.RETENTION_INTERVAL_S == 0.0
     assert c.DIALOG_RETENTION_DAYS == 0.0
     assert c.TASK_RETENTION_DAYS == 30
@@ -81,6 +82,26 @@ def test_retention_env_overrides(monkeypatch):
     assert c.PROBE_RESULT_RETENTION_DAYS == 60
     assert c.RETENTION_WAL_CHECKPOINT is True
     assert c.RETENTION_VACUUM_AFTER_ROWS == 1000
+
+
+def test_auto_update_setup_mode_normalizes_aliases(monkeypatch):
+    c = _fresh_config(
+        monkeypatch,
+        env={"THREADKEEPER_AUTO_UPDATE_SETUP": "dry-run"},
+    )
+    assert c.AUTO_UPDATE_SETUP == "check"
+
+    c = _fresh_config(
+        monkeypatch,
+        env={"THREADKEEPER_AUTO_UPDATE_SETUP": "1"},
+    )
+    assert c.AUTO_UPDATE_SETUP == "apply"
+
+    c = _fresh_config(
+        monkeypatch,
+        env={"THREADKEEPER_AUTO_UPDATE_SETUP": "off"},
+    )
+    assert c.AUTO_UPDATE_SETUP == "skip"
 
 
 def test_unknown_threadkeeper_env_key_warns(monkeypatch, caplog):
@@ -149,6 +170,7 @@ def test_all_exported_names_present(monkeypatch):
         "AUTO_UPDATE_EXPECTED_PUBLISHER_WORKFLOW",
         "AUTO_UPDATE_PYPI_BASE_URL",
         "AUTO_UPDATE_RESTART",
+        "AUTO_UPDATE_SETUP",
         "AUTO_UPDATE_TIMEOUT_S",
         "AUTO_UPDATE_VERIFY_PROVENANCE",
         "BACKGROUND_DAEMONS_ALLOWED",

--- a/threadkeeper/auto_update.py
+++ b/threadkeeper/auto_update.py
@@ -35,6 +35,7 @@ from .config import (
     AUTO_UPDATE_INTERVAL_S,
     AUTO_UPDATE_PYPI_BASE_URL,
     AUTO_UPDATE_RESTART,
+    AUTO_UPDATE_SETUP,
     AUTO_UPDATE_TIMEOUT_S,
     AUTO_UPDATE_VERIFY_PROVENANCE,
     BACKGROUND_DAEMONS_ALLOWED,
@@ -394,13 +395,54 @@ def _git_branch_remote(repo: Path) -> tuple[str, str, str] | str:
     return branch, remote, remote_branch
 
 
+def _setup_dry_run_would_change(stdout: str) -> bool:
+    """Best-effort parse of thread-keeper-setup --dry-run output."""
+    change_markers = (
+        " would ",
+        ": would ",
+        ": created",
+        ": updated",
+        ": installed",
+        ": prepended",
+        ": migrated ",
+        " + added ",
+        " + updated ",
+    )
+    for line in stdout.splitlines():
+        text = line.strip().lower()
+        if not text or text.startswith("thread-keeper setup"):
+            continue
+        if text.startswith("done."):
+            continue
+        if any(marker in text for marker in change_markers):
+            return True
+    return False
+
+
 def _run_setup() -> str:
+    mode = str(AUTO_UPDATE_SETUP).strip().lower()
+    if mode == "skip":
+        return " setup=skipped mode=skip"
+
+    args = [sys.executable, "-m", "threadkeeper._setup"]
+    if mode == "check":
+        args.append("--dry-run")
     setup = _run(
-        [sys.executable, "-m", "threadkeeper._setup"],
+        args,
         timeout=min(120, AUTO_UPDATE_TIMEOUT_S),
     )
     if setup.returncode != 0:
         return f" setup=failed err={_short(setup.stderr)}"
+    if mode == "check":
+        if _setup_dry_run_would_change(setup.stdout):
+            logger.warning(
+                "auto_update: setup dry-run found pending CLI config changes; "
+                "set THREADKEEPER_AUTO_UPDATE_SETUP=apply to allow auto-update "
+                "to write them, or run thread-keeper-setup manually. output=%s",
+                _short(setup.stdout, 240),
+            )
+            return " setup=checked status=changes_pending"
+        return " setup=checked status=unchanged"
     return " setup=ok"
 
 

--- a/threadkeeper/config.py
+++ b/threadkeeper/config.py
@@ -118,6 +118,12 @@ class Settings(BaseSettings):
     auto_update_interval_s: float = 86400.0
     auto_update_restart: bool = True
     auto_update_timeout_s: int = 600
+    # Post-update setup mode:
+    #   check (default) -> run thread-keeper-setup --dry-run and record whether
+    #                      CLI config rewrites would be needed, but do not write
+    #   apply           -> run the full installer after updates
+    #   skip            -> do not run setup from auto-update at all
+    auto_update_setup: str = "check"
     auto_update_verify_provenance: bool = True
     auto_update_pypi_base_url: str = "https://pypi.org"
     auto_update_expected_publisher_repository: str = "po4erk91/thread-keeper"
@@ -432,6 +438,30 @@ class Settings(BaseSettings):
         # vocabulary has a single owner and config stays import-cycle free.
         return v.strip().lower()
 
+    @field_validator("auto_update_setup", mode="after")
+    @classmethod
+    def _normalize_auto_update_setup(cls, v: str) -> str:
+        value = str(v).strip().lower()
+        aliases = {
+            "1": "apply",
+            "true": "apply",
+            "yes": "apply",
+            "on": "apply",
+            "0": "skip",
+            "false": "skip",
+            "no": "skip",
+            "off": "skip",
+            "disabled": "skip",
+            "dry-run": "check",
+            "dry_run": "check",
+        }
+        value = aliases.get(value, value)
+        if value not in {"check", "apply", "skip"}:
+            raise ValueError(
+                "auto_update_setup must be one of: check, apply, skip"
+            )
+        return value
+
     @field_validator("panel_roles", mode="before")
     @classmethod
     def _parse_panel_roles(cls, v):
@@ -596,6 +626,7 @@ def _derive_constants(s: "Settings") -> dict:
         "AUTO_UPDATE_INTERVAL_S": s.auto_update_interval_s,
         "AUTO_UPDATE_RESTART": s.auto_update_restart,
         "AUTO_UPDATE_TIMEOUT_S": s.auto_update_timeout_s,
+        "AUTO_UPDATE_SETUP": s.auto_update_setup,
         "AUTO_UPDATE_VERIFY_PROVENANCE": s.auto_update_verify_provenance,
         "AUTO_UPDATE_PYPI_BASE_URL": s.auto_update_pypi_base_url,
         "AUTO_UPDATE_EXPECTED_PUBLISHER_REPOSITORY": (


### PR DESCRIPTION
## Summary
- default auto-update post-setup to a dry-run check instead of silently applying CLI config rewrites
- add THREADKEEPER_AUTO_UPDATE_SETUP modes: check, apply, skip
- document the consent behavior and add focused auto-update/config tests

## Tests
- env -u THREADKEEPER_NO_EMBEDDINGS .venv/bin/python -m pytest -q (exited 0 twice; quiet config suppresses pass-count summary)
- env -u THREADKEEPER_NO_EMBEDDINGS .venv/bin/python -m pytest -q -o addopts='--strict-markers' (1128 passed, 1 skipped, 95 warnings)

Closes #87