### PR TITLE
fix: expire pickup claims

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,13 @@ version bumps follow semver per the policy in
 
 ### Fixed
 
+- **Pickup claims stop pinning stale threads forever (#96).** Thread pickup
+  claims now expire after the same 24h lease used by roadmap issue claims:
+  `pickup_candidates` shows stale-claimed threads again, `claim_pickup` clears
+  expired leases before taking one, and auto-spawn pickup children are told to
+  call `release_pickup` as their final step. A spawned child can release its
+  parent's claim through the recorded `tasks` parent/child link.
+
 - **Auto-update no longer silently rewrites CLI setup config (#87).**
   Post-update setup now defaults to a dry-run check
   (`THREADKEEPER_AUTO_UPDATE_SETUP=check`) that records unchanged vs pending

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -157,7 +157,10 @@ version left unchanged for a retry.
 1. **threads + notes** — the main state machine of working memory.
    Thread = an open question; note = a move in it (`move`/`failed`/`insight`/`open_q`).
    `close_thread` records the outcome; `idle_thread` freezes it, and the next
-   note automatically reactivates it.
+   note automatically reactivates it. `claim_pickup` uses `threads.claimed_at`
+   / `claimed_by_cid` as a 24h lease: stale claims are eligible again in
+   `pickup_candidates`, and a spawned pickup child can release its parent's
+   lease when it finishes.
 
 2. **core_memory** — Letta-style RAM tier. High-priority lines that ALWAYS
    appear in the brief regardless of relevance. Flat key/priority/content;

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -147,6 +147,12 @@ remains a live question.
   for another migrator, and records `CURRENT_SCHEMA_VERSION` on success.
   Duplicate-column `ALTER TABLE` errors remain the only swallowed migration
   no-op; other migration `OperationalError`s are logged and raised.
+- Pickup claim TTL + auto-spawn release (#96): self-initiated pickup claims now
+  mirror the roadmap issue 24h lease. `pickup_candidates` treats stale thread
+  claims as eligible again, `claim_pickup` reaps stale leases before claiming,
+  and auto-spawn pickup prompts finish by calling `release_pickup`; spawned
+  children are allowed to release the parent claim through their `tasks`
+  parent/child link.
 
 ---
 
@@ -787,9 +793,6 @@ deduplicated against the issues above):
 - Legacy **DB migration** copies the live `-wal`/`-shm` sidecars with non-atomic
   `shutil.copy2` and no checkpoint — pairing a stale `-shm` with a copied `-wal`
   can produce a torn/corrupt DB at the new path (#95).
-- **Pickup claims leak**: `threads.claimed_at` has no TTL/reaper and the
-  `auto_spawn` child is never told to `release_pickup`, so even a successful
-  pickup pins the thread out of the candidate pool forever (#96).
 - Codex adapter: the fallback message **UUID** has no per-line offset, so
   timestamp-colliding messages collapse to one uuid and the later ones are
   deduped away; separately, each rollout file is fully scanned twice per ingest

--- a/tests/test_pickup.py
+++ b/tests/test_pickup.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+import os
+import time
+
+
+_PARENT_CID = "11112222-3333-4444-5555-666677778888"
+_CHILD_CID = "99990000-aaaa-bbbb-cccc-ddddeeeeffff"
+_OTHER_CID = "aaaaaaaa-bbbb-cccc-dddd-eeeeffffffff"
+
+
+def _tool(pkg, name):
+    return pkg["mcp"]._tool_manager._tools[name].fn
+
+
+def _insert_thread(pkg, tid: str, *, last_touched_at: int,
+                   claimed_at: int | None = None,
+                   claimed_by_cid: str | None = None) -> None:
+    conn = pkg["db"].get_db()
+    conn.execute(
+        "INSERT INTO threads (id, question, state, opened_at, "
+        "last_touched_at, claimed_at, claimed_by_cid) "
+        "VALUES (?,?,?,?,?,?,?)",
+        (
+            tid,
+            f"pickup question {tid}",
+            "idle",
+            last_touched_at,
+            last_touched_at,
+            claimed_at,
+            claimed_by_cid,
+        ),
+    )
+    conn.commit()
+
+
+def _claim_row(pkg, tid: str):
+    conn = pkg["db"].get_db()
+    return conn.execute(
+        "SELECT claimed_at, claimed_by_cid FROM threads WHERE id=?",
+        (tid,),
+    ).fetchone()
+
+
+def _insert_spawn_task(pkg, *, parent_cid: str, child_cid: str) -> None:
+    conn = pkg["db"].get_db()
+    conn.execute(
+        "INSERT INTO tasks (id, pid, parent_cid, spawned_cid, cwd, prompt, "
+        "started_at) VALUES (?,?,?,?,?,?,?)",
+        (
+            "tk_pickup_child",
+            os.getpid(),
+            parent_cid,
+            child_cid,
+            "/tmp",
+            "pickup child",
+            int(time.time()),
+        ),
+    )
+    conn.commit()
+
+
+def test_stale_claim_reappears_and_is_reaped_on_claim(mp_with_cid):
+    pkg = mp_with_cid(_PARENT_CID)
+    from threadkeeper.config import PICKUP_CLAIM_TTL_S
+
+    now = int(time.time())
+    tid = "Tpickup_stale"
+    _insert_thread(
+        pkg,
+        tid,
+        last_touched_at=now - 4 * 86400,
+        claimed_at=now - PICKUP_CLAIM_TTL_S - 10,
+        claimed_by_cid=_OTHER_CID,
+    )
+
+    candidates = _tool(pkg, "pickup_candidates")(min_idle_days=3, max_n=5)
+    assert tid in candidates
+
+    out = _tool(pkg, "claim_pickup")(thread_id=tid)
+    assert out == f"ok claimed thread={tid}"
+    row = _claim_row(pkg, tid)
+    assert row["claimed_by_cid"] == _PARENT_CID
+    assert row["claimed_at"] >= now
+
+
+def test_fresh_claim_stays_hidden_and_blocks_other_claimant(mp_with_cid):
+    pkg = mp_with_cid(_PARENT_CID)
+    from threadkeeper.config import PICKUP_CLAIM_TTL_S
+
+    now = int(time.time())
+    tid = "Tpickup_fresh"
+    claimed_at = now - PICKUP_CLAIM_TTL_S + 10
+    _insert_thread(
+        pkg,
+        tid,
+        last_touched_at=now - 4 * 86400,
+        claimed_at=claimed_at,
+        claimed_by_cid=_OTHER_CID,
+    )
+
+    candidates = _tool(pkg, "pickup_candidates")(min_idle_days=3, max_n=5)
+    assert tid not in candidates
+
+    out = _tool(pkg, "claim_pickup")(thread_id=tid)
+    assert out.startswith("ERR already_claimed")
+    row = _claim_row(pkg, tid)
+    assert row["claimed_by_cid"] == _OTHER_CID
+    assert row["claimed_at"] == claimed_at
+
+
+def test_auto_spawn_child_can_release_parent_pickup_claim(
+    mp_with_cid, monkeypatch
+):
+    pkg = mp_with_cid(_PARENT_CID)
+    from threadkeeper.tools import pickup
+
+    now = int(time.time())
+    tid = "Tpickup_child_release"
+    _insert_thread(pkg, tid, last_touched_at=now - 4 * 86400)
+
+    captured = {}
+
+    def fake_spawn(**kwargs):
+        captured.update(kwargs)
+        return (
+            "ok task=tk_pickup_child pid=123 "
+            f"child_cid={_CHILD_CID[:8]} parent_cid={_PARENT_CID[:8]} "
+            "perm=auto mode=headless log=/tmp/tk_pickup_child.log"
+        )
+
+    monkeypatch.setattr(pickup, "spawn", fake_spawn)
+    out = _tool(pkg, "claim_pickup")(thread_id=tid, auto_spawn=True)
+    assert out.startswith(f"ok claimed thread={tid} | spawn: ok task=")
+    assert "mcp__thread-keeper__release_pickup" in captured["prompt"]
+    assert f"thread_id={tid}" in captured["prompt"]
+
+    monkeypatch.setenv("THREADKEEPER_FORCE_CID", _CHILD_CID)
+    blocked = _tool(pkg, "release_pickup")(thread_id=tid)
+    assert blocked.startswith("ERR not_my_claim")
+
+    _insert_spawn_task(pkg, parent_cid=_PARENT_CID, child_cid=_CHILD_CID)
+    released = _tool(pkg, "release_pickup")(thread_id=tid)
+    assert released == f"ok released thread={tid}"
+    row = _claim_row(pkg, tid)
+    assert row["claimed_at"] is None
+    assert row["claimed_by_cid"] is None

--- a/threadkeeper/brief.py
+++ b/threadkeeper/brief.py
@@ -17,7 +17,10 @@ import time
 from datetime import datetime, timezone
 from typing import Optional
 
-from .config import SEMANTIC_AVAILABLE, DIALOG_LOG, TASK_LOG_DIR, BRIEF_LEAN, DB_PATH
+from .config import (
+    SEMANTIC_AVAILABLE, DIALOG_LOG, TASK_LOG_DIR, BRIEF_LEAN, DB_PATH,
+    PICKUP_CLAIM_TTL_S,
+)
 from .helpers import fmt_age, q
 from . import identity
 from .identity import _detect_self_cid, _ensure_cursor
@@ -841,10 +844,11 @@ def render_brief(conn: sqlite3.Connection, query: str = "", k: int = 6,
         if active_count < 3 and not eff_lean:
             top = conn.execute(
                 "SELECT id, question, last_touched_at FROM threads "
-                "WHERE state IN ('active','idle') AND claimed_at IS NULL "
+                "WHERE state IN ('active','idle') "
+                "AND (claimed_at IS NULL OR claimed_at <= ?) "
                 "AND last_touched_at <= ? "
                 "ORDER BY last_touched_at ASC LIMIT 1",
-                (now - 3 * 86400,),
+                (now - PICKUP_CLAIM_TTL_S, now - 3 * 86400),
             ).fetchone()
             if top:
                 out.append("")

--- a/threadkeeper/config.py
+++ b/threadkeeper/config.py
@@ -588,6 +588,10 @@ def _warn_unknown_threadkeeper_env_keys() -> None:
 settings = Settings()
 _warn_unknown_threadkeeper_env_keys()
 
+# Pickup-thread claims mirror roadmap issue claims: abandoned work should stop
+# excluding a thread from self-initiated pickup after one day.
+PICKUP_CLAIM_TTL_S = 24 * 60 * 60
+
 
 # ── Compat shim: re-export all prior module-level names ──────────────────────
 # Every name listed here is imported by ≥1 call site in the package. They are

--- a/threadkeeper/tools/pickup.py
+++ b/threadkeeper/tools/pickup.py
@@ -10,12 +10,44 @@ import time
 from typing import Optional
 
 from .._mcp import read_tool, write_tool
+from ..config import PICKUP_CLAIM_TTL_S
 from ..db import get_db
 from ..helpers import fmt_age, q
 from .. import identity
 from ..identity import _ensure_session, _detect_self_cid, _emit
 from ..embeddings import _embed, embed_tag
 from .spawn import spawn
+
+
+def _stale_claim_cutoff(now_t: int) -> int:
+    return now_t - PICKUP_CLAIM_TTL_S
+
+
+def _reap_stale_pickup_claims(conn: sqlite3.Connection, now_t: int) -> int:
+    cur = conn.execute(
+        "UPDATE threads SET claimed_at=NULL, claimed_by_cid=NULL "
+        "WHERE claimed_at IS NOT NULL AND claimed_at <= ?",
+        (_stale_claim_cutoff(now_t),),
+    )
+    count = max(0, cur.rowcount or 0)
+    if count:
+        _emit(
+            conn,
+            "pickup_claim_reaped",
+            summary=f"stale={count} ttl_s={PICKUP_CLAIM_TTL_S}",
+        )
+    return count
+
+
+def _claim_release_cids(conn: sqlite3.Connection, self_cid: str) -> set[str]:
+    allowed = {self_cid}
+    rows = conn.execute(
+        "SELECT parent_cid FROM tasks "
+        "WHERE spawned_cid=? AND parent_cid IS NOT NULL",
+        (self_cid,),
+    ).fetchall()
+    allowed.update(r["parent_cid"] for r in rows if r["parent_cid"])
+    return allowed
 
 
 @read_tool()
@@ -29,16 +61,21 @@ def pickup_candidates(min_idle_days: int = 3, max_n: int = 5) -> str:
     _ensure_session(conn)
     now_t = int(time.time())
     cutoff = now_t - max(0, int(min_idle_days)) * 86400
+    claim_cutoff = _stale_claim_cutoff(now_t)
     rows = conn.execute(
         "SELECT id, question, state, last_touched_at, last_move "
         "FROM threads "
         "WHERE state IN ('active','idle') "
-        "AND last_touched_at <= ? AND claimed_at IS NULL "
+        "AND last_touched_at <= ? "
+        "AND (claimed_at IS NULL OR claimed_at <= ?) "
         "ORDER BY last_touched_at ASC LIMIT ?",
-        (cutoff, max(1, int(max_n))),
+        (cutoff, claim_cutoff, max(1, int(max_n))),
     ).fetchall()
     if not rows:
-        return f"no_candidates (no unclaimed thread idle >= {min_idle_days}d)"
+        return (
+            "no_candidates "
+            f"(no unclaimed or stale-claimed thread idle >= {min_idle_days}d)"
+        )
     lines = [f"candidates n={len(rows)} idle>={min_idle_days}d"]
     for t in rows:
         idle = fmt_age(now_t - t["last_touched_at"])
@@ -64,6 +101,7 @@ def claim_pickup(thread_id: str, plan: str = "",
     if not self_cid:
         return "ERR cannot_detect_self_cid"
     tid = thread_id.strip()
+    now_t = int(time.time())
     t = conn.execute(
         "SELECT id, question, state, claimed_at, claimed_by_cid "
         "FROM threads WHERE id=?",
@@ -71,12 +109,13 @@ def claim_pickup(thread_id: str, plan: str = "",
     ).fetchone()
     if not t:
         return f"ERR thread_not_found={tid}"
-    if t["claimed_at"] and t["claimed_by_cid"] != self_cid:
+    if t["claimed_at"] and t["claimed_at"] <= _stale_claim_cutoff(now_t):
+        _reap_stale_pickup_claims(conn, now_t)
+    elif t["claimed_at"] and t["claimed_by_cid"] != self_cid:
         return (
             f"ERR already_claimed by={(t['claimed_by_cid'] or '')[:8]} "
             f"at={fmt_age(int(time.time()) - t['claimed_at'])}_ago"
         )
-    now_t = int(time.time())
     conn.execute(
         "UPDATE threads SET claimed_at=?, claimed_by_cid=?, "
         "last_touched_at=? WHERE id=?",
@@ -111,7 +150,9 @@ def claim_pickup(thread_id: str, plan: str = "",
             f"Plan from caller: {plan or '(infer one and proceed)'}\n\n"
             f"Make ONE concrete advance. Add a note to the thread "
             f"(mcp__thread-keeper__note with thread_id={tid}, kind='move'). "
-            f"When done, broadcast 'pickup-{tid}: <one-line result>'."
+            f"Then broadcast 'pickup-{tid}: <one-line result>'. "
+            f"Final step: call mcp__thread-keeper__release_pickup "
+            f"with thread_id={tid} so this pickup claim is cleared."
         )
         result = spawn(
             prompt=child_prompt,
@@ -126,7 +167,7 @@ def claim_pickup(thread_id: str, plan: str = "",
 
 @write_tool(idempotent=True)
 def release_pickup(thread_id: str) -> str:
-    """Release a claim. Only the claimant can release."""
+    """Release a claim. The claimant or its spawned child can release."""
     conn = get_db()
     _ensure_session(conn)
     self_cid = _detect_self_cid()
@@ -138,7 +179,7 @@ def release_pickup(thread_id: str) -> str:
     ).fetchone()
     if not t or not t["claimed_by_cid"]:
         return "not_claimed"
-    if t["claimed_by_cid"] != self_cid:
+    if t["claimed_by_cid"] not in _claim_release_cids(conn, self_cid):
         return f"ERR not_my_claim by={t['claimed_by_cid'][:8]}"
     conn.execute(
         "UPDATE threads SET claimed_at=NULL, claimed_by_cid=NULL WHERE id=?",


### PR DESCRIPTION
## Summary
- expire pickup claims after 24h in candidates and the brief hint
- reap stale pickup leases before taking a claim
- let auto-spawn pickup children release the parent claim and prompt them to do it
- update roadmap, architecture, changelog, and add focused tests

## Tests
- env -u THREADKEEPER_NO_EMBEDDINGS .venv/bin/python -m pytest -q

Closes #96