### PR TITLE
test: stop evolve tests provisioning a real checkout (~850s off the suite)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,4 +50,9 @@ jobs:
           # per-test package re-import (tests/conftest.py) otherwise piles up
           # native ONNX/tokenizer thread pools that can deadlock sqlite
           # connection finalize in a single long-lived interpreter.
+          # NB: kept serial on purpose. `-n auto` (pytest-xdist) does not
+          # compose here — with --forked it collides on the xdist worker tmp
+          # dir, and without --forked a few tests race on shared state. Fixing
+          # the suite for parallel runs is tracked separately; xdist is shipped
+          # as an opt-in local accelerator (see CONTRIBUTING).
           python -m pytest -q --forked --tb=short

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,18 @@ version bumps follow semver per the policy in
 
 ### Changed
 
-- **Faster local test loop + opt-in parallel runs.** The heaviest test files
-  (`test_evolve_applier.py`, `test_evolve_daemon.py`) are now marked
-  `pytest.mark.slow` (joining `test_onnx_embeddings.py`), so `pytest -m "not
-  slow"` skips the ~30 s-per-test evolve suite for a fast local inner loop.
-  Added `pytest-xdist` to the `dev` extra as an opt-in local accelerator
+- **Evolve tests no longer provision a real checkout — ~850 s off the suite.**
+  The evolve applier/reviewer resolve their repo to an UNprovisioned managed
+  checkout by default (#164/#214); the test bootstraps left that unpinned, so
+  every dispatch test ran a real `git clone` + venv + `pip install` against a
+  shared dir (`test_apply_evolve_builds_spawn_call` alone was 42 s). The evolve
+  test bootstraps and the shared `fresh_mp` fixture now pin a ready tmp checkout
+  so those tests run without a real clone and stay isolated:
+  `test_evolve_applier.py` 80 tests ~900 s → 9.5 s, `test_evolve_daemon.py`
+  ~145 s → 2.7 s, the evolve `test_tool_smoke` params ~26 s each → <0.1 s.
+  Also added `pytest-xdist` to the `dev` extra as an opt-in local accelerator
   (`-n auto`); CI stays serial `--forked` because the suite is not yet
-  parallel-safe (tracked in #217). CONTRIBUTING documents both.
+  parallel-safe (tracked in #217). CONTRIBUTING documents the runners.
 - **Hot-config reload now watches the universal `~/.threadkeeper/.env` layer,
   not just Claude's `settings.json` (#133).** The `config_watcher` previously
   hardcoded `~/.claude/settings.json` — the lowest-priority layer for Claude

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ version bumps follow semver per the policy in
 
 ### Changed
 
+- **Faster local test loop + opt-in parallel runs.** The heaviest test files
+  (`test_evolve_applier.py`, `test_evolve_daemon.py`) are now marked
+  `pytest.mark.slow` (joining `test_onnx_embeddings.py`), so `pytest -m "not
+  slow"` skips the ~30 s-per-test evolve suite for a fast local inner loop.
+  Added `pytest-xdist` to the `dev` extra as an opt-in local accelerator
+  (`-n auto`); CI stays serial `--forked` because the suite is not yet
+  parallel-safe (tracked in #217). CONTRIBUTING documents both.
 - **Evolve loops run in a dedicated managed checkout by default (#164
   isolation).** The reviewer and applier resolve their working checkout to
   `~/.threadkeeper/evolve-repo` even on an editable install, instead of the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,7 +50,7 @@ threadkeeper/            # the package
 python -m venv .venv && source .venv/bin/activate
 pip install -e '.[semantic,dev]'
 python -m pytest                 # full suite
-python -m pytest -m "not slow"   # fast inner loop — skips the slow evolve/embedding tests
+python -m pytest -m "not slow"   # fast inner loop — skips the embedding-warmup tests
 ```
 
 CI runs the full suite under `--forked` (each test in its own process; the
@@ -60,10 +60,11 @@ pools that can deadlock sqlite finalize in one long-lived interpreter).
 Test isolation uses a tempdir DB per test, all daemons disabled via env
 (`THREADKEEPER_*_INTERVAL_S=0`). See `tests/conftest.py`.
 
-The heaviest files (`test_evolve_applier.py`, `test_evolve_daemon.py`,
-`test_onnx_embeddings.py`) carry `pytestmark = pytest.mark.slow` — they exercise
-real git plumbing / embedding warmup and dominate wall-clock. `-m "not slow"`
-skips them for a fast local loop; CI still runs everything.
+`test_onnx_embeddings.py` carries `pytestmark = pytest.mark.slow` (it warms up
+the embedding model); `-m "not slow"` skips it. The evolve tests were once the
+suite's dominant cost — each ran a real `git clone` + venv + `pip install` — but
+their bootstraps (and the shared `fresh_mp` fixture) now pin a ready tmp
+checkout, so they are fast and run in every mode.
 
 `pytest-xdist` ships in the `dev` extra as an **opt-in local** accelerator
 (`pytest -n auto`). It is not the CI default: the suite is not yet fully

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,11 +49,28 @@ threadkeeper/            # the package
 ```bash
 python -m venv .venv && source .venv/bin/activate
 pip install -e '.[semantic,dev]'
-python -m pytest
+python -m pytest                 # full suite
+python -m pytest -m "not slow"   # fast inner loop — skips the slow evolve/embedding tests
 ```
+
+CI runs the full suite under `--forked` (each test in its own process; the
+per-test package re-import otherwise piles up native ONNX/tokenizer thread
+pools that can deadlock sqlite finalize in one long-lived interpreter).
 
 Test isolation uses a tempdir DB per test, all daemons disabled via env
 (`THREADKEEPER_*_INTERVAL_S=0`). See `tests/conftest.py`.
+
+The heaviest files (`test_evolve_applier.py`, `test_evolve_daemon.py`,
+`test_onnx_embeddings.py`) carry `pytestmark = pytest.mark.slow` — they exercise
+real git plumbing / embedding warmup and dominate wall-clock. `-m "not slow"`
+skips them for a fast local loop; CI still runs everything.
+
+`pytest-xdist` ships in the `dev` extra as an **opt-in local** accelerator
+(`pytest -n auto`). It is not the CI default: the suite is not yet fully
+parallel-safe (a few tests race on shared state) and `-n auto` does not compose
+with `--forked`. See [#217](https://github.com/po4erk91/thread-keeper/issues/217).
+On macOS, combining `-n` with `--forked` also needs
+`OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES`.
 
 ## Schema migrations
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,11 +53,15 @@ semantic-st = [
 # Test runner + coverage. pytest-forked isolates each test in its own
 # process: the per-test package re-import (tests/conftest.py) accumulates
 # native ONNX/tokenizer thread pools that can deadlock sqlite finalize in a
-# single long-lived process, so CI runs `pytest --forked`.
+# single long-lived process, so CI runs `pytest --forked`. pytest-xdist is an
+# opt-in LOCAL accelerator (`-n auto`); it is NOT used in CI because it does
+# not compose with --forked (collides on the xdist worker tmp dir) and a few
+# tests still race under it. See CONTRIBUTING → Running tests.
 dev = [
     "pytest>=8.0",
     "pytest-cov>=5.0",
     "pytest-forked>=1.6",
+    "pytest-xdist>=3.5",
 ]
 
 [project.urls]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -114,6 +114,18 @@ def _bootstrap_mp(tmp_path, monkeypatch, force_cid: str = ""):
     import threadkeeper.server  # noqa: F401
     from threadkeeper import _mcp, identity, db, brief, config
 
+    # Mechanical invariant: no test ever provisions the real evolve checkout.
+    # The isolation default (#164/#214) resolves the evolve repo to an
+    # UNprovisioned managed checkout (~/.threadkeeper/evolve-repo); any tool
+    # that runs the apply/reviewer path (e.g. the evolve_apply* tools in the
+    # tool-smoke sweep) would then do a real `git clone` + venv + `pip install`
+    # (~25 s/call) against a shared dir. Pin a ready tmp checkout instead.
+    # Tests that exercise repo resolution itself use their own bootstrap.
+    from threadkeeper import evolve_applier as _ea
+    _repo = tmp_path / "evolve-repo"
+    monkeypatch.setattr(_ea, "_resolve_repo_root", lambda: _repo)
+    monkeypatch.setattr(_ea, "_is_git_repo", lambda p: True)
+
     return {
         "mcp": _mcp.mcp,
         "identity": identity,

--- a/tests/test_evolve_applier.py
+++ b/tests/test_evolve_applier.py
@@ -14,6 +14,13 @@ import sys
 import time
 from pathlib import Path
 
+import pytest
+
+# These evolve tests run ~30 s each and dominate the suite's wall-clock
+# (measured via --durations). Marked `slow` so `pytest -m "not slow"` gives a
+# fast local inner loop; CI still runs the full suite.
+pytestmark = pytest.mark.slow
+
 
 _FAKE_CID = "aaaa1111-2222-3333-4444-555566667777"
 

--- a/tests/test_evolve_applier.py
+++ b/tests/test_evolve_applier.py
@@ -14,18 +14,11 @@ import sys
 import time
 from pathlib import Path
 
-import pytest
-
-# These evolve tests run ~30 s each and dominate the suite's wall-clock
-# (measured via --durations). Marked `slow` so `pytest -m "not slow"` gives a
-# fast local inner loop; CI still runs the full suite.
-pytestmark = pytest.mark.slow
-
 
 _FAKE_CID = "aaaa1111-2222-3333-4444-555566667777"
 
 
-def _bootstrap(tmp_path, monkeypatch, interval="0"):
+def _bootstrap(tmp_path, monkeypatch, interval="0", pin_repo=True):
     env = {
         "THREADKEEPER_DB": str(tmp_path / "db.sqlite"),
         "CLAUDE_PROJECTS_DIR": str(tmp_path / "fake_claude_projects"),
@@ -115,6 +108,17 @@ def _bootstrap(tmp_path, monkeypatch, interval="0"):
     import threadkeeper.config as _cfg
     monkeypatch.setattr(_cfg, "ROADMAP_CLAIM_RACE_WINDOW_S", 0.0)
     monkeypatch.setattr(evolve_applier, "ROADMAP_CLAIM_RACE_WINDOW_S", 0.0)
+    # Isolation default (#164/#214) resolves to the UNprovisioned managed
+    # checkout (~/.threadkeeper/evolve-repo); left as-is the apply/spawn path
+    # calls _ensure_repo_ready() -> a real `git clone` + venv + `pip install`
+    # (~40 s/test) against a shared real dir. Pin a ready tmp checkout by
+    # default so every dispatch test runs without a real clone and stays
+    # isolated. Tests exercising the resolution/provisioning logic itself pass
+    # pin_repo=False and set up their own repo mocks.
+    if pin_repo:
+        _repo = tmp_path / "evolve-repo"
+        monkeypatch.setattr(evolve_applier, "_resolve_repo_root", lambda: _repo)
+        monkeypatch.setattr(evolve_applier, "_is_git_repo", lambda p: True)
     return {"mcp": _mcp.mcp, "db": db, "ea": evolve_applier,
             "identity": identity, "orig": orig}
 
@@ -1912,7 +1916,7 @@ def test_repo_root_prefers_env_override(tmp_path, monkeypatch):
     external = tmp_path / "external_repo"
     external.mkdir()
     monkeypatch.setenv("THREADKEEPER_EVOLVE_REPO_ROOT", str(external))
-    pkg = _bootstrap(tmp_path, monkeypatch)
+    pkg = _bootstrap(tmp_path, monkeypatch, pin_repo=False)
     assert pkg["ea"]._repo_root() == external
 
 
@@ -1928,7 +1932,7 @@ def test_repo_root_defaults_to_managed_checkout(tmp_path, monkeypatch):
 def test_repo_root_falls_back_in_place_when_autoclone_off(tmp_path, monkeypatch):
     """The escape hatch: THREADKEEPER_EVOLVE_AUTO_CLONE=0 keeps the pre-isolation
     in-place behaviour, resolving to the editable package-parent checkout."""
-    pkg = _bootstrap(tmp_path, monkeypatch)
+    pkg = _bootstrap(tmp_path, monkeypatch, pin_repo=False)
     monkeypatch.setattr(pkg["ea"], "EVOLVE_AUTO_CLONE", False)
     from pathlib import Path as _P
     pkg_parent = _P(pkg["ea"].__file__).resolve().parent.parent
@@ -2003,7 +2007,7 @@ def test_ensure_repo_ready_disabled_flag_blocks_auto_clone(tmp_path, monkeypatch
 def test_ensure_repo_ready_override_not_checkout_errors(tmp_path, monkeypatch):
     """An explicit override that isn't a checkout is never auto-cloned into —
     the user is told to fix the path."""
-    pkg = _bootstrap(tmp_path, monkeypatch)
+    pkg = _bootstrap(tmp_path, monkeypatch, pin_repo=False)
     bad = tmp_path / "not-a-repo"
     bad.mkdir()
     monkeypatch.setattr(pkg["ea"], "EVOLVE_REPO_ROOT", str(bad))

--- a/tests/test_evolve_daemon.py
+++ b/tests/test_evolve_daemon.py
@@ -15,6 +15,13 @@ import threading
 import time
 from pathlib import Path
 
+import pytest
+
+# These evolve tests run ~30 s each and dominate the suite's wall-clock
+# (measured via --durations). Marked `slow` so `pytest -m "not slow"` gives a
+# fast local inner loop; CI still runs the full suite.
+pytestmark = pytest.mark.slow
+
 
 _FAKE_CID = "dddd4444-5555-6666-7777-888899990000"
 

--- a/tests/test_evolve_daemon.py
+++ b/tests/test_evolve_daemon.py
@@ -15,18 +15,12 @@ import threading
 import time
 from pathlib import Path
 
-import pytest
-
-# These evolve tests run ~30 s each and dominate the suite's wall-clock
-# (measured via --durations). Marked `slow` so `pytest -m "not slow"` gives a
-# fast local inner loop; CI still runs the full suite.
-pytestmark = pytest.mark.slow
-
 
 _FAKE_CID = "dddd4444-5555-6666-7777-888899990000"
 
 
-def _bootstrap(tmp_path, monkeypatch, interval="0", review_min="2"):
+def _bootstrap(tmp_path, monkeypatch, interval="0", review_min="2",
+               pin_repo=True):
     env = {
         "THREADKEEPER_DB": str(tmp_path / "db.sqlite"),
         "CLAUDE_PROJECTS_DIR": str(tmp_path / "fake_claude_projects"),
@@ -68,6 +62,15 @@ def _bootstrap(tmp_path, monkeypatch, interval="0", review_min="2"):
         evolve_daemon, "_open_roadmap_doc_prs",
         lambda repo_root, branch: ([], ""),
     )
+    # Pin a ready tmp checkout so the reviewer's _ensure_repo_ready() gate does
+    # not run a real `git clone` + venv + `pip install` (~30 s/test) against the
+    # shared managed checkout. `_resolve_repo_root`/`_is_git_repo` live in
+    # evolve_applier; the daemon resolves them there. Tests exercising the
+    # provisioning/error path pass pin_repo=False.
+    if pin_repo:
+        _repo = tmp_path / "evolve-repo"
+        monkeypatch.setattr(evolve_applier, "_resolve_repo_root", lambda: _repo)
+        monkeypatch.setattr(evolve_applier, "_is_git_repo", lambda p: True)
     return {
         "mcp": _mcp.mcp,
         "db": db,


### PR DESCRIPTION
## The real cause of the slow suite

Profiling one evolve test showed **42 s in the call phase** (setup 0.01 s). Root cause: the evolve applier/reviewer resolve their repo to an **UNprovisioned managed checkout** by default (`~/.threadkeeper/evolve-repo`, from #164/#214). The evolve test bootstraps stubbed the gh/PR calls but left `_resolve_repo_root`/`_is_git_repo` unpinned — so every dispatch test ran `_ensure_repo_ready()` → a **real `git clone` + `python -m venv` + `pip install`** against a shared dir.

This was:
- **incidental** — those tests assert spawn-call construction, not provisioning;
- **not isolated** — all tests mutated the same real `~/.threadkeeper/evolve-repo`.

## Fix

Pin a ready tmp checkout in the evolve bootstraps and the shared `fresh_mp` fixture (`_resolve_repo_root` → `tmp_path/evolve-repo`, `_is_git_repo` → True) — exactly the pattern the #214 flow tests already used locally. The ~10 tests that exercise the resolution/provisioning logic itself opt out with `pin_repo=False` (or use their own mocks).

Measured:

| file | before | after |
|---|---|---|
| `test_evolve_applier.py` (80 tests) | ~900 s | **9.5 s** |
| `test_evolve_daemon.py` (20 tests) | ~145 s | **2.7 s** |
| evolve `test_tool_smoke` params | ~26 s each | **<0.1 s** |

~850 s of real provisioning removed from the suite; the evolve tests are also now properly isolated (no shared real checkout — helps the parallel-safety work in #217).

## Also

- Removes the `pytest.mark.slow` markers this PR originally added to the evolve files — they were a workaround; the tests are fast now. `test_onnx_embeddings.py` (embedding warmup) stays `slow`, so `pytest -m "not slow"` still trims the last heavy file.
- Keeps `pytest-xdist` in the `dev` extra as an **opt-in local** accelerator, documented in CONTRIBUTING with the caveats (doesn't compose with `--forked`; a few tests still race under `-n auto`; macOS needs `OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES`). CI stays serial `--forked`.
- CONTRIBUTING + CHANGELOG updated.

The remaining suite cost is the structural per-test package re-import (`fresh_mp` wipes `sys.modules` per test) + subprocess tail; making the suite parallel-safe to unlock `-n auto` is tracked in #217.

🤖 Generated with [Claude Code](https://claude.com/claude-code)