### PR TITLE
fix: serialize lessons file writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,13 @@ version bumps follow semver per the policy in
 
 ### Fixed
 
+- **Lesson-store writes now serialize on `lessons.md.lock` (#91).**
+  `append_lesson`, `remove_lesson`, and lesson restore now hold a blocking
+  `fcntl.flock` across file creation/read/mutate/write, so foreground,
+  shadow-review, candidate-reviewer, auto-review, and curator children cannot
+  silently clobber each other's `lessons.md` edits. Added a multiprocessing
+  append/remove regression test that preserves every distinct section.
+
 - **Auto-update no longer silently rewrites CLI setup config (#87).**
   Post-update setup now defaults to a dry-run check
   (`THREADKEEPER_AUTO_UPDATE_SETUP=check`) that records unchanged vs pending

--- a/README.md
+++ b/README.md
@@ -653,6 +653,11 @@ foreground/user, pinned, or validated entries. Only after the child finishes
 does it call `evolve_mark_curator_report_applied(...)`, which prevents replaying
 the same report.
 
+The shared lesson file has its own write serialization: `lesson_append`,
+`lesson_remove`, and `lesson_restore` hold a blocking `fcntl.flock` on
+`lessons.md.lock` around file creation/read/mutate/write, so foreground calls
+and learning-loop children cannot last-writer-win over each other's sections.
+
 Lesson access is tracked the same way skill access is: `lesson_list` increments
 `lesson_usage.view_count` for displayed rows and `lesson_get` increments
 `lesson_usage.use_count` for the returned lesson. Curator dry runs include a

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -861,6 +861,11 @@ Optional subfolders: `references/`, `templates/`, `scripts/`, `assets/`.
   swept on new trash writes. Protected refusal behavior is unchanged:
   user/foreground lessons still require `force`, and pinned skills still refuse
   deletion. `mp_dashboard()` renders destructive action counts by window.
+  The lesson file itself is a separate serialization boundary:
+  `append_lesson`, `lesson_remove`, and `lesson_restore` hold a blocking
+  `fcntl.flock` on `lessons.md.lock` across file creation/read/mutate/write, so
+  foreground writes and every learning-loop child serialize on the shared
+  store instead of relying on per-daemon dispatch locks.
 
 - **skill_manage write_origin** — `THREADKEEPER_WRITE_ORIGIN`
   (`foreground` default | `background_review` | `shadow_review`) is written to

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -337,11 +337,16 @@ a dump of what would be archived" this item asked for already exists: set
 `THREADKEEPER_CURATOR_DESTRUCTIVE=0` for advisory REPORT-only.
 
 Open follow-ups (issue-backed): broader recovery/UX paths outside the snapshot
-plus trash safety net (#52); a write lock for the unlocked
-`lessons.md` read-modify-write now that the curator and shadow_review both
-mutate it (#91); bounding the curator/candidate_reviewer prompt argv so the
-full inventory dump can't hit `E2BIG` — the single-flight half of #24 has
-landed but the argv bound has not (#24). Scope: S–M each.
+plus trash safety net (#52); bounding the curator/candidate_reviewer prompt
+argv so the full inventory dump can't hit `E2BIG` — the single-flight half of
+#24 has landed but the argv bound has not (#24). Scope: S–M each.
+
+✅ DONE (#91): lesson-store append/remove/restore mutations now serialize on a
+blocking `lessons.md.lock` flock around the file creation/read/mutate/write
+critical section. This closes the cross-loop last-writer-wins race between
+foreground `lesson_append`, shadow-review, candidate-reviewer, auto-review, and
+curator children; the curator's own single-flight remains only its dispatch
+guard.
 
 ✅ DONE (#35): curator wake-ups now hash the stable lessons / lesson_usage /
 skills / concepts inventory before spawning. If the hash matches the last
@@ -768,10 +773,9 @@ deduplicated against the issues above):
   (a value, not an exception, so the `try/except` misses it), and the `extract`
   daemon scans a fixed wall-clock window with a dead cursor, leaving an
   uncovered gap whenever `interval > window` (#90).
-- `lessons.md` append/remove is an **unlocked read-modify-write**, so concurrent
-  loop writers (shadow / candidate / auto-review / foreground) last-writer-win
-  and silently clobber each other's edits — the new curator single-flight only
-  serializes curators against each other (#91).
+- ✅ DONE (#91): `lessons.md` append/remove/restore read-modify-write sections
+  are guarded by a per-file blocking flock, so concurrent loop writers
+  serialize on the store itself instead of last-writer-winning.
 - `spawn_budget` daemon **starts inside spawned children**: `start_budget_daemon`
   lacks the `BACKGROUND_DAEMONS_ALLOWED` gate `memory_guard` already has, so
   every slim child runs a perpetual `ps`-polling thread it was explicitly

--- a/tests/test_lessons.py
+++ b/tests/test_lessons.py
@@ -6,11 +6,53 @@ see issue #7.
 """
 from __future__ import annotations
 
+import multiprocessing as mp
+import os
 import re
 import sys
+import time
 from pathlib import Path
 
 import pytest
+
+
+def _lessons_rmw_worker(
+    lessons_path: str,
+    action: str,
+    title: str,
+    errors: mp.Queue,
+) -> None:
+    os.environ["THREADKEEPER_LESSONS"] = lessons_path
+    for name in [m for m in list(sys.modules) if m.startswith("threadkeeper")]:
+        del sys.modules[name]
+
+    original_read_text = Path.read_text
+    target = Path(lessons_path)
+
+    def slow_lesson_read(path: Path, *args, **kwargs):
+        body = original_read_text(path, *args, **kwargs)
+        if path == target:
+            time.sleep(0.1)
+        return body
+
+    Path.read_text = slow_lesson_read
+    try:
+        from threadkeeper import lessons
+
+        if action == "append":
+            lessons.append_lesson(
+                title=title,
+                body=f"{title} body",
+                summary=f"{title} summary",
+                source="shadow",
+            )
+        elif action == "remove":
+            lessons.remove_lesson(title)
+        else:  # pragma: no cover - test helper guard.
+            raise AssertionError(f"unknown action: {action}")
+    except BaseException as e:  # pragma: no cover - surfaced in parent.
+        errors.put(repr(e))
+        raise
 
 
 def _bootstrap(tmp_path, monkeypatch):
@@ -92,6 +134,52 @@ def test_iter_lessons_returns_in_file_order(tmp_path, monkeypatch):
     items = list(pkg["lessons"].iter_lessons())
     assert [i["slug"] for i in items] == ["first", "second", "third"]
     assert items[2]["source"] == "shadow"
+
+
+def test_concurrent_append_remove_preserves_distinct_edits(
+    tmp_path, monkeypatch,
+):
+    pkg = _bootstrap(tmp_path, monkeypatch)
+    pkg["lessons"].append_lesson(
+        title="keep me", body="still here", source="shadow",
+    )
+    pkg["lessons"].append_lesson(
+        title="remove me", body="delete me", source="shadow",
+    )
+
+    ctx = mp.get_context("spawn")
+    errors = ctx.Queue()
+    jobs = [
+        ctx.Process(
+            target=_lessons_rmw_worker,
+            args=(str(pkg["path"]), "remove", "remove-me", errors),
+        )
+    ]
+    titles = [f"concurrent lesson {i}" for i in range(8)]
+    jobs.extend(
+        ctx.Process(
+            target=_lessons_rmw_worker,
+            args=(str(pkg["path"]), "append", title, errors),
+        )
+        for title in titles
+    )
+
+    for job in jobs:
+        job.start()
+    for job in jobs:
+        job.join(timeout=10)
+        if job.is_alive():
+            job.terminate()
+            job.join(timeout=2)
+            pytest.fail("lesson writer process did not exit")
+
+    assert [job.exitcode for job in jobs] == [0] * len(jobs)
+    assert errors.empty()
+    body = pkg["path"].read_text()
+    assert "slug=keep-me" in body
+    assert "slug=remove-me" not in body
+    for title in titles:
+        assert f"slug={title.replace(' ', '-')}" in body
 
 
 def test_count_zero_when_no_file(tmp_path, monkeypatch):

--- a/threadkeeper/lessons.py
+++ b/threadkeeper/lessons.py
@@ -27,6 +27,7 @@ land at the bottom (chronological).
 """
 from __future__ import annotations
 
+from contextlib import contextmanager
 import math
 import os
 import re
@@ -91,6 +92,28 @@ _BLOCK_RE = re.compile(
 )
 
 
+@contextmanager
+def _lessons_file_lock(path: Path) -> Iterator[None]:
+    """Serialize read-modify-write access to one lessons.md file."""
+    try:
+        import fcntl
+    except ImportError:  # pragma: no cover - thread-keeper runs on Unix CLIs.
+        yield
+        return
+
+    lock_path = path.with_name(f"{path.name}.lock")
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    with lock_path.open("w") as lock:
+        fcntl.flock(lock.fileno(), fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            try:
+                fcntl.flock(lock.fileno(), fcntl.LOCK_UN)
+            except OSError:
+                pass
+
+
 LESSON_DECAY_TAU_DAYS = 45
 LESSON_STALE_AFTER_DAYS = 30
 LESSON_STALE_MAX_PULLS = 1
@@ -121,42 +144,46 @@ def append_lesson(
     id ("Tabc123") or "shadow" for shadow_review writes.
     """
     fp = path or _LESSONS_PATH
-    _ensure_file(fp)
     slug = _slugify(title)
     ts = int(time.time())
     new_section = _format_section(slug, summary, body, source or "", ts)
 
-    body_existing = fp.read_text()
-    # If a section with this slug already exists, replace it in-place
-    # (idempotent re-materialization of the same lesson).
-    target_begin = f"<!-- LESSON:BEGIN slug={slug} "
-    target_end = f"<!-- LESSON:END slug={slug} -->"
-    if target_begin in body_existing and target_end in body_existing:
-        head, _, rest = body_existing.partition(target_begin)
-        # Find the matching END after the BEGIN.
-        end_marker = target_end
-        end_idx = rest.find(end_marker)
-        if end_idx >= 0:
-            tail = rest[end_idx + len(end_marker):]
-            body_existing = head + new_section.rstrip() + "\n" + tail.lstrip("\n")
+    with _lessons_file_lock(fp):
+        _ensure_file(fp)
+        body_existing = fp.read_text()
+        # If a section with this slug already exists, replace it in-place
+        # (idempotent re-materialization of the same lesson).
+        target_begin = f"<!-- LESSON:BEGIN slug={slug} "
+        target_end = f"<!-- LESSON:END slug={slug} -->"
+        if target_begin in body_existing and target_end in body_existing:
+            head, _, rest = body_existing.partition(target_begin)
+            # Find the matching END after the BEGIN.
+            end_marker = target_end
+            end_idx = rest.find(end_marker)
+            if end_idx >= 0:
+                tail = rest[end_idx + len(end_marker):]
+                body_existing = (
+                    head + new_section.rstrip() + "\n" + tail.lstrip("\n")
+                )
+            else:
+                # Malformed file (BEGIN without END) — just append at end.
+                body_existing = body_existing.rstrip() + "\n\n" + new_section
         else:
-            # Malformed file (BEGIN without END) — just append at end.
             body_existing = body_existing.rstrip() + "\n\n" + new_section
-    else:
-        body_existing = body_existing.rstrip() + "\n\n" + new_section
-    fp.write_text(body_existing)
+        fp.write_text(body_existing)
     return slug
 
 
 def remove_lesson(slug: str, path: Optional[Path] = None) -> bool:
     """Remove one lesson section by exact slug. Returns True when removed."""
-    found = lesson_section(slug, path=path)
-    if not found:
-        return False
     fp = path or _LESSONS_PATH
-    body_existing = found["file_body"]
-    new_body = body_existing[:found["start"]] + body_existing[found["end"]:]
-    fp.write_text(new_body)
+    with _lessons_file_lock(fp):
+        found = lesson_section(slug, path=fp)
+        if not found:
+            return False
+        body_existing = found["file_body"]
+        new_body = body_existing[:found["start"]] + body_existing[found["end"]:]
+        fp.write_text(new_body)
     return True
 
 
@@ -206,15 +233,16 @@ def restore_lesson_section(
 ) -> bool:
     """Restore an exact lesson section. Refuses to overwrite an existing slug."""
     fp = path or _LESSONS_PATH
-    _ensure_file(fp)
-    if lesson_section(slug, path=fp):
-        return False
-    body_existing = fp.read_text()
-    insert_at = len(body_existing)
-    if char_start is not None and 0 <= char_start <= len(body_existing):
-        insert_at = char_start
-    new_body = body_existing[:insert_at] + section + body_existing[insert_at:]
-    fp.write_text(new_body)
+    with _lessons_file_lock(fp):
+        _ensure_file(fp)
+        if lesson_section(slug, path=fp):
+            return False
+        body_existing = fp.read_text()
+        insert_at = len(body_existing)
+        if char_start is not None and 0 <= char_start <= len(body_existing):
+            insert_at = char_start
+        new_body = body_existing[:insert_at] + section + body_existing[insert_at:]
+        fp.write_text(new_body)
     return True
 
 


### PR DESCRIPTION
## Summary
- add a blocking fcntl flock on lessons.md.lock around lesson file creation/read/mutate/write
- serialize append, remove, and restore writers across foreground and learning-loop processes
- add a multiprocessing append/remove race regression and update roadmap/docs/changelog

## Tests
- env -u THREADKEEPER_NO_EMBEDDINGS .venv/bin/python -m pytest -q (exit 0; double-quiet output hid the pass-count line)
- env -u THREADKEEPER_NO_EMBEDDINGS .venv/bin/python -m pytest -o addopts='--strict-markers' -q (1135 passed, 1 skipped, 95 warnings)

Closes #91