### PR TITLE
fix: preserve RSS on ps measurement failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,13 @@ version bumps follow semver per the policy in
 
 ### Fixed
 
+- **Spawn-budget and memory-guard RSS samples no longer fail open to zero
+  (#93).** Failed or garbled `ps` RSS reads now preserve the prior child RSS
+  instead of writing 0 into `tasks.rss_kb`, memory reclaim reports unknown RSS
+  instead of fake freed memory when before/after sampling fails, and the
+  spawn-budget liveness sweep covers every open task row instead of only the
+  newest 100.
+
 - **Auto-update no longer silently rewrites CLI setup config (#87).**
   Post-update setup now defaults to a dry-run check
   (`THREADKEEPER_AUTO_UPDATE_SETUP=check`) that records unchanged vs pending

--- a/README.md
+++ b/README.md
@@ -255,13 +255,15 @@ parent: N≥2 modular independent units of ≥5 min each = spawn signal.
 Spawn also marks children with `THREADKEEPER_SPAWNED_CHILD=1`, so
 autonomous learning daemons cannot recursively start inside review forks.
 
-A daemon measures combined child RSS every 10 s; admission control
-refuses a new spawn that would exceed `THREADKEEPER_SPAWN_BUDGET_MB`
-(3 GB default). Slim children that need semantic search delegate to the
-parent via `search_via_parent` — no per-child copy of the embedding model.
-Admission uses a SQLite `BEGIN IMMEDIATE` reservation: `spawn()` re-checks the
-budget and inserts the child task row with its RSS estimate before `Popen`, so
-two concurrent spawns cannot both squeeze through the cap.
+A daemon measures combined child RSS every 10 s; failed `ps` RSS samples keep
+the last-known value, and the liveness sweep covers every open task row so dead
+children stop counting against the cap. Admission control refuses a new spawn
+that would exceed `THREADKEEPER_SPAWN_BUDGET_MB` (3 GB default). Slim children
+that need semantic search delegate to the parent via `search_via_parent` — no
+per-child copy of the embedding model. Admission uses a SQLite
+`BEGIN IMMEDIATE` reservation: `spawn()` re-checks the budget and inserts the
+child task row with its RSS estimate before `Popen`, so two concurrent spawns
+cannot both squeeze through the cap.
 
 The spawn wrapper also records each completed child's `duration_s`,
 `tokens_in`, `tokens_out`, `tokens_total`, and `cost_usd` when the underlying

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -684,7 +684,9 @@ optional 24h spawned-child token and dollar ceilings when
   the row still has wall-time for cost/benefit triage. Captured `.log` files
   in `THREADKEEPER_TASK_LOG_DIR` are created owner-only (`0600`), matching the
   stdin prompt spool.
-- Daemon ticks update real RSS via `ps`; dead root pids → `ended_at`.
+- Daemon ticks update real RSS via `ps`; unreadable RSS samples preserve the
+  last-known `rss_kb`, and every open row is swept for dead root pids →
+  `ended_at`.
 - Visible spawns (Terminal.app) persist `pid=0`; the daemon resolves their live
   pid from the `--session-id <cid>` the child carries in `ps` argv and measures
   the same subtree RSS, so they contribute real memory, not the estimate. A

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -776,10 +776,10 @@ deduplicated against the issues above):
   lacks the `BACKGROUND_DAEMONS_ALLOWED` gate `memory_guard` already has, so
   every slim child runs a perpetual `ps`-polling thread it was explicitly
   designed not to run (#92).
-- Budget/guard **RSS accounting**: `ps` failures are read as 0 MB (suppressing a
-  needed retire/kill, or freeing in-use budget), and the liveness refresh caps
-  at 100 rows while the budget sums over *all* un-ended rows, so a >100-row tail
-  of unrefreshed rows pins the budget. Complements #64/#66 (#93).
+- ✅ DONE (#93): Budget/guard **RSS accounting** no longer reads failed `ps`
+  RSS samples as 0 MB. Spawn-budget refresh preserves last-known child RSS on
+  measurement failure and sweeps every open task row for liveness, so a >100-row
+  stale tail cannot pin the budget.
 - Security: the `/tmp/thread-keeper-tasks` **spool dir** is created world-knowable
   with `exist_ok=True` and no owner/`O_NOFOLLOW` check, then per-file
   create-then-`chmod` — a symlink + brief-disclosure vector for spawn-prompt

--- a/tests/test_memory_guard.py
+++ b/tests/test_memory_guard.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import os
 import signal as _sig
+import subprocess
 import threading
 
 
@@ -452,6 +453,53 @@ def test_maybe_notify_keeps_dict_bounded(monkeypatch):
         assert len(mg._last_notify_at) <= 1
     finally:
         mg._last_notify_at.clear()
+
+
+def test_pid_rss_mb_distinguishes_failed_sample_from_zero(monkeypatch):
+    from threadkeeper import memory_guard as mg
+
+    def fail_run(args, **kwargs):
+        raise subprocess.TimeoutExpired(args, kwargs.get("timeout", 3))
+
+    monkeypatch.setattr(mg.subprocess, "run", fail_run)
+    assert mg._pid_rss_mb(1234) is None
+
+    class _Result:
+        def __init__(self, stdout):
+            self.stdout = stdout
+
+    monkeypatch.setattr(mg.subprocess, "run", lambda *a, **k: _Result("nope\n"))
+    assert mg._pid_rss_mb(1234) is None
+
+    monkeypatch.setattr(mg.subprocess, "run", lambda *a, **k: _Result("0\n"))
+    assert mg._pid_rss_mb(1234) == 0
+
+
+def test_reclaim_does_not_treat_failed_after_sample_as_freed_memory(
+    mp_with_cid, monkeypatch,
+):
+    mp_with_cid(_FAKE_CID)
+    from threadkeeper import embeddings, memory_guard as mg
+
+    monkeypatch.setattr(mg, "_reclaim_backoff_until", 123.0)
+    monkeypatch.setattr(mg, "_reclaim_fail_streak", 2)
+    monkeypatch.setattr(mg, "_log_line", lambda *a, **k: None)
+    monkeypatch.setattr(mg, "_emit_event", lambda *a, **k: None)
+    monkeypatch.setattr(mg, "_empty_torch_caches", lambda: [])
+    monkeypatch.setattr(mg, "_allocator_pressure_relief", lambda: [])
+    monkeypatch.setattr(embeddings, "unload_model", lambda: False)
+    rss = iter([2000, None])
+    monkeypatch.setattr(mg, "_pid_rss_mb", lambda pid: next(rss))
+
+    out = mg.reclaim_memory(reason="aggregate_warn", force=True)
+
+    assert out["before_mb"] == 2000
+    assert out["after_mb"] is None
+    assert out["freed_mb"] == 0
+    assert "rss_measurement_unavailable" in out["actions"]
+    assert not any(a.startswith("backoff=") for a in out["actions"])
+    assert mg._reclaim_backoff_until == 123.0
+    assert mg._reclaim_fail_streak == 2
 
 
 # ──────────────────────────────────────────────────────────────────────

--- a/tests/test_spawn_budget.py
+++ b/tests/test_spawn_budget.py
@@ -6,6 +6,7 @@ status logic exercises the budget module directly against a temp DB.
 from __future__ import annotations
 
 import os
+import subprocess
 import threading
 import time
 
@@ -35,6 +36,8 @@ def _insert_task(
     ended=False,
     tokens_total=None,
     cost_usd=None,
+    pid=None,
+    started_at=None,
 ):
     """Insert a fake task. Uses the test process's own pid so
     _refresh_tasks (alive() check) doesn't mark it ended on a brief()
@@ -45,8 +48,10 @@ def _insert_task(
         "INSERT INTO tasks (id, pid, parent_cid, spawned_cid, cwd, prompt, "
         "started_at, ended_at, rss_kb, rss_updated_at, tokens_total, cost_usd) "
         "VALUES (?,?,?,?,?,?,?,?,?,?,?,?)",
-        (task_id, os.getpid(), _FAKE_CID, f"child-{task_id}", "/tmp",
-         "test", now, (now if ended else None), rss_kb, now, tokens_total,
+        (task_id, (os.getpid() if pid is None else pid), _FAKE_CID,
+         f"child-{task_id}", "/tmp", "test",
+         (now if started_at is None else started_at), (now if ended else None),
+         rss_kb, now, tokens_total,
          cost_usd),
     )
     conn.commit()
@@ -422,6 +427,76 @@ def test_visible_within_ttl_not_reaped(mp_with_cid, monkeypatch):
         "SELECT ended_at FROM tasks WHERE id='tk_young'"
     ).fetchone()
     assert row["ended_at"] is None  # still within TTL → keeps counting
+
+
+def test_refresh_keeps_last_rss_when_ps_rss_sample_fails(mp_with_cid, monkeypatch):
+    """A transient `ps` failure while reading RSS must not write 0 over the
+    last known child RSS; admission control should keep using the prior value."""
+    monkeypatch.setenv("THREADKEEPER_SPAWN_BUDGET_MB", "3072")
+    pkg = mp_with_cid(_FAKE_CID)
+    pid = 4242
+    _insert_task(pkg, "tk_ps_fail", pid=pid, rss_kb=700 * 1024)
+
+    import threadkeeper.spawn_budget as sb
+
+    class _Result:
+        def __init__(self, stdout):
+            self.stdout = stdout
+
+    def fake_run(args, **kwargs):
+        if args == ["ps", "-ax", "-o", "pid=,ppid="]:
+            return _Result(f"{pid} 1\n")
+        if args == ["ps", "-o", "pid=,rss=", "-p", str(pid)]:
+            raise subprocess.TimeoutExpired(args, kwargs.get("timeout", 3))
+        raise AssertionError(args)
+
+    monkeypatch.setattr(sb, "alive", lambda p: p == pid)
+    monkeypatch.setattr(sb.subprocess, "run", fake_run)
+
+    conn = pkg["db"].get_db()
+    before = conn.execute(
+        "SELECT rss_kb, rss_updated_at FROM tasks WHERE id='tk_ps_fail'"
+    ).fetchone()
+    assert sb._refresh_all_running(conn) == 0
+    after = conn.execute(
+        "SELECT rss_kb, rss_updated_at, ended_at "
+        "FROM tasks WHERE id='tk_ps_fail'"
+    ).fetchone()
+
+    assert after["rss_kb"] == before["rss_kb"] == 700 * 1024
+    assert after["rss_updated_at"] == before["rss_updated_at"]
+    assert after["ended_at"] is None
+
+
+def test_refresh_reaps_dead_tail_beyond_first_100_open_rows(mp_with_cid, monkeypatch):
+    """The liveness sweep must cover every open task, not only the newest
+    100 rows, because budget accounting sums every `ended_at IS NULL` row."""
+    monkeypatch.setenv("THREADKEEPER_SPAWN_BUDGET_MB", "3072")
+    pkg = mp_with_cid(_FAKE_CID)
+    base = int(time.time()) - 1000
+    dead_pid = 5000
+    for i in range(101):
+        _insert_task(
+            pkg,
+            f"tk_tail_{i:03d}",
+            pid=dead_pid + i,
+            rss_kb=10 * 1024,
+            started_at=base + i,
+        )
+
+    import threadkeeper.spawn_budget as sb
+
+    monkeypatch.setattr(sb, "alive", lambda pid: pid != dead_pid)
+    monkeypatch.setattr(sb, "measure_tree_rss_kb", lambda pid: None)
+
+    conn = pkg["db"].get_db()
+    sb._refresh_all_running(conn)
+
+    oldest = conn.execute(
+        "SELECT ended_at FROM tasks WHERE id='tk_tail_000'"
+    ).fetchone()
+    assert oldest["ended_at"] is not None
+    assert sb._running_tasks_rss(conn) == 100 * 10 * 1024
 
 
 # ─────────────────────────────────────────────────────────────────────

--- a/threadkeeper/memory_guard.py
+++ b/threadkeeper/memory_guard.py
@@ -60,21 +60,26 @@ def _rss_mb(p: dict) -> int:
     return int(p.get("rss_kb") or 0) // 1024
 
 
-def _pid_rss_mb(pid: int) -> int:
+def _pid_rss_mb(pid: int) -> int | None:
+    """Return pid RSS in MB, or None when `ps` could not measure it."""
     try:
         r = subprocess.run(
             ["ps", "-o", "rss=", "-p", str(pid)],
             capture_output=True, text=True, timeout=3,
         )
     except (subprocess.SubprocessError, OSError):
-        return 0
+        return None
     txt = (r.stdout or "").strip()
     if not txt:
-        return 0
+        return None
     try:
         return int(txt.split()[0]) // 1024
     except (ValueError, IndexError):
-        return 0
+        return None
+
+
+def _fmt_rss_mb(value: int | None) -> str:
+    return "unknown" if value is None else f"{value}MB"
 
 
 def _log_line(line: str) -> None:
@@ -255,7 +260,8 @@ def reclaim_memory(reason: str = "manual", force: bool = False) -> dict:
         if skip:
             rss = _pid_rss_mb(os.getpid())
             _log_line(
-                f"{int(now)} reclaim_skip pid={os.getpid()} rss={rss}MB "
+                f"{int(now)} reclaim_skip pid={os.getpid()} "
+                f"rss={_fmt_rss_mb(rss)} "
                 f"reason={reason} skip={skip}"
             )
             return {
@@ -291,8 +297,14 @@ def reclaim_memory(reason: str = "manual", force: bool = False) -> dict:
     actions.append(f"gc.collect={collected}")
     actions.extend(_allocator_pressure_relief())
     after = _pid_rss_mb(os.getpid())
-    freed = before - after
-    if freed <= 0 and before > 0:
+    if before is None or after is None:
+        freed = 0
+        actions.append("rss_measurement_unavailable")
+    else:
+        freed = before - after
+    if before is None or after is None:
+        pass
+    elif freed <= 0 and before > 0:
         _reclaim_fail_streak += 1
         backoff = min(
             _RECLAIM_BACKOFF_MAX_S,
@@ -313,11 +325,13 @@ def reclaim_memory(reason: str = "manual", force: bool = False) -> dict:
     }
     _log_line(
         f"{int(time.time())} reclaim pid={os.getpid()} "
-        f"before={before}MB after={after}MB freed={freed}MB reason={reason}"
+        f"before={_fmt_rss_mb(before)} after={_fmt_rss_mb(after)} "
+        f"freed={freed}MB reason={reason}"
     )
     _emit_event(
         "memory_reclaim", os.getpid(),
-        f"before={before}MB after={after}MB freed={freed}MB reason={reason}",
+        f"before={_fmt_rss_mb(before)} after={_fmt_rss_mb(after)} "
+        f"freed={freed}MB reason={reason}",
     )
     return result
 
@@ -382,7 +396,8 @@ def handle_resource_controls() -> list[dict]:
             continue
         result = reclaim_memory(reason=f"control:{r['reason'] or 'trim'}")
         summary = (
-            f"before={result['before_mb']}MB after={result['after_mb']}MB "
+            f"before={_fmt_rss_mb(result['before_mb'])} "
+            f"after={_fmt_rss_mb(result['after_mb'])} "
             f"freed={result['freed_mb']}MB"
         )
         conn.execute(

--- a/threadkeeper/spawn_budget.py
+++ b/threadkeeper/spawn_budget.py
@@ -112,8 +112,13 @@ def _ps_pairs() -> list[tuple[int, int]]:
     return out
 
 
-def _rss_for_pids(pids: list[int]) -> int:
-    """Sum RSS (KB) for the given pids via `ps`. Missing pids contribute 0."""
+def _rss_for_pids(pids: list[int]) -> int | None:
+    """Sum RSS (KB) for the given pids via `ps`.
+
+    Missing pids contribute 0, but a failed or garbled `ps` sample returns
+    None so callers keep the last known RSS instead of treating the process as
+    freed.
+    """
     if not pids:
         return 0
     try:
@@ -122,22 +127,24 @@ def _rss_for_pids(pids: list[int]) -> int:
             capture_output=True, text=True, timeout=3,
         )
     except (subprocess.SubprocessError, OSError):
-        return 0
+        return None
     total = 0
+    saw_row = False
     for line in (r.stdout or "").splitlines():
         parts = line.split()
         if len(parts) < 2:
-            continue
+            return None
         try:
             total += int(parts[1])
         except ValueError:
-            continue
-    return total
+            return None
+        saw_row = True
+    return total if saw_row else None
 
 
 def measure_tree_rss_kb(root_pid: int) -> Optional[int]:
     """Walk descendants of root_pid and return summed RSS in KB.
-    Returns None when the root is gone (so caller can leave the row alone)."""
+    Returns None when the root is gone or RSS is unreadable this tick."""
     if root_pid is None or root_pid <= 0:
         return None
     pairs = _ps_pairs()
@@ -562,7 +569,7 @@ def _refresh_all_running(conn) -> int:
     refreshed."""
     rows = conn.execute(
         "SELECT * FROM tasks "
-        "WHERE ended_at IS NULL ORDER BY started_at DESC LIMIT 100"
+        "WHERE ended_at IS NULL ORDER BY started_at DESC"
     ).fetchall()
     now = int(time.time())
     updated = 0

--- a/threadkeeper/tools/memory_guard.py
+++ b/threadkeeper/tools/memory_guard.py
@@ -6,6 +6,10 @@ from ..db import get_db
 from ..identity import _ensure_session
 
 
+def _fmt_mb(value) -> str:
+    return "unknown" if value is None else f"{value}MB"
+
+
 def _fmt_proc(p: dict, prefix: str) -> str:
     return (
         f"  {prefix} pid={p['pid']} rss={p['rss_mb']}MB "
@@ -95,8 +99,8 @@ def memory_guard_check(dry_run: bool = True, notify: bool = False) -> str:
         if result.get("local_reclaim"):
             r = result["local_reclaim"]
             out.append(
-                f"  reclaim self before={r['before_mb']}MB "
-                f"after={r['after_mb']}MB freed={r['freed_mb']}MB"
+                f"  reclaim self before={_fmt_mb(r['before_mb'])} "
+                f"after={_fmt_mb(r['after_mb'])} freed={r['freed_mb']}MB"
             )
         for f in result["failed"]:
             out.append(f"  ERR pid={f['pid']} {f['err']}")
@@ -120,8 +124,8 @@ def memory_guard_reclaim(scope: str = "self") -> str:
         return "ERR bad_scope (use self|all)"
     result = memory_guard.reclaim_memory(reason=f"manual:{scope}", force=True)
     out = [
-        f"self pid={result['pid']} before={result['before_mb']}MB "
-        f"after={result['after_mb']}MB freed={result['freed_mb']}MB",
+        f"self pid={result['pid']} before={_fmt_mb(result['before_mb'])} "
+        f"after={_fmt_mb(result['after_mb'])} freed={result['freed_mb']}MB",
         "actions=" + ",".join(result["actions"]),
     ]
     if scope == "all":


### PR DESCRIPTION
## Summary
- Preserve last-known spawn RSS when a ps RSS sample fails or is garbled instead of writing 0 into tasks.rss_kb.
- Sweep every open task row during spawn-budget refresh so dead tail rows beyond 100 are closed.
- Report memory-guard reclaim RSS as unknown when before/after sampling fails instead of treating it as freed memory.

## Tests
- env -u THREADKEEPER_NO_EMBEDDINGS .venv/bin/python -m pytest -q (exited 0; project addopts make this double-quiet)
- env -u THREADKEEPER_NO_EMBEDDINGS .venv/bin/python -m pytest -o addopts='' -q -> 1138 passed, 1 skipped, 95 warnings
- .venv/bin/python -m pytest tests/test_spawn_budget.py tests/test_memory_guard.py -q

Closes #93