### PR TITLE
fix: gate spawn budget daemon in children

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,11 @@ version bumps follow semver per the policy in
 
 ### Fixed
 
+- **Spawn-budget daemon stays out of spawned children (#92).** The
+  `spawn_budget` RSS/watchdog polling thread now honors
+  `BACKGROUND_DAEMONS_ALLOWED`, matching `memory_guard`, so slim children do
+  not each start their own perpetual `ps` loop.
+
 - **Auto-update no longer silently rewrites CLI setup config (#87).**
   Post-update setup now defaults to a dry-run check
   (`THREADKEEPER_AUTO_UPDATE_SETUP=check`) that records unchanged vs pending

--- a/README.md
+++ b/README.md
@@ -255,7 +255,8 @@ parent: N≥2 modular independent units of ≥5 min each = spawn signal.
 Spawn also marks children with `THREADKEEPER_SPAWNED_CHILD=1`, so
 autonomous learning daemons cannot recursively start inside review forks.
 
-A daemon measures combined child RSS every 10 s; admission control
+A daemon in the foreground parent measures combined child RSS every 10 s;
+spawned children do not start their own `ps` polling loop. Admission control
 refuses a new spawn that would exceed `THREADKEEPER_SPAWN_BUDGET_MB`
 (3 GB default). Slim children that need semantic search delegate to the
 parent via `search_via_parent` — no per-child copy of the embedding model.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -254,9 +254,11 @@ All daemon threads are cheap (ticks 0.5–30 s), no-op when env-knobs disable th
   `VACUUM` plus `PRAGMA wal_checkpoint(TRUNCATE)`.
 - **search_proxy** — serves `search_via_parent` from slim children via
   signals (see below).
-- **spawn_budget** — once per `SPAWN_BUDGET_POLL_S` (default 10 s) walks
-  the subtree of each `running` task via `ps`, updates `tasks.rss_kb` and
-  closes dead ones. The same sweep is the **wall-clock watchdog** (#80): a
+- **spawn_budget** — in foreground parent processes only, once per
+  `SPAWN_BUDGET_POLL_S` (default 10 s) walks the subtree of each `running`
+  task via `ps`, updates `tasks.rss_kb` and closes dead ones. Spawned children
+  do not start their own budget polling daemon. The same sweep is the
+  **wall-clock watchdog** (#80): a
   pid>0 child whose row outlives `SPAWN_MAX_RUNTIME_S` (1 h default; 0
   disables) is `SIGTERM`'d, then `SIGKILL`'d after `SPAWN_KILL_GRACE_S`, and
   its row is closed with `return_code` 124 so the spawning loop's single-flight
@@ -684,7 +686,8 @@ optional 24h spawned-child token and dollar ceilings when
   the row still has wall-time for cost/benefit triage. Captured `.log` files
   in `THREADKEEPER_TASK_LOG_DIR` are created owner-only (`0600`), matching the
   stdin prompt spool.
-- Daemon ticks update real RSS via `ps`; dead root pids → `ended_at`.
+- Daemon ticks run only in foreground parent processes, update real RSS via
+  `ps`, and set dead root pids → `ended_at`.
 - Visible spawns (Terminal.app) persist `pid=0`; the daemon resolves their live
   pid from the `--session-id <cid>` the child carries in `ps` argv and measures
   the same subtree RSS, so they contribute real memory, not the estimate. A

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -772,10 +772,9 @@ deduplicated against the issues above):
   loop writers (shadow / candidate / auto-review / foreground) last-writer-win
   and silently clobber each other's edits — the new curator single-flight only
   serializes curators against each other (#91).
-- `spawn_budget` daemon **starts inside spawned children**: `start_budget_daemon`
-  lacks the `BACKGROUND_DAEMONS_ALLOWED` gate `memory_guard` already has, so
-  every slim child runs a perpetual `ps`-polling thread it was explicitly
-  designed not to run (#92).
+- ✅ DONE (#92): `spawn_budget.start_budget_daemon` now honors the same
+  `BACKGROUND_DAEMONS_ALLOWED` gate as `memory_guard`, so spawned children do
+  not start their own perpetual `ps`-polling budget thread.
 - Budget/guard **RSS accounting**: `ps` failures are read as 0 MB (suppressing a
   needed retire/kill, or freeing in-use budget), and the liveness refresh caps
   at 100 rows while the budget sums over *all* un-ended rows, so a >100-row tail

--- a/tests/test_spawn_budget.py
+++ b/tests/test_spawn_budget.py
@@ -183,6 +183,43 @@ def test_check_budget_refuses_when_cost_budget_reached(mp_with_cid, monkeypatch)
     assert "cost_budget_exceeded" in msg
 
 
+@pytest.mark.parametrize(
+    ("background_allowed", "expected_started"),
+    [(False, False), (True, True)],
+)
+def test_start_budget_daemon_respects_background_daemons_allowed(
+    mp_with_cid, monkeypatch, background_allowed, expected_started
+):
+    mp_with_cid(_FAKE_CID)
+    import threadkeeper.spawn_budget as sb
+
+    calls: list[tuple[str, str | None, bool | None]] = []
+
+    class _Thread:
+        def __init__(self, *, target, name, daemon):
+            assert target is sb._daemon_loop
+            calls.append(("init", name, daemon))
+
+        def start(self):
+            calls.append(("start", None, None))
+
+    monkeypatch.setattr(sb, "_started", False)
+    monkeypatch.setattr(sb, "BACKGROUND_DAEMONS_ALLOWED", background_allowed)
+    monkeypatch.setattr(sb, "SPAWN_BUDGET_POLL_S", 60.0)
+    monkeypatch.setattr(sb, "SPAWN_BUDGET_MB", 3072)
+    monkeypatch.setattr(sb, "SPAWN_MAX_RUNTIME_S", 3600.0)
+    monkeypatch.setattr(sb.threading, "Thread", _Thread)
+
+    sb.start_budget_daemon()
+
+    assert sb._started is expected_started
+    assert calls == (
+        [("init", "spawn_budget", True), ("start", None, None)]
+        if expected_started
+        else []
+    )
+
+
 def test_spawn_reserves_rss_budget_before_popen(mp_with_cid, monkeypatch):
     """Two concurrent spawns against a cap that admits one must serialize at
     reservation time, so only one subprocess launch is attempted."""

--- a/threadkeeper/spawn_budget.py
+++ b/threadkeeper/spawn_budget.py
@@ -39,6 +39,7 @@ import time
 from typing import Optional, Tuple
 
 from .config import (
+    BACKGROUND_DAEMONS_ALLOWED,
     SPAWN_BUDGET_MB,
     SPAWN_ESTIMATE_SLIM_MB,
     SPAWN_ESTIMATE_FULL_MB,
@@ -625,7 +626,7 @@ def _daemon_loop() -> None:
 
 
 def start_budget_daemon() -> None:
-    """Idempotent — call from _ensure_session lazily."""
+    """Idempotent daemon starter. Runs only in foreground parent processes."""
     global _started
     if _started:
         return
@@ -633,6 +634,8 @@ def start_budget_daemon() -> None:
         return
     if SPAWN_BUDGET_MB <= 0 and SPAWN_MAX_RUNTIME_S <= 0:
         return  # both RSS budget and wall-clock watchdog (#80) off — nothing to do
+    if not BACKGROUND_DAEMONS_ALLOWED:
+        return
     t = threading.Thread(
         target=_daemon_loop, name="spawn_budget", daemon=True,
     )


### PR DESCRIPTION
## Summary
- gate spawn_budget.start_budget_daemon with BACKGROUND_DAEMONS_ALLOWED
- add a parameterized unit test for child no-op vs foreground parent start
- update roadmap/changelog/docs for the parent-only polling behavior

## Tests
- env -u THREADKEEPER_NO_EMBEDDINGS .venv/bin/python -m pytest -q
- env -u THREADKEEPER_NO_EMBEDDINGS .venv/bin/python -m pytest -o addopts='--strict-markers' -q (visible summary: 1136 passed, 1 skipped, 95 warnings)

Closes #92