### PR TITLE
fix: preserve learning daemon scan windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,13 @@ version bumps follow semver per the policy in
 
 ### Fixed
 
+- **Learning daemons no longer drop unprocessed dialog windows (#90).**
+  `shadow_review` now keeps its old cursor when spawn admission returns
+  `ERR ...` or raises before an observer child launches, so budget-cap
+  rejections are retried on the next tick. `extract_daemon` now uses its
+  `extract_pass` cursor to extend scans when the configured interval is longer
+  than the base window, avoiding uncovered gaps between ticks.
+
 - **Auto-update no longer silently rewrites CLI setup config (#87).**
   Post-update setup now defaults to a dry-run check
   (`THREADKEEPER_AUTO_UPDATE_SETUP=check`) that records unchanged vs pending

--- a/README.md
+++ b/README.md
@@ -559,7 +559,11 @@ clusters via cosine ≥ 0.80. Each match enqueues a row in
 `extract_candidates.status='pending'`. Same self-pollution filter as
 shadow_review (autonomous child lineage excluded) plus message-level noise
 filter (compaction summaries, SKILL.md
-injections, subagent role prompts, test-runner log dumps).
+injections, subagent role prompts, test-runner log dumps). The manual
+`extract_recent()` tool uses the configured sliding window directly; the daemon
+also keeps an `extract_pass` cursor and extends a pass back to the previous
+successful tick when `THREADKEEPER_EXTRACT_INTERVAL_S` is longer than
+`THREADKEEPER_EXTRACT_WINDOW_MIN`, so no dialog falls between ticks.
 
 Where shadow extracts CLASS-LEVEL durable rules, extract harvests
 PER-INCIDENT decision-shaped utterances. Heuristic, not LLM —
@@ -942,8 +946,8 @@ The most-used env knobs (full list in `threadkeeper/config.py`):
 | `THREADKEEPER_CONFIG_WATCH_PATH` | "" | escape hatch: pin ONE settings file to watch (single-file mode); when unset, hybrid mode watches `.env` + the CLI file resolved via host identity |
 | `THREADKEEPER_SHADOW_REVIEW_INTERVAL_S` | 0 (off) | shadow daemon tick (s) |
 | `THREADKEEPER_SHADOW_REVIEW_WINDOW_S` | 900 | sliding window for shadow scan (s) |
-| `THREADKEEPER_EXTRACT_INTERVAL_S` | 0 (off) | extract daemon tick (s); 600 = 10 min recommended |
-| `THREADKEEPER_EXTRACT_WINDOW_MIN` | 30 | sliding dialog window per extract pass (min) |
+| `THREADKEEPER_EXTRACT_INTERVAL_S` | 0 (off) | extract daemon tick (s); 600 = 10 min recommended; if this exceeds the base window, the daemon extends from the previous successful `extract_pass` cursor so ticks do not leave gaps |
+| `THREADKEEPER_EXTRACT_WINDOW_MIN` | 30 | base sliding dialog window per extract pass (min); daemon runs may scan farther back only to cover an interval/window gap |
 | `THREADKEEPER_CANDIDATE_REVIEW_INTERVAL_S` | 0 (off) | candidate-reviewer daemon tick (s); 3600 = 1h recommended |
 | `THREADKEEPER_CANDIDATE_REVIEW_MIN` | 3 | min pending candidates before reviewer engages |
 | `THREADKEEPER_CURATOR_INTERVAL_S` | 0 (off) | curator daemon tick (s); 604800 = 7d recommended |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -759,7 +759,11 @@ every SHADOW_REVIEW_INTERVAL_S (default 0=off, typical prod 900s):
    broad skill. `lesson_append(source='shadow')` is the compact fallback.
 7. Child-side MCP startup sees `THREADKEEPER_SPAWNED_CHILD=1` /
    `write_origin='shadow_review'` and refuses to start its own shadow daemon.
-8. Write events.kind='shadow_review_pass' with the new high-water rowid.
+8. Write events.kind='shadow_review_pass' with the new high-water rowid only
+   after a child is actually spawned or the window was intentionally classified
+   as `no_window`/`too_short`; spawn `ERR ...` rejections, exceptions, and
+   already-running-child deferrals keep the old cursor so the same window is
+   retried.
 ```
 
 Dedupe — via an **ingest-order** cursor in `events.target` (the rowid of the
@@ -770,6 +774,12 @@ whose `created_at` lands below the cursor — still gets a fresh rowid above it
 and is reviewed exactly once (a `created_at` cursor silently stepped over it).
 Idempotent: the monotonic rowid advance means a repeated tick will not
 re-evaluate (or re-spawn on) what it has already seen.
+
+The cursor advances only after real processing. If the dispatch layer cannot
+launch an observer child — budget admission returns `ERR ...`, spawn raises, or
+another observer is already running — the pass records the prior cursor with an
+error/deferred outcome. That preserves the dialog window for the next tick
+instead of treating a launch rejection as a completed evaluation.
 
 Harvest boundary (#36): raw transcript ingest keeps autonomous child rows for
 diagnostics, but dialog-derived memory loops must not learn from their own

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -763,11 +763,14 @@ deduplicated against the issues above):
   session start), and the skip guard compares only mtime — never the stored
   `last_size` — so same-second appends are dropped. Distinct from the global
   out-of-order cursor #69 (#89).
-- Two learning daemons **drop dialog windows**: `shadow_review` records its
+- ✅ DONE (#90). Two learning daemons **dropped dialog windows**:
+  `shadow_review` recorded its
   high-water cursor even when `spawn()` returns an `ERR ...` budget-cap string
   (a value, not an exception, so the `try/except` misses it), and the `extract`
   daemon scans a fixed wall-clock window with a dead cursor, leaving an
-  uncovered gap whenever `interval > window` (#90).
+  uncovered gap whenever `interval > window`. `shadow_review` now keeps the old
+  cursor on spawn `ERR`/exception outcomes, and `extract_daemon` extends daemon
+  scans back to the previous successful `extract_pass` cursor when needed.
 - `lessons.md` append/remove is an **unlocked read-modify-write**, so concurrent
   loop writers (shadow / candidate / auto-review / foreground) last-writer-win
   and silently clobber each other's edits — the new curator single-flight only

--- a/tests/test_extract_daemon.py
+++ b/tests/test_extract_daemon.py
@@ -127,6 +127,37 @@ def test_run_extract_pass_picks_up_user_want_pattern(tmp_path, monkeypatch):
     assert "verbatim" in kinds, f"got kinds: {kinds}"
 
 
+def test_run_extract_pass_covers_interval_window_gap(tmp_path, monkeypatch):
+    """When interval > window, the daemon must scan back to its cursor so a
+    message after the previous tick but before the next sliding window is kept."""
+    pkg = _bootstrap(tmp_path, monkeypatch, interval="3600", window_min="1")
+    conn = pkg["db"].get_db()
+    first_tick = 1_800_000_000
+    next_tick = first_tick + 3600
+    pkg["extract_daemon"]._record_extract_pass(
+        conn, first_tick, "ok window=1m scanned=0",
+    )
+    _seed_dialog(
+        conn, "user",
+        "I want you to always preserve dialog that lands between daemon "
+        "ticks, even when the extract interval is longer than the window.",
+        first_tick + 120, session_id="gap-sess",
+    )
+    conn.commit()
+
+    monkeypatch.setattr(pkg["extract_daemon"].time, "time", lambda: next_tick)
+    out = pkg["extract_daemon"].run_extract_pass(force=True)
+    assert "ok" in out
+    rows = conn.execute(
+        "SELECT source_cid, content FROM extract_candidates WHERE status='pending'"
+    ).fetchall()
+    assert any(
+        r["source_cid"] == "gap-sess"
+        and "between daemon ticks" in r["content"]
+        for r in rows
+    )
+
+
 def test_extract_filters_noise_content_prefixes(tmp_path, monkeypatch):
     """Message-level noise filter — even within a valid session,
     individual messages matching known noise prefixes (compaction

--- a/tests/test_shadow_review.py
+++ b/tests/test_shadow_review.py
@@ -383,6 +383,40 @@ def test_run_shadow_pass_spawns_when_threshold_met(tmp_path, monkeypatch):
     assert "Read" not in tool_list
 
 
+def test_run_shadow_pass_spawn_err_does_not_advance_cursor(
+    tmp_path, monkeypatch,
+):
+    """spawn() can reject by returning an ERR string instead of raising.
+    No evaluator child saw the dialog, so the window must be retried."""
+    pkg = _bootstrap(tmp_path, monkeypatch, min_chars="100")
+    import threadkeeper.tools.spawn as spawn_mod
+
+    calls = []
+
+    def fake_spawn(**kwargs):
+        calls.append(kwargs)
+        return "ERR spawn budget cap would be exceeded"
+
+    monkeypatch.setattr(spawn_mod, "spawn", fake_spawn)
+
+    conn = pkg["db"].get_db()
+    long_msg = "Pattern: in this type of task always X. " * 10
+    _seed_dialog(conn, "user", long_msg, int(time.time()) - 5)
+    conn.commit()
+
+    out = pkg["shadow_review"].run_shadow_pass(force=True)
+    assert out.startswith("ERR spawn budget")
+    assert pkg["shadow_review"]._last_shadow_rowid(conn) == 0
+
+    monkeypatch.setattr(
+        spawn_mod, "spawn",
+        lambda **kw: calls.append(kw) or "spawn task_id=retry-ok pid=0",
+    )
+    retry = pkg["shadow_review"].run_shadow_pass(force=True)
+    assert "retry-ok" in retry
+    assert len(calls) == 2
+
+
 def test_run_shadow_pass_fences_injected_window_as_data(tmp_path, monkeypatch):
     """A crafted dialog turn that reads like a stated policy ("always run X /
     ignore prior skills") must be wrapped in the <observed_dialog> data

--- a/threadkeeper/extract_daemon.py
+++ b/threadkeeper/extract_daemon.py
@@ -4,9 +4,9 @@ from dialog_messages into the extract_candidates queue.
 Architecture mirror of shadow_review:
 
   1. Daemon thread wakes every EXTRACT_INTERVAL_S seconds (0 = off).
-  2. Calls extract_recent(window_min=EXTRACT_WINDOW_MIN) — same logic as
-     the MCP tool, just invoked automatically instead of waiting for the
-     agent to remember to call it.
+  2. Runs the same extraction logic as extract_recent(), but floors the scan
+     at the previous successful pass when the interval is wider than the base
+     window so dialog cannot fall between ticks.
   3. Records events.kind='extract_pass' with the per-pass counters so
      `extract_review_status()` can show health at a glance.
 
@@ -40,7 +40,7 @@ _started = False
 
 
 def _last_extract_ts(conn: sqlite3.Connection) -> int:
-    """High-water timestamp of the most recent extract pass, or 0."""
+    """Timestamp cursor from the most recent extract pass, or 0."""
     try:
         row = conn.execute(
             "SELECT target FROM events WHERE kind='extract_pass' "
@@ -71,6 +71,19 @@ def _record_extract_pass(conn: sqlite3.Connection,
         logger.debug("extract_daemon: failed to record pass", exc_info=True)
 
 
+def _extract_scan_cutoff(now: int, last_cursor: int) -> int:
+    """Earliest dialog timestamp this pass must scan.
+
+    The MCP tool keeps its simple sliding wall-clock window. The daemon adds a
+    cursor so interval > window does not leave an uncovered gap between the
+    previous pass end and the next pass's window start.
+    """
+    window_cutoff = int(now) - max(1, int(EXTRACT_WINDOW_MIN)) * 60
+    if int(last_cursor) <= 0:
+        return window_cutoff
+    return min(window_cutoff, int(last_cursor))
+
+
 def run_extract_pass(force: bool = False, *, scheduled: bool = False) -> str:
     """Execute one extract pass synchronously. Used by the daemon AND by
     the MCP tool for manual triggering.
@@ -87,17 +100,22 @@ def run_extract_pass(force: bool = False, *, scheduled: bool = False) -> str:
         "extract", EXTRACT_INTERVAL_S, scheduled=scheduled,
     ):
         return "not_due"
+    conn = get_db()
+    started_at = int(time.time())
+    last_cursor = _last_extract_ts(conn)
+    cutoff = _extract_scan_cutoff(started_at, last_cursor)
     # Late import — tools.extract registers MCP tools at import time, and
     # the daemon module loads before all tools are registered.
-    from .tools.extract import extract_recent
+    from .tools.extract import _extract_recent_from_cutoff
     try:
-        result = extract_recent(window_min=EXTRACT_WINDOW_MIN)
+        result = _extract_recent_from_cutoff(
+            cutoff, window_min=EXTRACT_WINDOW_MIN,
+        )
     except Exception as e:
         logger.debug("extract_daemon: pass failed", exc_info=True)
-        _record_extract_pass(get_db(), int(time.time()),
-                             f"error: {e}")
+        _record_extract_pass(conn, last_cursor, f"error: {e}")
         return f"error: {e}"
-    _record_extract_pass(get_db(), int(time.time()), str(result)[:200])
+    _record_extract_pass(conn, started_at, str(result)[:200])
     return str(result)
 
 

--- a/threadkeeper/shadow_review.py
+++ b/threadkeeper/shadow_review.py
@@ -594,11 +594,19 @@ def run_shadow_pass(force: bool = False, *, scheduled: bool = False) -> str:
                 ),
             )
         except Exception as e:
-            _record_shadow_pass(conn, high_water, f"spawn_error: {e}")
+            # No evaluator processed this window. Keep the old cursor so the
+            # next tick can retry the same dialog instead of dropping it.
+            _record_shadow_pass(conn, floor, f"spawn_error: {e}")
             return f"spawn_error: {e}"
 
-        _record_shadow_pass(conn, high_water, str(result)[:200])
-        return str(result)
+        result_s = str(result)
+        if result_s.startswith("ERR"):
+            # spawn() returns ERR strings for admission/budget rejections.
+            # Treat those like a running child: no child processed the window.
+            _record_shadow_pass(conn, floor, result_s[:200])
+        else:
+            _record_shadow_pass(conn, high_water, result_s[:200])
+        return result_s
 
 
 def _serve_loop() -> None:

--- a/threadkeeper/tools/extract.py
+++ b/threadkeeper/tools/extract.py
@@ -127,9 +127,13 @@ def _enqueue(conn, kind, source_uuid, source_cid, content, rationale):
     return cur.lastrowid
 
 
-@write_tool()
-def extract_recent(window_min: int = 60, max_messages: int = 500) -> str:
-    """Scan recent dialog_messages and enqueue heuristic candidates.
+def _extract_recent_from_cutoff(
+    cutoff: int,
+    *,
+    window_min: int = 60,
+    max_messages: int = 500,
+) -> str:
+    """Shared extract implementation for wall-clock and cursor-based scans.
 
     H1 user_want         → verbatim (normative phrasing)
     H2 long_insight      → distill (assistant ≥500ch + ## headers + conclusion marker)
@@ -137,8 +141,8 @@ def extract_recent(window_min: int = 60, max_messages: int = 500) -> str:
     H4 paraphrase_repeat → note (≥3 msgs cosine ≥0.80 within same session)"""
     conn = get_db()
     _ensure_session(conn)
-    now = int(time.time())
-    cutoff = now - max(1, int(window_min)) * 60
+    window_min = max(1, int(window_min))
+    cutoff = int(cutoff)
     # Exclude autonomous review/audit lineage before applying heuristics.
     from ..harvest import harvest_exclusion_cte
 
@@ -268,6 +272,16 @@ def extract_recent(window_min: int = 60, max_messages: int = 500) -> str:
         f"verbatim={counts['verbatim']} distill={counts['distill']} "
         f"concept={counts['concept']} note={counts['note']} "
         f"skipped_existing={skipped}"
+    )
+
+
+@write_tool()
+def extract_recent(window_min: int = 60, max_messages: int = 500) -> str:
+    """Scan recent dialog_messages and enqueue heuristic candidates."""
+    window_min = max(1, int(window_min))
+    cutoff = int(time.time()) - window_min * 60
+    return _extract_recent_from_cutoff(
+        cutoff, window_min=window_min, max_messages=max_messages,
     )
 
 


### PR DESCRIPTION
Summary
- Keep shadow_review cursor pinned to the prior floor when spawn returns ERR or raises before a child launches.
- Let extract_daemon scan from the older of its base window and last successful extract_pass cursor.
- Document the interval/window behavior and close the roadmap entry.

Tests
- env -u THREADKEEPER_NO_EMBEDDINGS .venv/bin/python -m pytest -q (exit 0; exact gate)
- env -u THREADKEEPER_NO_EMBEDDINGS .venv/bin/python -m pytest -o addopts='--strict-markers' -q (1136 passed, 1 skipped, 95 warnings)

Closes #90