### PR TITLE
fix: gate 4 remaining background daemon starters on BACKGROUND_DAEMONS_ALLOWED

### DIFF
--- a/tests/test_delegated_search.py
+++ b/tests/test_delegated_search.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import json
 import os
+import threading
 import time
 
 import pytest
@@ -153,6 +154,20 @@ def test_search_proxy_handles_empty_query(mp_with_cid):
     ).fetchone()
     body = json.loads(resp["content"])
     assert body.get("error") == "empty_query"
+
+
+def test_start_search_proxy_respects_disable_bg_daemons(mp_with_cid, monkeypatch):
+    """BACKGROUND_DAEMONS_ALLOWED=False must block the daemon thread even
+    when SEMANTIC_AVAILABLE and the poll interval would otherwise allow it."""
+    mp_with_cid(_PARENT_CID)
+    from threadkeeper import search_proxy
+    monkeypatch.setattr(search_proxy, "SEMANTIC_AVAILABLE", True)
+    monkeypatch.setattr(search_proxy, "_POLL_INTERVAL_S", 0.5)
+
+    before = {t.name for t in threading.enumerate()}
+    search_proxy.start_search_proxy()
+    after = {t.name for t in threading.enumerate()}
+    assert "search_proxy" not in (after - before)
 
 
 # ─────────────────────────────────────────────────────────────────────

--- a/tests/test_ingest_status.py
+++ b/tests/test_ingest_status.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import threading
+
 
 _FAKE_CID = "77778888-9999-aaaa-bbbb-ccccdddd0000"
 
@@ -27,3 +29,16 @@ def test_ingest_pass_event_recorded_for_status_ui(mp_with_cid):
     assert row["kind"] == "ingest_pass"
     assert row["target"]
     assert row["summary"] == "ok mode=recent new=2 files=5"
+
+
+def test_start_background_ingester_respects_disable_bg_daemons(mp_with_cid, monkeypatch):
+    """BACKGROUND_DAEMONS_ALLOWED=False must block the daemon thread even
+    when the ingest interval is positive."""
+    mp_with_cid(_FAKE_CID)
+    from threadkeeper import ingest
+    monkeypatch.setattr(ingest, "_ingest_interval_s", 3.0)
+
+    before = {t.name for t in threading.enumerate()}
+    ingest._start_background_ingester()
+    after = {t.name for t in threading.enumerate()}
+    assert "thread-keeper-live-ingest" not in (after - before)

--- a/tests/test_skill_watcher.py
+++ b/tests/test_skill_watcher.py
@@ -180,6 +180,19 @@ def test_start_skill_watcher_disabled_when_interval_zero(tmp_path, monkeypatch):
     assert not any(n == "skill_watcher" for n in new_threads)
 
 
+def test_start_skill_watcher_respects_disable_bg_daemons(tmp_path, monkeypatch):
+    """BACKGROUND_DAEMONS_ALLOWED=False must block the daemon thread even
+    when the poll interval is positive."""
+    monkeypatch.setenv("THREADKEEPER_DISABLE_BG_DAEMONS", "1")
+    pkg = _bootstrap(tmp_path, monkeypatch, interval_s="10")
+    sw = pkg["skill_watcher"]
+    import threading
+    before = {t.name for t in threading.enumerate()}
+    sw.start_skill_watcher()
+    after = {t.name for t in threading.enumerate()}
+    assert not any(n == "skill_watcher" for n in (after - before))
+
+
 def test_scan_once_preserves_existing_origin(tmp_path, monkeypatch):
     """If a skill already has an agent-created provenance row, the watcher
     must NOT overwrite created_by_origin — INSERT … ON CONFLICT DO NOTHING."""

--- a/tests/test_spawn_budget.py
+++ b/tests/test_spawn_budget.py
@@ -452,3 +452,21 @@ def test_spawn_budget_set_rejects_negative(mp_with_cid):
     pkg = mp_with_cid(_FAKE_CID)
     r = _tool(pkg, "spawn_budget_set")(limit_mb=-1)
     assert r.startswith("ERR")
+
+
+# ─────────────────────────────────────────────────────────────────────
+# start_budget_daemon — background-daemon kill switch
+# ─────────────────────────────────────────────────────────────────────
+
+def test_start_budget_daemon_respects_disable_bg_daemons(mp_with_cid, monkeypatch):
+    """BACKGROUND_DAEMONS_ALLOWED=False must block the daemon thread even
+    when the poll interval and budget would otherwise allow it."""
+    mp_with_cid(_FAKE_CID)
+    import threadkeeper.spawn_budget as sb
+    monkeypatch.setattr(sb, "SPAWN_BUDGET_POLL_S", 10.0)
+    monkeypatch.setattr(sb, "SPAWN_BUDGET_MB", 3072)
+
+    before = {t.name for t in threading.enumerate()}
+    sb.start_budget_daemon()
+    after = {t.name for t in threading.enumerate()}
+    assert "spawn_budget" not in (after - before)

