### PR TITLE
fix: hot-config reload watches the universal .env layer, not just Claude settings.json (#133)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -43,9 +43,15 @@
 # THREADKEEPER_SKILL_UPDATE_INFER_SOURCES=true # infer source by skill name from configured source roots
 # THREADKEEPER_SKILL_UPDATE_ALLOW_UNTRACKED_OVERWRITE=false  # do not overwrite inferred untracked local edits by default
 
-# ── hot-config reload (#2) ──
-# THREADKEEPER_CONFIG_WATCH_INTERVAL_S=2        # poll ~/.claude/settings.json and hot-apply changed env knobs in-process; 0 disables
-# THREADKEEPER_CONFIG_WATCH_PATH=               # override the watched settings.json path (default ~/.claude/settings.json)
+# ── hot-config reload (#2, cross-CLI #133) ──
+# Hybrid watch (default): this universal .env (every host reads it) PLUS the
+# host CLI's own env-block file (Claude -> ~/.claude/settings.json), resolved
+# via host identity. Editing a knob here hot-reloads it on all seven CLIs,
+# precedence-correct (real env > .env > default). Put runtime-tunable knobs
+# here for unambiguous cross-CLI, cross-scope hot-reload.
+# THREADKEEPER_CONFIG_WATCH_INTERVAL_S=2        # poll interval (s); 0 disables the watcher
+# THREADKEEPER_CONFIG_WATCH_PATH=               # escape hatch: pin ONE file to watch (single-file mode); disables the universal .env target
+# THREADKEEPER_ENV_FILE=                        # relocate this universal env-file (default ~/.threadkeeper/.env)
 
 # ── ingest ──
 # THREADKEEPER_INGEST_CAP=50

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ version bumps follow semver per the policy in
 
 ### Changed
 
+- **Hot-config reload now watches the universal `~/.threadkeeper/.env` layer,
+  not just Claude's `settings.json` (#133).** The `config_watcher` previously
+  hardcoded `~/.claude/settings.json` — the lowest-priority layer for Claude
+  Code and the wrong file (or a no-op) for the other six CLIs, so an edited
+  knob never hot-reloaded on Codex / Desktop / Antigravity / Gemini / Copilot
+  (observed this session: `retention` set in `.env` only took effect on the
+  Claude-spawned server). The watcher now polls two targets: the universal
+  `.env` (read by every host's `Settings()`; reloaded natively with no
+  `os.environ` mirroring, so real spawn-time env keeps precedence — no
+  inversion) plus the host CLI's own env-block file resolved via
+  `identity.active_cli()`. A key a higher scope pinned at spawn is no longer
+  silently overridden by the lowest-priority user file (#133 problem 1).
+  `THREADKEEPER_CONFIG_WATCH_PATH` becomes a single-file escape hatch;
+  `config_watch_status()` reports both watched files.
 - **Evolve loops run in a dedicated managed checkout by default (#164
   isolation).** The reviewer and applier resolve their working checkout to
   `~/.threadkeeper/evolve-repo` even on an editable install, instead of the

--- a/README.md
+++ b/README.md
@@ -938,8 +938,8 @@ The most-used env knobs (full list in `threadkeeper/config.py`):
 | `THREADKEEPER_SKILL_UPDATE_SOURCES` | `openai/skills@main:skills/.curated` | comma-separated GitHub source roots (`owner/repo@ref:path`) used to infer upstream skill updates |
 | `THREADKEEPER_SKILL_UPDATE_INFER_SOURCES` | true | infer upstream source by skill name from configured source roots |
 | `THREADKEEPER_SKILL_UPDATE_ALLOW_UNTRACKED_OVERWRITE` | false | allow overwriting inferred untracked local skill copies; default false only adopts exact matches |
-| `THREADKEEPER_CONFIG_WATCH_INTERVAL_S` | 2 | hot-config reload: poll `~/.claude/settings.json` and re-apply changed env knobs in-process (no Claude Code restart); 0 disables |
-| `THREADKEEPER_CONFIG_WATCH_PATH` | "" (`~/.claude/settings.json`) | override the watched settings file |
+| `THREADKEEPER_CONFIG_WATCH_INTERVAL_S` | 2 | hot-config reload: poll the universal `~/.threadkeeper/.env` (every host) + the host CLI's env-block file and re-apply changed env knobs in-process (no CLI restart); 0 disables |
+| `THREADKEEPER_CONFIG_WATCH_PATH` | "" | escape hatch: pin ONE settings file to watch (single-file mode); when unset, hybrid mode watches `.env` + the CLI file resolved via host identity |
 | `THREADKEEPER_SHADOW_REVIEW_INTERVAL_S` | 0 (off) | shadow daemon tick (s) |
 | `THREADKEEPER_SHADOW_REVIEW_WINDOW_S` | 900 | sliding window for shadow scan (s) |
 | `THREADKEEPER_EXTRACT_INTERVAL_S` | 0 (off) | extract daemon tick (s); 600 = 10 min recommended |
@@ -1005,11 +1005,16 @@ to three local presets, and request a ThreadKeeper restart after saving.
 At startup and hot-reload, unknown `THREADKEEPER_*` keys present in the process
 environment are logged as warnings so mistyped host env-block overrides do not
 fail silently.
-Hot-config reload for the watched `settings.json` env block is implemented
-(shipped in #2): the `config_watcher` daemon re-applies changed `THREADKEEPER_*`
-knobs in-process within ~2 s, with no Claude Code restart — toggle it via
+Hot-config reload is implemented (shipped in #2, generalized cross-CLI in
+#133): the `config_watcher` daemon re-applies changed `THREADKEEPER_*` knobs
+in-process within ~2 s, with no CLI restart. It watches two layers — the
+universal `~/.threadkeeper/.env` (read by every host's `Settings()`, so an edit
+hot-reloads on all seven CLIs and stays precedence-correct: real env > `.env` >
+default) and the host CLI's own env-block file (Claude Code →
+`~/.claude/settings.json`, resolved via host identity; a key a higher scope
+pinned at spawn is never overridden by the lower-priority user file). Toggle via
 `THREADKEEPER_CONFIG_WATCH_INTERVAL_S` (above; `0` disables) and inspect with
-`config_watch_status()`.
+`config_watch_status()`, which reports both watched files.
 
 ### Per-loop agent dispatch
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -286,27 +286,43 @@ All daemon threads are cheap (ticks 0.5–30 s), no-op when env-knobs disable th
   skills are backed up under the state dir, and source-tracked local edits after
   the last upstream hash are skipped rather than overwritten.
 - **config_watcher** (`config_watcher.start_config_watcher`) — once per
-  `CONFIG_WATCH_INTERVAL_S` (default 2 s, 0 = off) stats
-  `~/.claude/settings.json` (override: `THREADKEEPER_CONFIG_WATCH_PATH`) and,
-  when its mtime moves, re-reads the file's `env` block, mirrors the
-  threadkeeper-relevant keys (`THREADKEEPER_*` plus the unprefixed
-  `CLAUDE_SKILLS_DIR`/`CLAUDE_PROJECTS_DIR`) into `os.environ` (applying new
-  values, dropping deleted ones), and calls `config.reload_settings()`. That
-  re-instantiates `Settings`, re-publishes the UPPER_CASE module constants,
-  and `_propagate`s each changed value into every loaded `threadkeeper.*`
-  module that did `from .config import X` — which works because a function
-  resolves a module-global name at call time, so the next daemon tick / tool
-  call sees the new value with no restart (the issue-#2 acceptance test:
-  change the shadow interval, `shadow_review_status()` reflects it within
-  ~1 s). A daemon whose interval crossed 0 → >0 is started here; the rest
-  self-adjust (and `daemon_sleep` keeps a hot-disabled loop from busy-spinning
-  on `time.sleep(0)`, and jitters every sleep by ±15% so concurrent MCP
-  instances on one host don't fire their `ps`/notify work in lockstep — #86).
-  Cold start records only a baseline (the env is already
+  `CONFIG_WATCH_INTERVAL_S` (default 2 s, 0 = off) stats **two** targets, each
+  with its own mtime cursor (#2, generalized cross-CLI in #133):
+  1. the **universal env-file** `~/.threadkeeper/.env` (`config._ENV_FILE`,
+     overridable via `THREADKEEPER_ENV_FILE`). Every host's `Settings()` reads
+     this file, so it is the one layer that hot-reloads config for all seven
+     CLIs — not just Claude. On change it calls `config.reload_settings()` with
+     **no** `os.environ` mirroring: pydantic re-reads the file natively and
+     real spawn-time env vars keep precedence (env var > `.env` > default), so
+     there is no precedence inversion.
+  2. the **host CLI's own env-block file**, resolved from the active-CLI
+     identity (`identity.active_cli()`; Claude Code → `~/.claude/settings.json`).
+     Its `env` block's threadkeeper-relevant keys (`THREADKEEPER_*` plus the
+     unprefixed `CLAUDE_SKILLS_DIR`/`CLAUDE_PROJECTS_DIR`) are mirrored into
+     `os.environ` (applying new values, dropping deleted ones) — **minus** any
+     key a higher-priority scope pinned at spawn (detected at first sighting
+     when `os.environ` disagrees with the file's value), so the lowest-priority
+     user file never silently overrides a project/local/managed value (#133
+     problem 1). CLIs whose env block is not a flat JSON map rely on target 1.
+
+  `THREADKEEPER_CONFIG_WATCH_PATH` is an escape hatch / test seam: it pins ONE
+  file (watched as a CLI-settings target) and disables the universal env-file
+  target — legacy single-file mode. Either target's change calls
+  `config.reload_settings()`, which re-instantiates `Settings`, re-publishes
+  the UPPER_CASE module constants, and `_propagate`s each changed value into
+  every loaded `threadkeeper.*` module that did `from .config import X` — which
+  works because a function resolves a module-global name at call time, so the
+  next daemon tick / tool call sees the new value with no restart (the issue-#2
+  acceptance test: change the shadow interval, `shadow_review_status()` reflects
+  it within ~1 s). A daemon whose interval crossed 0 → >0 is started here; the
+  rest self-adjust (and `daemon_sleep` keeps a hot-disabled loop from
+  busy-spinning on `time.sleep(0)`, and jitters every sleep by ±15% so
+  concurrent MCP instances on one host don't fire their `ps`/notify work in
+  lockstep — #86). Cold start records only a baseline (the env is already
   applied at spawn); a half-written file is skipped via the mtime-cursor +
   JSON-parse guard and retried. Manual trigger `config_reload()`; diagnostics
-  `config_watch_status()`. Embedding-backend / process-identity flags are
-  intentionally not hot-reloaded.
+  `config_watch_status()` (reports both watched files). Embedding-backend /
+  process-identity flags are intentionally not hot-reloaded.
 
 Spawning daemons that enforce single-flight share one non-blocking
 `helpers.single_flight_lock(name)` primitive around their local

--- a/tests/test_config_watcher.py
+++ b/tests/test_config_watcher.py
@@ -294,3 +294,146 @@ def test_config_watch_status_tool(tmp_path, monkeypatch):
     out = mcp._tool_manager._tools["config_watch_status"].fn()
     assert "interval_s=" in out
     assert "settings.json" in out
+
+
+# ── #133: universal env-file + per-CLI resolution + precedence guard ───────
+
+def _bootstrap_hybrid(tmp_path, monkeypatch, *, env_file, active_cli="codex",
+                      watch_interval="2", extra_env=None):
+    """Re-import threadkeeper in HYBRID mode: no CONFIG_WATCH_PATH override, so
+    the watcher watches the universal env-file (THREADKEEPER_ENV_FILE -> a tmp
+    .env) plus the host-CLI file resolved from THREADKEEPER_ACTIVE_CLI."""
+    env = {
+        "THREADKEEPER_DB": str(tmp_path / "db.sqlite"),
+        "CLAUDE_PROJECTS_DIR": str(tmp_path / "fake_claude_projects"),
+        "THREADKEEPER_DISABLE_BG_DAEMONS": "1",
+        "THREADKEEPER_INGEST_INTERVAL_S": "0",
+        "THREADKEEPER_INGEST_CAP": "0",
+        "THREADKEEPER_SKILL_WATCH_INTERVAL_S": "0",
+        "THREADKEEPER_SPAWN_BUDGET_POLL_S": "0",
+        "THREADKEEPER_SEARCH_PROXY_POLL_S": "0",
+        "THREADKEEPER_MEMORY_GUARD_POLL_S": "0",
+        "THREADKEEPER_AUTO_UPDATE_INTERVAL_S": "0",
+        "THREADKEEPER_CONFIG_WATCH_INTERVAL_S": watch_interval,
+        "THREADKEEPER_ENV_FILE": str(env_file),
+        "THREADKEEPER_ACTIVE_CLI": active_cli,
+        "THREADKEEPER_CLIENT": "pytest",
+        "THREADKEEPER_FORCE_CID": "aaaa1111-2222-3333-4444-555566667777",
+    }
+    if extra_env:
+        env.update(extra_env)
+    # Isolate: let the tmp .env (not the runner's own environment) own these.
+    for k in ("THREADKEEPER_SHADOW_REVIEW_INTERVAL_S",
+              "THREADKEEPER_RETENTION_INTERVAL_S"):
+        if k not in env:
+            monkeypatch.delenv(k, raising=False)
+    for k, v in env.items():
+        monkeypatch.setenv(k, v)
+    Path(env["CLAUDE_PROJECTS_DIR"]).mkdir(parents=True, exist_ok=True)
+    for name in [m for m in list(sys.modules) if m.startswith("threadkeeper")]:
+        del sys.modules[name]
+    import threadkeeper.server  # noqa: F401  (registers tools)
+    from threadkeeper import config, config_watcher
+    return {"config": config, "watcher": config_watcher}
+
+
+def _bump(path: Path) -> None:
+    """Nudge mtime forward so the watcher sees the change (coarse-fs safe)."""
+    import os
+    st = path.stat()
+    os.utime(path, (st.st_atime, st.st_mtime + 1))
+
+
+def test_env_file_change_hot_reloads_for_any_host(tmp_path, monkeypatch):
+    """The universal env-file hot-reloads for EVERY host — here a non-Claude
+    host (codex) with no CLI env-block file: only the env-file target fires.
+    This is the cross-CLI gap #133 closes (retention-class bug)."""
+    env_file = tmp_path / ".env"
+    env_file.write_text("THREADKEEPER_SHADOW_REVIEW_INTERVAL_S=111\n")
+    pkg = _bootstrap_hybrid(tmp_path, monkeypatch, env_file=env_file,
+                            active_cli="codex")
+    w = pkg["watcher"]
+    assert pkg["config"].SHADOW_REVIEW_INTERVAL_S == 111.0
+    out = w.run_config_watch_pass()  # init
+    assert "env=initialized" in out
+    assert "cli=" not in out  # codex has no parseable env-block file here
+    env_file.write_text("THREADKEEPER_SHADOW_REVIEW_INTERVAL_S=222\n")
+    _bump(env_file)
+    out = w.run_config_watch_pass()
+    assert "env=reloaded" in out
+    assert pkg["config"].SHADOW_REVIEW_INTERVAL_S == 222.0
+
+
+def test_env_file_does_not_override_real_spawn_env(tmp_path, monkeypatch):
+    """Native .env re-read keeps precedence: a real spawn-time env var wins
+    over the .env file, and editing .env never inverts that (the mirroring
+    trap #133 flags for settings.json does not exist for the env-file path)."""
+    env_file = tmp_path / ".env"
+    env_file.write_text("THREADKEEPER_SHADOW_REVIEW_INTERVAL_S=111\n")
+    pkg = _bootstrap_hybrid(
+        tmp_path, monkeypatch, env_file=env_file, active_cli="codex",
+        extra_env={"THREADKEEPER_SHADOW_REVIEW_INTERVAL_S": "777"},
+    )
+    w = pkg["watcher"]
+    assert pkg["config"].SHADOW_REVIEW_INTERVAL_S == 777.0  # env wins over .env
+    w.run_config_watch_pass()  # init
+    env_file.write_text("THREADKEEPER_SHADOW_REVIEW_INTERVAL_S=222\n")
+    _bump(env_file)
+    w.run_config_watch_pass()
+    assert pkg["config"].SHADOW_REVIEW_INTERVAL_S == 777.0  # still env, not .env
+
+
+def test_higher_scope_pin_not_overridden_by_user_file(tmp_path, monkeypatch):
+    """Issue #133 problem 1: a key a higher scope pinned at spawn (os.environ
+    disagrees with the lowest-priority user settings file) is NOT mirrored
+    over by the user-level value."""
+    pkg = _bootstrap(tmp_path, monkeypatch, shadow="0")  # env + file both 0
+    w = pkg["watcher"]
+    # A higher-priority scope pins 999; the user file still says 0.
+    monkeypatch.setenv("THREADKEEPER_SHADOW_REVIEW_INTERVAL_S", "999")
+    w.run_config_watch_pass()  # init: detects the divergence -> shadowed
+    assert "THREADKEEPER_SHADOW_REVIEW_INTERVAL_S" in w._shadowed_keys
+    # User edits the (lowest-priority) user file; it must NOT win.
+    _write_env(pkg["settings_json"],
+               {"THREADKEEPER_SHADOW_REVIEW_INTERVAL_S": "123"})
+    w.run_config_watch_pass()
+    assert "THREADKEEPER_SHADOW_REVIEW_INTERVAL_S" not in w._applied_keys
+    assert pkg["config"].SHADOW_REVIEW_INTERVAL_S == 999.0  # higher scope wins
+
+
+def test_cli_settings_path_resolves_via_identity(tmp_path, monkeypatch):
+    """The host CLI file is resolved from active-CLI identity, not hardcoded:
+    Claude -> ~/.claude/settings.json; a host with no env-block file -> None
+    (it hot-reloads via the universal env-file instead)."""
+    env_file = tmp_path / ".env"
+    env_file.write_text("")
+    pkg = _bootstrap_hybrid(tmp_path, monkeypatch, env_file=env_file,
+                            active_cli="claude")
+    w = pkg["watcher"]
+    from threadkeeper import identity
+    assert w._cli_settings_path() == Path("~/.claude/settings.json").expanduser()
+    # Switch host identity to a CLI with no env-block file -> None.
+    identity._active_cli = None
+    monkeypatch.setenv("THREADKEEPER_ACTIVE_CLI", "codex")
+    assert w._cli_settings_path() is None
+
+
+def test_hybrid_status_reports_both_files(tmp_path, monkeypatch):
+    """config_watch_status surfaces BOTH watched files in hybrid mode."""
+    env_file = tmp_path / ".env"
+    env_file.write_text("THREADKEEPER_SHADOW_REVIEW_INTERVAL_S=111\n")
+    settings_json = tmp_path / "settings.json"
+    settings_json.write_text(json.dumps({"env": {}}))
+    pkg = _bootstrap_hybrid(tmp_path, monkeypatch, env_file=env_file,
+                            active_cli="claude")
+    # Redirect the claude env-block file to a tmp file (never touch ~/.claude).
+    monkeypatch.setitem(pkg["watcher"]._CLI_SETTINGS_FILE, "claude",
+                        str(settings_json))
+    pkg["watcher"].run_config_watch_pass()
+    from threadkeeper._mcp import mcp
+    out = mcp._tool_manager._tools["config_watch_status"].fn()
+    assert "mode=hybrid" in out
+    assert "env_file=" in out
+    assert str(env_file) in out
+    assert "cli_file=" in out
+    assert str(settings_json) in out

--- a/threadkeeper/config_watcher.py
+++ b/threadkeeper/config_watcher.py
@@ -1,30 +1,55 @@
-"""Hot-config reload daemon (issue #2).
+"""Hot-config reload daemon (issue #2 + #133).
 
-Problem: the MCP server receives its env at stdio-spawn time (Claude Code
-injects the `env` block of `~/.claude/settings.json` into the process). When
-the user edits an env knob — e.g. `THREADKEEPER_SHADOW_REVIEW_INTERVAL_S` —
-the running server never re-reads it, so a full Claude Code restart is the
-only way the change takes effect.
+Problem: the MCP server receives its env at stdio-spawn time (the host CLI
+injects env into the process). When the user edits an env knob — e.g.
+`THREADKEEPER_SHADOW_REVIEW_INTERVAL_S` — the running server never re-reads it,
+so a full CLI restart is the only way the change takes effect.
 
-This daemon closes that gap. It polls `~/.claude/settings.json` (a single
-mtime stat per tick — cheap), and when the file changes it:
+This daemon closes that gap. It polls two independent targets (a single mtime
+stat per target per tick — cheap):
 
-1. parses the file's `env` block,
-2. mirrors the threadkeeper-relevant keys into `os.environ` (applying new
-   values and dropping keys the user deleted),
+1. **The universal env-file** (`~/.threadkeeper/.env`, overridable via
+   `THREADKEEPER_ENV_FILE`). Every host's `Settings()` reads this file, so it
+   is the one layer that hot-reloads config for ALL seven CLIs (Claude Code /
+   Desktop, Codex, Antigravity, Gemini, Copilot, VS Code) — not just Claude.
+   On change we call `config.reload_settings()` with NO os.environ mirroring:
+   pydantic re-reads the file natively and real spawn-time env vars keep their
+   precedence (env var > .env file > default). No precedence inversion.
+
+2. **The host CLI's own env-block file**, resolved from the active-CLI
+   identity (Claude Code → `~/.claude/settings.json`). Its `env` block is
+   mirrored into `os.environ` and republished — MINUS any key a
+   higher-priority layer already pinned at spawn (see below). CLIs whose env
+   block we cannot yet parse as a flat map rely on target 1 alone (they still
+   hot-reload, just via the universal `.env`).
+
+`THREADKEEPER_CONFIG_WATCH_PATH` is an escape hatch / test seam: when set it
+pins ONE file (watched as a CLI-settings target), and the universal env-file
+target is skipped — legacy single-file behavior.
+
+On a real change the daemon:
+
+1. parses the changed file (target 2) or re-reads natively (target 1),
+2. for target 2, mirrors the threadkeeper-relevant keys into `os.environ`
+   (applying new values and dropping keys the user deleted), excluding keys a
+   higher-priority scope pinned at spawn (issue #133 precedence guard),
 3. calls `config.reload_settings()` which re-instantiates `Settings`,
-   re-publishes the module constants, and propagates every changed value
-   into the loaded `threadkeeper.*` modules that imported a copy, and
+   re-publishes the module constants, and propagates every changed value into
+   the loaded `threadkeeper.*` modules that imported a copy, and
 4. starts any daemon that was just enabled (interval 0 → >0). Daemons that
-   were already running pick up a changed interval on their next tick
-   (their `_serve_loop` reads the interval module-global dynamically); a
-   daemon disabled at runtime (interval → 0) idles via `daemon_sleep`.
+   were already running pick up a changed interval on their next tick (their
+   `_serve_loop` reads the interval module-global dynamically); a daemon
+   disabled at runtime (interval → 0) idles via `daemon_sleep`.
 
 Caveats (from the roadmap item):
 - Does NOT help host-CLI hooks — those are read by the CLI, not by us.
+- For target 2 (Claude), only the USER-level settings file is read; a knob set
+  at a higher scope (project/local/managed) is honored via the spawn-time
+  precedence guard but its later edits are not tracked. Put runtime-tunable
+  knobs in the universal `.env` for unambiguous cross-scope hot-reload.
 - Racy multi-writer edits are handled by debounce (poll granularity) + a
-  JSON-parse guard: a half-written file is skipped and retried next tick,
-  and the mtime cursor is only advanced on a clean read.
+  JSON-parse guard: a half-written file is skipped and retried next tick, and
+  the mtime cursor is only advanced on a clean read.
 """
 
 from __future__ import annotations
@@ -49,14 +74,30 @@ _started = False
 
 # Per-process watcher state. Each MCP server watches and reloads its OWN
 # in-process config — this is intentionally not shared via the DB.
-_last_mtime: Optional[float] = None
-_applied_keys: set[str] = set()
+#
+# Two independent watch targets, each with its own mtime cursor:
+#   * env-file (universal ~/.threadkeeper/.env) — reloaded natively, no
+#     os.environ mirroring, so real spawn-time env keeps precedence.
+#   * cli-settings (host CLI env-block file via identity) — mirrored into
+#     os.environ, minus keys a higher-priority layer pinned at spawn.
+_env_last_mtime: Optional[float] = None      # env-file target cursor
+_last_mtime: Optional[float] = None          # cli-settings target cursor
+_applied_keys: set[str] = set()              # keys mirrored from the cli file
+_shadowed_keys: set[str] = set()             # cli-file keys a higher layer pins
 
 # Unprefixed env names threadkeeper honors (see config.AliasChoices). Pulled
 # from settings.json alongside every THREADKEEPER_* key.
 _UNPREFIXED_KEYS: frozenset[str] = frozenset(
     {"CLAUDE_SKILLS_DIR", "CLAUDE_PROJECTS_DIR"}
 )
+
+# Host CLI -> its env-block settings file (relative to $HOME). Only CLIs whose
+# env block we can parse as a flat {key: value} JSON map appear here. Others
+# rely on the universal env-file target — they still hot-reload, just via
+# ~/.threadkeeper/.env rather than their own config file.
+_CLI_SETTINGS_FILE: dict[str, str] = {
+    "claude": "~/.claude/settings.json",
+}
 
 # Interval constant -> (module, start-fn). After a reload, a daemon whose
 # interval crossed 0 → >0 is (re)started here; the rest self-adjust on their
@@ -79,13 +120,24 @@ _DAEMON_FOR_INTERVAL: dict[str, tuple[str, str]] = {
 }
 
 
-def _settings_path() -> Path:
-    """The watched file. `THREADKEEPER_CONFIG_WATCH_PATH` overrides; default
-    is the Claude Code per-user settings (`~/.claude/settings.json`)."""
+def _env_file_path() -> Path:
+    """The universal env-file every host's `Settings()` reads (precedence:
+    real env > this file > defaults). Path comes from `config._ENV_FILE`, which
+    already honors the `THREADKEEPER_ENV_FILE` override."""
+    return Path(config._ENV_FILE).expanduser()
+
+
+def _cli_settings_path() -> Optional[Path]:
+    """The host CLI's own env-block file, resolved from the active-CLI
+    identity. `THREADKEEPER_CONFIG_WATCH_PATH` overrides it (and, when set, is
+    the ONLY file watched — see run_config_watch_pass). Returns None when the
+    host CLI has no env-block file we parse here."""
     override = config.CONFIG_WATCH_PATH
     if override:
         return Path(override).expanduser()
-    return Path("~/.claude/settings.json").expanduser()
+    cli = identity.active_cli()
+    rel = _CLI_SETTINGS_FILE.get(cli or "")
+    return Path(rel).expanduser() if rel else None
 
 
 def _is_relevant(key: str) -> bool:
@@ -151,22 +203,52 @@ def _restart_changed_daemons(changed: dict) -> list[str]:
     return started
 
 
-def run_config_watch_pass(force: bool = False) -> str:
-    """Execute one watch tick synchronously (also the MCP manual trigger).
+def _tick_env_file(force: bool) -> Optional[str]:
+    """Watch the universal env-file. On change, reload `Settings()` natively —
+    NO os.environ mirroring, so the real spawn-time env still wins (pydantic
+    precedence: env vars > .env file). Returns a per-target status string, or
+    None when the file is absent (nothing to watch)."""
+    global _env_last_mtime
+    path = _env_file_path()
+    try:
+        mtime = path.stat().st_mtime
+    except FileNotFoundError:
+        return None
+    except OSError as e:
+        return f"stat_error: {e}"
 
-    Returns a short status string:
-      - 'disabled'      — watcher off (interval<=0) and not forced
-      - 'no_file'       — the settings file does not exist
-      - 'unchanged'     — mtime has not moved since the last pass
-      - 'initialized'   — first sighting; baseline recorded, no reload
-      - 'parse_error: …'— file unreadable/half-written; retried next tick
-      - 'reloaded changed=N started=[…]' — config re-read and republished
+    if not force and _env_last_mtime is not None and mtime == _env_last_mtime:
+        return "unchanged"
+
+    # First sighting (cold process): the file was already loaded by Settings()
+    # at spawn, so just record the baseline. No reload — nothing changed yet.
+    if not force and _env_last_mtime is None:
+        _env_last_mtime = mtime
+        return "initialized"
+
+    # Native re-read: reload_settings() re-instantiates Settings(), which reads
+    # os.environ + the .env file fresh. Passing no env/remove means we never
+    # mirror the (lower-priority) file into os.environ.
+    changed = config.reload_settings()
+    _env_last_mtime = mtime
+    started = _restart_changed_daemons(changed)
+    return f"reloaded changed={len(changed)} started={started}"
+
+
+def _tick_cli_settings(force: bool) -> Optional[str]:
+    """Watch the host CLI's env-block file and mirror its keys into os.environ.
+
+    Keys a higher-priority scope pinned at spawn (os.environ disagrees with
+    this file's value at first sighting) are excluded so the lower-priority
+    user-level file never silently overrides them (issue #133 problem 1).
+
+    Returns a per-target status string, or None when there is no CLI env-block
+    file for this host (the universal env-file target covers it instead).
     """
-    global _last_mtime, _applied_keys
-    if config.CONFIG_WATCH_INTERVAL_S <= 0 and not force:
-        return "disabled"
-
-    path = _settings_path()
+    global _last_mtime, _applied_keys, _shadowed_keys
+    path = _cli_settings_path()
+    if path is None:
+        return None
     try:
         mtime = path.stat().st_mtime
     except FileNotFoundError:
@@ -178,35 +260,90 @@ def run_config_watch_pass(force: bool = False) -> str:
         return "unchanged"
 
     # First sighting (cold process): the env was already applied by the host
-    # CLI at spawn, so just record the baseline + which keys are present (so a
-    # later deletion can be reverted). No reload — nothing changed yet.
+    # CLI at spawn. Record the baseline + which keys are present (so a later
+    # deletion can be reverted) + which keys a HIGHER-priority scope pins
+    # (os.environ already holds a different value) so we never mirror the
+    # lower-priority file value over them. No reload — nothing changed yet.
     if not force and _last_mtime is None:
         try:
-            _applied_keys = set(_relevant_env(path))
+            present = _relevant_env(path)
         except (json.JSONDecodeError, OSError):
             return "parse_error: malformed settings.json (will retry)"
+        _shadowed_keys = {
+            k for k, v in present.items()
+            if os.environ.get(k) not in (None, v)
+        }
+        _applied_keys = set(present) - _shadowed_keys
         _last_mtime = mtime
         return "initialized"
 
     try:
-        desired = _relevant_env(path)
+        present = _relevant_env(path)
     except (json.JSONDecodeError, OSError) as e:
         # Do NOT advance the cursor — retry on the next tick once the writer
         # has finished. This is the debounce/lock guard for racy writers.
         return f"parse_error: {e}"
 
+    desired = {k: v for k, v in present.items() if k not in _shadowed_keys}
     remove = sorted(_applied_keys - set(desired))
     changed = config.reload_settings(env=desired, remove=remove)
     _applied_keys = set(desired)
     _last_mtime = mtime
 
     started = _restart_changed_daemons(changed)
-    outcome = f"reloaded changed={len(changed)} started={started}"
+    return f"reloaded changed={len(changed)} started={started}"
+
+
+def run_config_watch_pass(force: bool = False) -> str:
+    """Execute one watch tick synchronously (also the MCP manual trigger).
+
+    Ticks the watch targets and returns a status string. In the default
+    (hybrid) mode it ticks BOTH the universal env-file and the host CLI's
+    env-block file and returns a combined string (``env=… cli=…``); each
+    target keeps its own mtime cursor, so an edit to either is picked up
+    independently. When `THREADKEEPER_CONFIG_WATCH_PATH` pins one file, that
+    single file is watched and its status is returned verbatim (legacy mode).
+
+    Per-target status vocabulary:
+      - 'disabled'      — watcher off (interval<=0) and not forced
+      - 'no_file'       — the CLI settings file does not exist
+      - 'unchanged'     — mtime has not moved since the last pass
+      - 'initialized'   — first sighting; baseline recorded, no reload
+      - 'parse_error: …'— file unreadable/half-written; retried next tick
+      - 'reloaded changed=N started=[…]' — config re-read and republished
+    """
+    if config.CONFIG_WATCH_INTERVAL_S <= 0 and not force:
+        return "disabled"
+
+    # Escape hatch / test seam: CONFIG_WATCH_PATH pins ONE file. Watch only it
+    # (as a cli-settings target) and return its status verbatim.
+    if config.CONFIG_WATCH_PATH:
+        outcome = _tick_cli_settings(force) or "no_file"
+        if "reloaded" in outcome:
+            _record_outcome(outcome, _last_mtime)
+        return outcome
+
+    # Default (production): dual watch — universal env-file + host CLI file.
+    parts: list[str] = []
+    env_status = _tick_env_file(force)
+    if env_status is not None:
+        parts.append(f"env={env_status}")
+    cli_status = _tick_cli_settings(force)
+    if cli_status is not None:
+        parts.append(f"cli={cli_status}")
+
+    outcome = " ".join(parts) if parts else "no_targets"
+    if "reloaded" in outcome:
+        _record_outcome(outcome, max(_env_last_mtime or 0.0, _last_mtime or 0.0))
+    return outcome
+
+
+def _record_outcome(outcome: str, mtime: Optional[float]) -> None:
+    """Persist a reload outcome, swallowing DB errors (observability only)."""
     try:
-        _record_pass(get_db(), mtime, outcome)
+        _record_pass(get_db(), mtime or 0.0, outcome)
     except Exception:
         logger.debug("config_watch: record failed", exc_info=True)
-    return outcome
 
 
 def _serve_loop() -> None:

--- a/threadkeeper/tools/config_watch.py
+++ b/threadkeeper/tools/config_watch.py
@@ -1,13 +1,13 @@
-"""MCP tools for hot-config reload (issue #2).
+"""MCP tools for hot-config reload (issue #2 + #133).
 
   config_reload(force=True)
-    Re-read ~/.claude/settings.json NOW and republish changed knobs across
+    Re-read the watched config files NOW and republish changed knobs across
     the live process. `force=True` (default) bypasses the mtime/interval
     gates so a manual call always re-reads.
 
   config_watch_status()
-    Diagnostic snapshot: watched file, interval, cursor, applied keys, and
-    the last few reload passes.
+    Diagnostic snapshot: watched files (universal env-file + host CLI file),
+    interval, cursors, applied/shadowed keys, and the last few reload passes.
 """
 
 from __future__ import annotations
@@ -23,13 +23,14 @@ from .. import config_watcher
 
 @write_tool(idempotent=True)
 def config_reload(force: bool = True) -> str:
-    """Re-read the watched settings file and hot-apply changed env knobs.
+    """Re-read the watched config files and hot-apply changed env knobs.
 
-    Mirrors the threadkeeper-relevant `env` keys from
-    `~/.claude/settings.json` into the live process (no Claude Code restart),
-    then republishes the changed constants to every daemon and tool. Newly
-    enabled daemons are started; changed intervals take effect on the next
-    daemon tick. Returns the pass outcome (e.g. `reloaded changed=2 ...`).
+    Re-reads the universal env-file (`~/.threadkeeper/.env`, every host) and
+    the host CLI's own env-block file (Claude Code → `~/.claude/settings.json`)
+    into the live process — no CLI restart — then republishes the changed
+    constants to every daemon and tool. Newly enabled daemons are started;
+    changed intervals take effect on the next daemon tick. Returns the pass
+    outcome (e.g. `env=reloaded changed=2 ... cli=unchanged`).
     """
     conn = get_db()
     _ensure_session(conn)
@@ -38,21 +39,53 @@ def config_reload(force: bool = True) -> str:
 
 @read_tool()
 def config_watch_status() -> str:
-    """Show hot-config-reload state + the last 5 reload passes."""
+    """Show hot-config-reload state + the last 5 reload passes.
+
+    In hybrid mode reports both watched files: the universal env-file
+    (`~/.threadkeeper/.env`, all hosts) and the host CLI's env-block file
+    (resolved via identity). `THREADKEEPER_CONFIG_WATCH_PATH` pins a single
+    file (legacy single-file mode).
+    """
     conn = get_db()
     _ensure_session(conn)
     now = int(time.time())
-    path = config_watcher._settings_path()
-    last_mtime = config_watcher._last_mtime
-    applied = sorted(config_watcher._applied_keys)
+    cw = config_watcher
+
+    def _cur(m: object) -> str:
+        return f"{m:.3f}" if isinstance(m, (int, float)) else "(none)"
+
+    single = bool(config.CONFIG_WATCH_PATH)
     lines = [
         f"interval_s={config.CONFIG_WATCH_INTERVAL_S:.0f} "
-        f"file={path} exists={path.exists()}",
-        f"cursor_mtime={last_mtime if last_mtime is not None else '(none)'} "
-        f"applied_keys={len(applied)}",
+        f"mode={'single-file' if single else 'hybrid'}"
     ]
-    if applied:
-        lines.append("  " + ", ".join(applied))
+
+    # Universal env-file target (skipped in single-file/escape-hatch mode).
+    if not single:
+        env = cw._env_file_path()
+        lines.append(
+            f"env_file={env} exists={env.exists()} "
+            f"cursor_mtime={_cur(cw._env_last_mtime)}"
+        )
+
+    # Host CLI env-block file target.
+    cli = cw._cli_settings_path()
+    if cli is not None:
+        applied = sorted(cw._applied_keys)
+        shadowed = sorted(cw._shadowed_keys)
+        lines.append(
+            f"cli_file={cli} exists={cli.exists()} "
+            f"cursor_mtime={_cur(cw._last_mtime)} "
+            f"applied_keys={len(applied)} shadowed_keys={len(shadowed)}"
+        )
+        if applied:
+            lines.append("  applied: " + ", ".join(applied))
+        if shadowed:
+            lines.append("  shadowed (higher-scope pins): " + ", ".join(shadowed))
+    else:
+        host = cw.identity.active_cli() or "(unknown)"
+        lines.append(f"cli_file=(none — host {host!r} hot-reloads via env_file)")
+
     lines.append("")
     lines.append("recent passes (newest first):")
     try:


### PR DESCRIPTION
## Problem (#133)

`config_watcher` hardcoded `~/.claude/settings.json`, which is:
- the **lowest-priority** layer for Claude Code (managed > local > project > **user**), so a knob set at a higher scope was never hot-reloaded — and worse, the user-level value could be mirrored back over a higher-priority spawn value (silent wrong-value);
- the **wrong file / a no-op** for the other six CLIs (Codex, Desktop, Antigravity, Gemini, Copilot, VS Code), which receive env from their own config, not Claude's.

Observed this session: `retention` added to `~/.threadkeeper/.env` only took effect on the Claude-spawned server; Codex/Desktop-spawned servers never picked it up.

## Fix — `.env`-primary hybrid

The watcher now polls **two independent targets**, each with its own mtime cursor:

1. **The universal env-file** `~/.threadkeeper/.env` (`config._ENV_FILE`, overridable via `THREADKEEPER_ENV_FILE`). Every host's `Settings()` reads it, so an edit hot-reloads on **all seven CLIs**. Reloaded **natively** via `reload_settings()` with no `os.environ` mirroring, so real spawn-time env keeps precedence (**env > `.env` > default** — no inversion).
2. **The host CLI's own env-block file**, resolved from `identity.active_cli()` (Claude → `~/.claude/settings.json`). Its keys are mirrored into `os.environ` **minus** any key a higher-priority scope pinned at spawn (detected at first sighting when `os.environ` disagrees with the file) — so the lowest-priority user file never silently overrides a project/local/managed value (**#133 problem 1**).

`THREADKEEPER_CONFIG_WATCH_PATH` becomes a single-file **escape hatch** (pins one file, disables the `.env` target — legacy behavior, used by the existing test seam). `config_watch_status()` now reports **both** watched files, cursors, and applied/shadowed keys.

## Acceptance criteria

- [x] A server spawned by CLI X watches a file that governs its config — the universal `.env` for every host, plus the host CLI file resolved via identity (unit test: `test_cli_settings_path_resolves_via_identity`).
- [x] A key a higher scope pinned is not overridden by a stale user-level value (`test_higher_scope_pin_not_overridden_by_user_file`).
- [x] Hot-reload scope documented (README + `docs/ARCHITECTURE.md`); `config_watch_status()` surfaces the watched files (`test_hybrid_status_reports_both_files`).

## Tests

`48 passed` across `test_config_watcher.py` (16 existing + 5 new), `test_tool_annotations.py`, `test_config_settings.py`. New: cross-CLI env-file reload, real-env-wins precedence, shadowed-key guard, identity path resolution, hybrid status.

## Docs

README (env table + hot-reload prose), `docs/ARCHITECTURE.md` (config_watcher bullet), `.env.example`, `CHANGELOG.md`.

Closes #133.

🤖 Generated with [Claude Code](https://claude.com/claude-code)