--- a/threadkeeper/ingest.py
+++ b/threadkeeper/ingest.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from typing import Optional
 
 from .config import (
+    BACKGROUND_DAEMONS_ALLOWED,
     INGEST_CAP_PER_CALL,
     INGEST_INTERVAL_S,
     INGEST_RECENT_WINDOW_S,
@@ -674,6 +675,8 @@ def _start_background_ingester() -> None:
         return
     if _ingest_interval_s <= 0:
         return  # disabled via env
+    if not BACKGROUND_DAEMONS_ALLOWED:
+        return
 
     def _loop() -> None:
         while True:

--- a/threadkeeper/search_proxy.py
+++ b/threadkeeper/search_proxy.py
@@ -29,7 +29,7 @@ import threading
 import time
 from typing import Optional
 
-from .config import SEMANTIC_AVAILABLE
+from .config import BACKGROUND_DAEMONS_ALLOWED, SEMANTIC_AVAILABLE
 from .db import get_db
 from . import identity
 
@@ -153,6 +153,8 @@ def start_search_proxy() -> None:
         return
     if _POLL_INTERVAL_S <= 0:
         return  # disabled via env (test environments, or explicit opt-out)
+    if not BACKGROUND_DAEMONS_ALLOWED:
+        return
     t = threading.Thread(
         target=_serve_loop, name="search_proxy", daemon=True,
     )

--- a/threadkeeper/skill_watcher.py
+++ b/threadkeeper/skill_watcher.py
@@ -13,7 +13,7 @@ import os
 import threading
 from typing import Optional
 
-from .config import CLAUDE_SKILLS_DIR
+from .config import BACKGROUND_DAEMONS_ALLOWED, CLAUDE_SKILLS_DIR
 from .db import get_db
 from .helpers import daemon_sleep
 
@@ -88,6 +88,8 @@ def start_skill_watcher() -> None:
     if _started:
         return
     if _tick_interval_s <= 0:
+        return
+    if not BACKGROUND_DAEMONS_ALLOWED:
         return
     t = threading.Thread(
         target=_watch_loop, name='skill_watcher', daemon=True,

--- a/threadkeeper/spawn_budget.py
+++ b/threadkeeper/spawn_budget.py
@@ -39,6 +39,7 @@ import time
 from typing import Optional, Tuple
 
 from .config import (
+    BACKGROUND_DAEMONS_ALLOWED,
     SPAWN_BUDGET_MB,
     SPAWN_ESTIMATE_SLIM_MB,
     SPAWN_ESTIMATE_FULL_MB,
@@ -633,6 +634,8 @@ def start_budget_daemon() -> None:
         return
     if SPAWN_BUDGET_MB <= 0 and SPAWN_MAX_RUNTIME_S <= 0:
         return  # both RSS budget and wall-clock watchdog (#80) off — nothing to do
+    if not BACKGROUND_DAEMONS_ALLOWED:
+        return
     t = threading.Thread(
         target=_daemon_loop, name="spawn_budget", daemon=True,
     )


### PR DESCRIPTION
## Summary
- `search_proxy.start_search_proxy`, `spawn_budget.start_budget_daemon`, `skill_watcher.start_skill_watcher`, and `ingest._start_background_ingester` were the only 4 of 19 daemon starters that never checked `BACKGROUND_DAEMONS_ALLOWED`, so `THREADKEEPER_DISABLE_BG_DAEMONS=1` (the documented hard kill-switch) didn't actually stop them from spawning a real thread.
- Added the same `if not BACKGROUND_DAEMONS_ALLOWED: return` early-out the other 15 starters already use, matching `memory_guard.py`'s reference pattern (import from `.config`, gate placed after the feature-specific interval/threshold checks, right before thread creation).
- Added one regression test per module (TDD: confirmed each leaked a real, named daemon thread before the fix). Each test forces the module's own interval/threshold open and relies solely on `BACKGROUND_DAEMONS_ALLOWED` to block the thread, so it actually exercises the gate rather than the pre-existing interval check.

## Test plan
- [x] New tests fail (RED) against pre-fix code — each shows the real thread leaking (`search_proxy`, `spawn_budget`, `skill_watcher`, `thread-keeper-live-ingest`)
- [x] New tests pass (GREEN) after the fix
- [x] Full targeted run: `test_delegated_search.py`, `test_spawn_budget.py`, `test_skill_watcher.py`, `test_ingest_status.py`, `test_memory_guard.py` — 61 passed, no regressions (in particular `test_start_skill_watcher_is_idempotent`, which relies on the daemon still starting when allowed)
- [x] Full suite with `--forked` (CI's exact invocation): 100% passed, 1 unrelated skip, `EXIT_CODE=0`
- [x] Confirmed no other test file references any of the 4 starters directly

🤖 Generated with [Claude Code](https://claude.com/claude-code)