### PR TITLE
feat: daemon-host + thin per-session servers (dark, THREADKEEPER_DAEMON_HOST)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -94,6 +94,13 @@
 # THREADKEEPER_MEMORY_GUARD_NOTIFY=true
 # THREADKEEPER_MEMORY_GUARD_COOLDOWN_S=300
 
+# ── Phase 1: daemon-host + thin servers (dark by default) ──
+# THREADKEEPER_DAEMON_HOST=0                  # 1 = one headless host owns the loops+model; per-session servers go thin
+# THREADKEEPER_HOST_SOCK=                     # embed socket path (default <db dir>/host.sock)
+# THREADKEEPER_HOST_HEARTBEAT_TTL_S=120       # host liveness window (s) for memory_guard supervision/respawn
+# THREADKEEPER_THIN_EMBED_FALLBACK=fts        # fts | local — how a thin server embeds a query when the host is unreachable
+# THREADKEEPER_ROLE=server                    # server | host — set to 'host' only by `python -m threadkeeper.host`; do not set by hand
+
 # ── background daemons (all 0 = off by default; opt in) ──
 # THREADKEEPER_SHADOW_REVIEW_INTERVAL_S=0
 # THREADKEEPER_SHADOW_REVIEW_WINDOW_S=900

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,18 @@ version bumps follow semver per the policy in
   by memory_guard. Off by default; no CLI config change. Removes the
   per-session RAM multiplier and the reclaim-thrash root.
 
+### Fixed
+
+- **All background daemon starters now honor `BACKGROUND_DAEMONS_ALLOWED`.**
+  `search_proxy`, `skill_watcher`, `spawn_budget`, and the background ingester
+  started unconditionally, ignoring the spawned-child / `DISABLE_BG_DAEMONS`
+  gate the other daemons respect — so a spawned review child (or a
+  `DISABLE_BG_DAEMONS` run) still spun up those loops. They now self-gate like
+  the rest, which also lets the daemon-host cleanly own them.
+- **`probe_daemon` no longer crashes on its first tick.** It called
+  `daemon_sleep()` without importing it from `.helpers`, so the probe loop died
+  with a `NameError` after one iteration. Added the missing import.
+
 ### Changed
 
 - **Evolve tests no longer provision a real checkout — ~850 s off the suite.**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ version bumps follow semver per the policy in
 
 ## [Unreleased]
 
+### Added
+
+- **Daemon-host + thin per-session servers (dark, `THREADKEEPER_DAEMON_HOST`).**
+  One headless host per machine owns the 18 background loops + the warm ONNX
+  model + a narrow embed unix-socket; per-session servers go thin (stdio MCP +
+  direct SQLite, no daemons, no ONNX) and route only query-embedding to the
+  host, falling back to FTS when it is unreachable. Elected via a flock, spawned
+  detached by the first thin server, supervised by memory_guard. Off by default;
+  no CLI config change. Removes the per-session RAM multiplier and the
+  reclaim-thrash root.
+
 ### Changed
 
 - **Evolve tests no longer provision a real checkout — ~850 s off the suite.**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,13 +10,14 @@ version bumps follow semver per the policy in
 ### Added
 
 - **Daemon-host + thin per-session servers (dark, `THREADKEEPER_DAEMON_HOST`).**
-  One headless host per machine owns the 18 background loops + the warm ONNX
-  model + a narrow embed unix-socket; per-session servers go thin (stdio MCP +
-  direct SQLite, no daemons, no ONNX) and route only query-embedding to the
-  host, falling back to FTS when it is unreachable. Elected via a flock, spawned
-  detached by the first thin server, supervised by memory_guard. Off by default;
-  no CLI config change. Removes the per-session RAM multiplier and the
-  reclaim-thrash root.
+  One headless host per machine owns the background loops (18 daemon starters
+  + the ingester) + the warm ONNX model + a narrow embed unix-socket;
+  per-session servers go thin (stdio MCP + direct SQLite, no daemons, no ONNX)
+  and route the embeddings they need (a search query, and content ingested
+  during the session) to the host, falling back to FTS when it is unreachable.
+  Elected via a flock, spawned detached by the first thin server, supervised
+  by memory_guard. Off by default; no CLI config change. Removes the
+  per-session RAM multiplier and the reclaim-thrash root.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -997,6 +997,11 @@ The most-used env knobs (full list in `threadkeeper/config.py`):
 | `THREADKEEPER_ROADMAP_ISSUE_MAX_ATTEMPTS` | 3 | poison-issue dead-letter cap: after this many implementer spawns for a roadmap issue with no resulting PR, the issue gets a `blocked` label + one summary comment and is excluded from the auto-drain until a human intervenes. A manual `evolve_apply_roadmap_issue(issue_number=N)` bypasses the cap, but the default skip-label gate still refuses the `blocked` label until it is removed or reconfigured |
 | `THREADKEEPER_ROADMAP_ISSUE_BACKOFF_BASE_S` | 172800 (2d) | base failure-backoff window for a roadmap issue; doubles per attempt (`base * 2^(attempts-1)`, capped at 30d). Defers re-selection of a repeatedly-aborting issue beyond the fixed 24h claim TTL |
 | `THREADKEEPER_DIALECTIC_MAX_NEW_CLAIMS` | 3 | max new dialectic claims the validator may create per pass |
+| `THREADKEEPER_DAEMON_HOST` | `0` (off) | Phase 1 rollout flag (dark by default; no CLI config change). `1` = one headless host (`python -m threadkeeper.host`) owns the background loops + the warm embedding model + the embed socket, and per-session servers go thin (no daemons, no ONNX). See [Embeddings](#embeddings) below |
+| `THREADKEEPER_ROLE` | `server` | process role: `server` (default; per-session MCP server) or `host`. Set to `host` only by `python -m threadkeeper.host` — do not set this by hand |
+| `THREADKEEPER_HOST_SOCK` | (auto) | embed-only unix socket the thin servers dial and the host binds; empty resolves to `<db dir>/host.sock` |
+| `THREADKEEPER_HOST_HEARTBEAT_TTL_S` | 120 | host liveness window (s): how stale the host's presence heartbeat may get before `memory_guard`/a thin server treats it as dead and spawns a replacement |
+| `THREADKEEPER_THIN_EMBED_FALLBACK` | `fts` | how a thin server embeds a query when the host is unreachable: `fts` (default) falls back to FTS-only search; `local` lazily loads the ONNX model in-process instead |
 
 Persist them in `~/.threadkeeper/.env` (copy from `.env.example`) — one file,
 read via pydantic-settings; real environment variables still override it. On
@@ -1215,6 +1220,22 @@ otherwise every vec0 insert mismatches the schema and the fast KNN path goes
 dead (semantic search still works via the legacy BLOB cosine path). thread-keeper
 logs a one-line warning naming both dimensions and this knob when it detects the
 mismatch, rather than failing silently.
+
+**Daemon-host + thin servers (Phase 1, dark by default).** Behind
+`THREADKEEPER_DAEMON_HOST` (`0` by default; no CLI config change), one headless
+host process per machine (`python -m threadkeeper.host`) owns the warm
+embedding model, the background loops, and a narrow embed-only unix socket
+(`THREADKEEPER_HOST_SOCK`, default `<db dir>/host.sock`). Per-session servers
+run thin instead — no ONNX, no daemon threads — and send any text needing a
+vector to the host over that socket instead of loading a model locally; the
+host's own background ingest daemon does the ongoing content-embedding work.
+If the host is unreachable a query embedding returns nothing and the caller
+falls back per `THREADKEEPER_THIN_EMBED_FALLBACK`: `fts` (default) runs
+FTS-only search, `local` lazily loads the model in-process instead. The
+host is elected via a flock and spawned detached by the first thin server that
+needs one; `memory_guard` supervises it — respawning it if its heartbeat goes
+stale past `THREADKEEPER_HOST_HEARTBEAT_TTL_S` — instead of idle-retiring it
+the way a thin server would be. See `docs/ARCHITECTURE.md` for the full design.
 
 ---
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -615,10 +615,15 @@ one always-on headless process per machine:
   needs goes through this same host-then-fallback path.
 - **`memory_guard` supervision** — thin servers are cheap (no ONNX, no
   daemon threads) and are excluded from aggregate idle-retire while the flag
-  is on (`_idle_retire_candidates`); instead `supervise_host()` checks the
-  host's presence heartbeat and, once it has gone stale past
-  `THREADKEEPER_HOST_HEARTBEAT_TTL_S`, calls `host.ensure_host_running()` to
-  spawn a replacement.
+  is on (`_idle_retire_candidates`); instead `supervise_host()` calls
+  `host.ensure_host_running()` once the host's presence heartbeat has gone
+  stale past `THREADKEEPER_HOST_HEARTBEAT_TTL_S`. That respawn only takes
+  effect when no live host still holds the election lock (`host.main()`
+  exits 0 immediately otherwise), so end-to-end this recovers a fully-dead
+  host; a thin session's own `ensure_host_running()` call at session start
+  (below) is the primary recovery path. Recovering a wedged-but-alive host
+  (stale heartbeat, process still up, lock still held) via SIGTERM-by-pid is
+  not yet implemented — tracked as a pre-enable follow-up.
 - **Always-on host, lazy spawn** — a thin server's `identity._ensure_session`
   calls `host.ensure_host_running()` on every session start: a no-op if a
   live heartbeat already exists, otherwise a **detached** spawn
@@ -626,8 +631,8 @@ one always-on headless process per machine:
   host outlives the session that spawned it and a closing CLI can never HUP
   it. The host then runs forever — no idle-exit — because the loops (daily
   retention, weekly curator, probe, …) must keep ticking with no active
-  session; it exits only on SIGTERM (a `memory_guard` restart) or losing the
-  host lock.
+  session; it exits only on SIGTERM (sent manually today — see the
+  supervision caveat above) or failing to acquire the host lock at startup.
 
 Flag off ⇒ zero behavior change: every session starts its own daemons and
 embeds locally, exactly as before Phase 1.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -578,6 +578,60 @@ shadow/extract/curator/candidate-reviewer daemons from starting recursively.
 The daemons share the `get_db()` connection pool; sqlite WAL allows one writer
 + many readers without blocking.
 
+### Daemon-host + thin servers (Phase 1)
+
+Behind `THREADKEEPER_DAEMON_HOST` (`0` by default — dark; no CLI config
+change), the daemon block above moves out of the per-session server and into
+one always-on headless process per machine:
+
+- **Election** — `python -m threadkeeper.host` (`host.main()`) takes
+  `HOST_LOCK_PATH` (`<db dir>/host.lock`) via `single_flight_lock`. A second
+  host racing for the same lock exits 0 immediately (idempotent spawn), so
+  there is never more than one host per machine.
+- **The moved daemon block** — `host.start_daemons()` centralizes exactly the
+  background ingester plus the 18 daemon starters that otherwise run inline in
+  `identity._ensure_session`'s foreground branch (above), starting each once
+  in the host process instead of once per session. With the flag off,
+  `_ensure_session` calls `host.start_daemons()` itself in-process — byte-for-
+  byte the pre-Phase-1 behavior, just centralized in one function.
+- **Embed socket + FTS fallback** — the host binds a narrow embed-only unix
+  socket (`host_embed.serve_embed_socket`, path `THREADKEEPER_HOST_SOCK`,
+  default `<db dir>/host.sock`; newline-delimited versioned JSON —
+  `{"v":1,"op":"embed","texts":[...]}` in, `{"v":1,"vectors":[...]}` or
+  `{"v":1,"error":...}` out). In a thin server (`THREADKEEPER_ROLE=server`,
+  the default under the flag), `embeddings._encode()` tries
+  `embed_via_host(...)` first for any text it needs to embed — query or the
+  session-start catch-up ingest pass below — instead of loading the model
+  itself. `embed_via_host` returns `None` on any failure (no host, timeout,
+  malformed reply), and `_encode` then honors
+  `THREADKEEPER_THIN_EMBED_FALLBACK`: `fts` (default) propagates that `None` so
+  the caller degrades to FTS-only, keeping the thin server model-free even
+  when the host is down; `local` instead falls through to lazily loading the ONNX
+  model in-process, trading the RAM savings for keeping semantic search fully
+  available. The ongoing content-embedding work (new dialog rows) is produced
+  by the host's own background ingest daemon; a thin server's session start
+  still runs the pre-existing bounded catch-up ingest pass
+  (`THREADKEEPER_INGEST_CAP`, unchanged by Phase 1), and any embedding it
+  needs goes through this same host-then-fallback path.
+- **`memory_guard` supervision** — thin servers are cheap (no ONNX, no
+  daemon threads) and are excluded from aggregate idle-retire while the flag
+  is on (`_idle_retire_candidates`); instead `supervise_host()` checks the
+  host's presence heartbeat and, once it has gone stale past
+  `THREADKEEPER_HOST_HEARTBEAT_TTL_S`, calls `host.ensure_host_running()` to
+  spawn a replacement.
+- **Always-on host, lazy spawn** — a thin server's `identity._ensure_session`
+  calls `host.ensure_host_running()` on every session start: a no-op if a
+  live heartbeat already exists, otherwise a **detached** spawn
+  (`subprocess.Popen(..., start_new_session=True)`, redirected stdio) so the
+  host outlives the session that spawned it and a closing CLI can never HUP
+  it. The host then runs forever — no idle-exit — because the loops (daily
+  retention, weekly curator, probe, …) must keep ticking with no active
+  session; it exits only on SIGTERM (a `memory_guard` restart) or losing the
+  host lock.
+
+Flag off ⇒ zero behavior change: every session starts its own daemons and
+embeds locally, exactly as before Phase 1.
+
 ## Spawn architecture
 
 `spawn(prompt, slim=True, role=…, visible=False, …)` brings up a child agent

--- a/docs/superpowers/plans/2026-07-07-daemon-host-thin-servers.md
+++ b/docs/superpowers/plans/2026-07-07-daemon-host-thin-servers.md
@@ -750,27 +750,37 @@ the loops in *whatever process calls it*, so the flag-off path runs them
 in-process exactly as before, and the host path runs them in the host. Both use
 lazy `from . import host` (no import cycle).
 
+Three cases (the host role must NOT restart daemons — `host.main()` already
+did, and `_ensure_session` runs again on the host's own heartbeat):
+
 ```python
         # ... one-shot ingest reads stay here (unchanged: _ingest_all,
         #     _backfill_dialog_fts_if_empty) ...
         from . import config as _cfg
         from . import host
-        if _cfg.DAEMON_HOST_ENABLED and _cfg.PROCESS_ROLE == "server":
+        if not _cfg.DAEMON_HOST_ENABLED:
+            # legacy (flag off): run every loop in THIS process, as before.
             try:
-                host.ensure_host_running()   # thin: delegate loops to the host
-            except Exception:
-                pass  # a thin server must never fail to start on host trouble
-        else:
-            try:
-                host.start_daemons()         # flag off / host role: in-process (legacy)
+                host.start_daemons()
             except Exception:
                 pass
+        elif _cfg.PROCESS_ROLE == "server":
+            # thin server: delegate the loops to the shared host.
+            try:
+                host.ensure_host_running()
+            except Exception:
+                pass  # a thin server must never fail to start on host trouble
+        # else: flag on + role == "host" — host.main() already started the
+        # loops; a re-entrant _ensure_session (e.g. the host heartbeat) must
+        # NOT restart them. Do nothing.
 ```
 
 Note: the current code starts the background ingester via
 `ingest._start_background_ingester()` and each daemon in its own `try/except`;
 `host.start_daemons()` (Task 4) already wraps the ingester + all 18 starters the
-same way, so this is the *same* behavior with the flag off, just centralized.
+same way, so the flag-off path is the *same* behavior, just centralized. The
+`elif`/no-`else` structure ensures the host process never double-starts its own
+loops on the heartbeat's re-entrant `_ensure_session`.
 
 - [ ] **Step 5: Run tests to verify they pass**
 

--- a/docs/superpowers/plans/2026-07-07-daemon-host-thin-servers.md
+++ b/docs/superpowers/plans/2026-07-07-daemon-host-thin-servers.md
@@ -1,0 +1,1015 @@
+# Daemon-host + thin servers — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace "a full MCP server per CLI session" with one headless daemon-host (owns the 15 background loops + the warm ONNX model + a narrow embed socket) and thin per-session servers (stdio MCP + direct SQLite, no daemons, no ONNX).
+
+**Architecture:** A machine-wide host process is elected via a flock. Thin servers spawn it detached on startup and route only query-embedding to it over a unix socket (`~/.threadkeeper/host.sock`), falling back to FTS when it is unreachable. Everything is gated by `THREADKEEPER_DAEMON_HOST` (dark by default), so with the flag off behavior is byte-for-byte today's.
+
+**Tech Stack:** Python 3.11+, stdlib `socket`/`json`/`subprocess`, pydantic-settings, sqlite (WAL), pytest (`--forked` in CI). No new third-party dependency.
+
+## Global Constraints
+
+- Python floor **3.11** (config uses `tomllib` + `dict[str, ...]`); target 3.11/3.12/3.13.
+- **No new third-party dependency.** Embed IPC is stdlib `socket` + `json`.
+- Flag default **off**: `THREADKEEPER_DAEMON_HOST=0` ⇒ zero behavior change. Every new code path is gated on it.
+- Env knobs are read via the pydantic `Settings` class (prefix `THREADKEEPER_`) and re-exported as UPPER_CASE module constants in `config.py`; hot-reloadable ones flow through `_derive_constants`.
+- Tests run under `pytest --forked`; each test re-imports the package via `fresh_mp`/bootstrap against a `tmp_path` DB. Never touch the real `~/.threadkeeper`.
+- Socket + lock + host log live under `DB_PATH.parent` so a custom `THREADKEEPER_DB` keeps host and servers co-located.
+- Run tests with the project venv from the worktree cwd, PYTHONPATH pinned to the worktree:
+  `PYTHONPATH="$PWD" /Users/dmytro/ai-memory/.venv/bin/python -m pytest ...`
+
+---
+
+### Task 1: Config knobs + derived constants
+
+**Files:**
+- Modify: `threadkeeper/config.py` (Settings fields near the other `auto_update_*`/`memory_guard_*` fields; `_derive_constants`; module-constant publish list)
+- Test: `tests/test_daemon_host_config.py`
+
+**Interfaces:**
+- Produces: module constants `DAEMON_HOST_ENABLED: bool`, `PROCESS_ROLE: str` (`"server"`|`"host"`), `HOST_SOCK_PATH: Path`, `HOST_HEARTBEAT_TTL_S: float`, `THIN_EMBED_FALLBACK: str` (`"fts"`|`"local"`), `HOST_LOCK_PATH: Path`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_daemon_host_config.py
+"""Phase 1 config knobs (daemon-host)."""
+from __future__ import annotations
+import importlib, sys
+from pathlib import Path
+
+
+def _reimport(monkeypatch, tmp_path, **env):
+    base = {
+        "THREADKEEPER_DB": str(tmp_path / "db.sqlite"),
+        "THREADKEEPER_DISABLE_BG_DAEMONS": "1",
+        "THREADKEEPER_INGEST_INTERVAL_S": "0",
+    }
+    base.update(env)
+    for k, v in base.items():
+        monkeypatch.setenv(k, v)
+    for name in [m for m in list(sys.modules) if m.startswith("threadkeeper")]:
+        del sys.modules[name]
+    return importlib.import_module("threadkeeper.config")
+
+
+def test_defaults_are_dark(monkeypatch, tmp_path):
+    cfg = _reimport(monkeypatch, tmp_path)
+    assert cfg.DAEMON_HOST_ENABLED is False
+    assert cfg.PROCESS_ROLE == "server"
+    assert cfg.THIN_EMBED_FALLBACK == "fts"
+    assert cfg.HOST_SOCK_PATH == (tmp_path / "host.sock")
+    assert cfg.HOST_LOCK_PATH == (tmp_path / "host.lock")
+    assert cfg.HOST_HEARTBEAT_TTL_S > 0
+
+
+def test_flag_and_role_and_sock_override(monkeypatch, tmp_path):
+    sock = tmp_path / "custom.sock"
+    cfg = _reimport(
+        monkeypatch, tmp_path,
+        THREADKEEPER_DAEMON_HOST="1",
+        THREADKEEPER_ROLE="host",
+        THREADKEEPER_HOST_SOCK=str(sock),
+        THREADKEEPER_THIN_EMBED_FALLBACK="local",
+    )
+    assert cfg.DAEMON_HOST_ENABLED is True
+    assert cfg.PROCESS_ROLE == "host"
+    assert cfg.HOST_SOCK_PATH == sock
+    assert cfg.THIN_EMBED_FALLBACK == "local"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `PYTHONPATH="$PWD" /Users/dmytro/ai-memory/.venv/bin/python -m pytest tests/test_daemon_host_config.py -v`
+Expected: FAIL — `AttributeError: module 'threadkeeper.config' has no attribute 'DAEMON_HOST_ENABLED'`.
+
+- [ ] **Step 3: Add the Settings fields**
+
+In `class Settings(BaseSettings)`, next to the `auto_update_*` block, add:
+
+```python
+    # ── Phase 1: daemon-host + thin servers (dark by default) ──
+    daemon_host: bool = False              # THREADKEEPER_DAEMON_HOST
+    role: str = "server"                   # THREADKEEPER_ROLE: server | host
+    host_sock: str = ""                    # "" -> <db dir>/host.sock
+    host_heartbeat_ttl_s: float = 120.0
+    thin_embed_fallback: str = "fts"       # fts | local
+```
+
+- [ ] **Step 4: Publish derived constants**
+
+In `_derive_constants(s)` add to the returned dict (so hot-reload picks up the flag/fallback), keeping path constants next to `DB_PATH`:
+
+```python
+        "DAEMON_HOST_ENABLED": bool(s.daemon_host),
+        "PROCESS_ROLE": (s.role or "server").strip().lower(),
+        "HOST_HEARTBEAT_TTL_S": float(s.host_heartbeat_ttl_s),
+        "THIN_EMBED_FALLBACK": (s.thin_embed_fallback or "fts").strip().lower(),
+```
+
+Then, after `DB_PATH` is defined (module scope, non-hot-reloaded like the other path constants), add:
+
+```python
+_HOST_SOCK_OVERRIDE = (settings.host_sock or "").strip()
+HOST_SOCK_PATH: Path = (
+    Path(_HOST_SOCK_OVERRIDE).expanduser() if _HOST_SOCK_OVERRIDE
+    else DB_PATH.parent / "host.sock"
+)
+HOST_LOCK_PATH: Path = DB_PATH.parent / "host.lock"
+```
+
+Add `DAEMON_HOST_ENABLED, PROCESS_ROLE, HOST_HEARTBEAT_TTL_S, THIN_EMBED_FALLBACK` to the `globals().update(_derive_constants(settings))` publish path (it already publishes everything the dict returns — no extra wiring), and export the two Path constants alongside `DB_PATH` in the module's constant list if one is maintained.
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `PYTHONPATH="$PWD" /Users/dmytro/ai-memory/.venv/bin/python -m pytest tests/test_daemon_host_config.py -v`
+Expected: PASS (2 passed).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add threadkeeper/config.py tests/test_daemon_host_config.py
+git commit -m "feat(host): config knobs for daemon-host + thin servers (dark)"
+```
+
+---
+
+### Task 2: Embed IPC — `host_embed.py`
+
+**Files:**
+- Create: `threadkeeper/host_embed.py`
+- Test: `tests/test_host_embed.py`
+
+**Interfaces:**
+- Produces:
+  - `serve_embed_socket(sock_path: Path, encode_fn) -> threading.Thread` — binds a unix socket, serves `{"v":1,"op":"embed","texts":[...]}` by calling `encode_fn(texts) -> list[list[float]] | None`, replies `{"v":1,"vectors":[...]}` or `{"v":1,"error":"..."}`. Returns the started daemon thread. `encode_fn` is injected so the socket layer has no import cycle with `embeddings`.
+  - `embed_via_host(texts: list[str], sock_path: Path, timeout: float = 3.0) -> list[list[float]] | None` — client; returns vectors, or `None` on any failure (no host, timeout, malformed).
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_host_embed.py
+from __future__ import annotations
+import time
+from pathlib import Path
+from threadkeeper import host_embed
+
+
+def test_roundtrip_and_batch(tmp_path):
+    sock = tmp_path / "h.sock"
+    # deterministic fake encoder: vector = [len(text), first-ord]
+    enc = lambda texts: [[float(len(t)), float(ord(t[0]) if t else 0)] for t in texts]
+    t = host_embed.serve_embed_socket(sock, enc)
+    try:
+        for _ in range(50):
+            if sock.exists():
+                break
+            time.sleep(0.02)
+        out = host_embed.embed_via_host(["ab", "xyz"], sock)
+        assert out == [[2.0, 97.0], [3.0, 120.0]]
+    finally:
+        host_embed.stop_embed_socket()
+        t.join(timeout=2)
+
+
+def test_client_returns_none_when_no_host(tmp_path):
+    assert host_embed.embed_via_host(["q"], tmp_path / "absent.sock", timeout=0.3) is None
+
+
+def test_server_error_maps_to_none(tmp_path):
+    sock = tmp_path / "h.sock"
+    enc = lambda texts: (_ for _ in ()).throw(RuntimeError("boom"))
+    t = host_embed.serve_embed_socket(sock, enc)
+    try:
+        for _ in range(50):
+            if sock.exists():
+                break
+            time.sleep(0.02)
+        assert host_embed.embed_via_host(["q"], sock) is None
+    finally:
+        host_embed.stop_embed_socket()
+        t.join(timeout=2)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `PYTHONPATH="$PWD" /Users/dmytro/ai-memory/.venv/bin/python -m pytest tests/test_host_embed.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'threadkeeper.host_embed'`.
+
+- [ ] **Step 3: Write the implementation**
+
+```python
+# threadkeeper/host_embed.py
+"""Narrow embed-only IPC between thin servers and the daemon-host (Phase 1).
+
+Thin servers do not load the ONNX model; to embed a search query they send the
+text to the host over a unix socket and get the vector back. Wire format is
+newline-delimited, versioned JSON:
+
+    req  {"v":1,"op":"embed","texts":["...", "..."]}
+    resp {"v":1,"vectors":[[...],[...]]}  |  {"v":1,"error":"..."}
+
+The socket layer is dependency-injected with `encode_fn` so it never imports
+`embeddings` (no cycle); the host wires the real encoder in.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import socket
+import threading
+from pathlib import Path
+from typing import Callable, Optional
+
+logger = logging.getLogger(__name__)
+
+_WIRE_V = 1
+_server_sock: Optional[socket.socket] = None
+_stop = threading.Event()
+
+
+def _handle(conn: socket.socket, encode_fn: Callable[[list], Optional[list]]) -> None:
+    with conn:
+        buf = b""
+        while b"\n" not in buf:
+            chunk = conn.recv(65536)
+            if not chunk:
+                return
+            buf += chunk
+        try:
+            req = json.loads(buf.split(b"\n", 1)[0].decode("utf-8"))
+            texts = list(req.get("texts") or [])
+            vecs = encode_fn(texts)
+            if vecs is None:
+                reply = {"v": _WIRE_V, "error": "embeddings_unavailable"}
+            else:
+                reply = {"v": _WIRE_V, "vectors": [list(map(float, v)) for v in vecs]}
+        except Exception as e:  # never crash the host on a bad request
+            reply = {"v": _WIRE_V, "error": f"{type(e).__name__}: {e}"}
+        try:
+            conn.sendall((json.dumps(reply) + "\n").encode("utf-8"))
+        except OSError:
+            pass
+
+
+def _serve_loop(srv: socket.socket, encode_fn) -> None:
+    while not _stop.is_set():
+        try:
+            conn, _ = srv.accept()
+        except OSError:
+            break
+        threading.Thread(target=_handle, args=(conn, encode_fn), daemon=True).start()
+
+
+def serve_embed_socket(sock_path: Path, encode_fn: Callable[[list], Optional[list]]) -> threading.Thread:
+    """Bind `sock_path` and serve embed requests via `encode_fn`. Idempotent
+    cleanup of a stale socket file; returns the started accept thread."""
+    global _server_sock
+    _stop.clear()
+    sock_path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        sock_path.unlink()          # clear a stale socket from a dead host
+    except FileNotFoundError:
+        pass
+    srv = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    srv.bind(str(sock_path))
+    os.chmod(sock_path, 0o600)
+    srv.listen(64)
+    _server_sock = srv
+    t = threading.Thread(target=_serve_loop, args=(srv, encode_fn),
+                         name="embed-socket", daemon=True)
+    t.start()
+    return t
+
+
+def stop_embed_socket() -> None:
+    _stop.set()
+    global _server_sock
+    if _server_sock is not None:
+        try:
+            _server_sock.close()
+        finally:
+            _server_sock = None
+
+
+def embed_via_host(texts: list, sock_path: Path, timeout: float = 3.0) -> Optional[list]:
+    """Client: ask the host to embed `texts`. Returns a list of vectors, or
+    None on ANY failure (no host / timeout / malformed) so the caller can fall
+    back to FTS."""
+    try:
+        with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as c:
+            c.settimeout(timeout)
+            c.connect(str(sock_path))
+            c.sendall((json.dumps({"v": _WIRE_V, "op": "embed",
+                                   "texts": list(texts)}) + "\n").encode("utf-8"))
+            buf = b""
+            while b"\n" not in buf:
+                chunk = c.recv(65536)
+                if not chunk:
+                    return None
+                buf += chunk
+        resp = json.loads(buf.split(b"\n", 1)[0].decode("utf-8"))
+        if resp.get("error") or "vectors" not in resp:
+            return None
+        return resp["vectors"]
+    except (OSError, ValueError, json.JSONDecodeError):
+        return None
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `PYTHONPATH="$PWD" /Users/dmytro/ai-memory/.venv/bin/python -m pytest tests/test_host_embed.py -v`
+Expected: PASS (3 passed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add threadkeeper/host_embed.py tests/test_host_embed.py
+git commit -m "feat(host): narrow embed-only unix-socket IPC (server + client)"
+```
+
+---
+
+### Task 3: `embeddings._encode` role-aware routing
+
+**Files:**
+- Modify: `threadkeeper/embeddings.py` (`_encode`, line ~132)
+- Test: `tests/test_embed_routing.py`
+
+**Interfaces:**
+- Consumes: `host_embed.embed_via_host` (Task 2); `config.DAEMON_HOST_ENABLED`, `config.PROCESS_ROLE`, `config.HOST_SOCK_PATH`, `config.THIN_EMBED_FALLBACK` (Task 1).
+- Produces: unchanged `_encode(texts) -> np.ndarray | None` signature. In a thin process with the flag on, it returns host-embedded vectors (normalized) or `None` (fallback=fts) / local (fallback=local).
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_embed_routing.py
+from __future__ import annotations
+import sys, importlib
+import numpy as np
+
+
+def _reimport(monkeypatch, tmp_path, **env):
+    base = {"THREADKEEPER_DB": str(tmp_path / "db.sqlite"),
+            "THREADKEEPER_DISABLE_BG_DAEMONS": "1"}
+    base.update(env)
+    for k, v in base.items():
+        monkeypatch.setenv(k, v)
+    for name in [m for m in list(sys.modules) if m.startswith("threadkeeper")]:
+        del sys.modules[name]
+    return importlib.import_module("threadkeeper.embeddings")
+
+
+def test_thin_role_uses_socket(monkeypatch, tmp_path):
+    emb = _reimport(monkeypatch, tmp_path,
+                    THREADKEEPER_DAEMON_HOST="1", THREADKEEPER_ROLE="server")
+    monkeypatch.setattr(emb.host_embed, "embed_via_host",
+                        lambda texts, sock, timeout=3.0: [[3.0, 4.0]] * len(texts))
+    out = emb._encode(["hello"])
+    # returned vector is L2-normalized: [3,4] -> [0.6,0.8]
+    assert out is not None
+    np.testing.assert_allclose(out[0], [0.6, 0.8], atol=1e-6)
+
+
+def test_thin_role_fts_fallback_returns_none(monkeypatch, tmp_path):
+    emb = _reimport(monkeypatch, tmp_path,
+                    THREADKEEPER_DAEMON_HOST="1", THREADKEEPER_ROLE="server",
+                    THREADKEEPER_THIN_EMBED_FALLBACK="fts")
+    monkeypatch.setattr(emb.host_embed, "embed_via_host",
+                        lambda texts, sock, timeout=3.0: None)
+    assert emb._encode(["hello"]) is None
+
+
+def test_flag_off_uses_local(monkeypatch, tmp_path):
+    emb = _reimport(monkeypatch, tmp_path, THREADKEEPER_DAEMON_HOST="0",
+                    THREADKEEPER_ROLE="server")
+    called = {"local": 0}
+    monkeypatch.setattr(emb, "_get_model", lambda: called.__setitem__("local", called["local"] + 1) or None)
+    emb._encode(["hello"])  # flag off -> local path (model None here -> None)
+    assert called["local"] == 1
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `PYTHONPATH="$PWD" /Users/dmytro/ai-memory/.venv/bin/python -m pytest tests/test_embed_routing.py -v`
+Expected: FAIL — `test_thin_role_uses_socket` errors (`_encode` has no `host_embed` attr / still hits local model).
+
+- [ ] **Step 3: Add the routing branch to `_encode`**
+
+At the top of `_encode`, before the `with _model_lock:` block, add the thin-role branch. Add `from . import host_embed` and the config imports near the other `from .config import ...` at module top.
+
+```python
+def _encode(texts: list[str]):
+    """(docstring unchanged)"""
+    global _last_used_at
+    from . import config as _cfg  # read live (hot-reloadable flag)
+    if _cfg.DAEMON_HOST_ENABLED and _cfg.PROCESS_ROLE == "server":
+        vecs = host_embed.embed_via_host(list(texts), _cfg.HOST_SOCK_PATH)
+        if vecs is None:
+            if _cfg.THIN_EMBED_FALLBACK == "local":
+                pass  # fall through to the local model below
+            else:
+                return None  # fts fallback: caller degrades to FTS
+        else:
+            import numpy as np  # type: ignore
+            arr = np.asarray(vecs, dtype="float32")
+            norms = np.linalg.norm(arr, axis=1, keepdims=True)
+            norms[norms == 0] = 1.0
+            _last_used_at = time.time()
+            return (arr / norms).astype("float32")
+    with _model_lock:
+        m = _get_model()
+        ...  # unchanged remainder
+```
+
+(Add `from . import host_embed` at the module top with the other imports.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `PYTHONPATH="$PWD" /Users/dmytro/ai-memory/.venv/bin/python -m pytest tests/test_embed_routing.py -v`
+Expected: PASS (3 passed).
+
+- [ ] **Step 5: Regression — embeddings still fine with flag off**
+
+Run: `PYTHONPATH="$PWD" /Users/dmytro/ai-memory/.venv/bin/python -m pytest tests/test_onnx_embeddings.py tests/test_vec_search.py -q`
+Expected: PASS (flag defaults off → local path unchanged).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add threadkeeper/embeddings.py tests/test_embed_routing.py
+git commit -m "feat(host): route query embedding to host socket in thin role"
+```
+
+---
+
+### Task 4: `host.py` — the daemon-host process
+
+**Files:**
+- Create: `threadkeeper/host.py`
+- Test: `tests/test_host_main.py`
+
+**Interfaces:**
+- Consumes: `config.HOST_LOCK_PATH`, `config.HOST_SOCK_PATH` (Task 1); `host_embed.serve_embed_socket` (Task 2); `helpers.single_flight_lock`; `embeddings._encode`; the 15 daemon `start_*_daemon` functions.
+- Produces:
+  - `start_daemons() -> list[str]` — the exact daemon-start block moved out of `identity._ensure_session`; returns started names. Reused by tests.
+  - `main() -> int` — acquire lock (exit 0 if held), set role=host, start daemons, bind embed socket, heartbeat loop until SIGTERM.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_host_main.py
+from __future__ import annotations
+import sys, importlib
+
+
+def _reimport(monkeypatch, tmp_path):
+    for k, v in {"THREADKEEPER_DB": str(tmp_path / "db.sqlite"),
+                 "THREADKEEPER_DAEMON_HOST": "1",
+                 "THREADKEEPER_DISABLE_BG_DAEMONS": "1"}.items():
+        monkeypatch.setenv(k, v)
+    for name in [m for m in list(sys.modules) if m.startswith("threadkeeper")]:
+        del sys.modules[name]
+    importlib.import_module("threadkeeper.server")  # register runtime
+    return importlib.import_module("threadkeeper.host")
+
+
+def test_start_daemons_calls_each_starter(monkeypatch, tmp_path):
+    host = _reimport(monkeypatch, tmp_path)
+    calls = []
+    for modname, fn in [("retention", "start_retention_daemon"),
+                        ("curator", "start_curator_daemon"),
+                        ("shadow_review", "start_shadow_daemon")]:
+        mod = importlib.import_module(f"threadkeeper.{modname}")
+        monkeypatch.setattr(mod, fn, (lambda n: (lambda: calls.append(n)))(modname))
+    started = host.start_daemons()
+    assert "retention" in started and "curator" in started and "shadow_review" in started
+    assert set(calls) >= {"retention", "curator", "shadow_review"}
+
+
+def test_serve_wires_local_encoder(monkeypatch, tmp_path):
+    host = _reimport(monkeypatch, tmp_path)
+    seen = {}
+    monkeypatch.setattr(host.host_embed, "serve_embed_socket",
+                        lambda sock, enc: seen.update(sock=sock, enc=enc) or __import__("threading").Thread(target=lambda: None))
+    host.start_embed_server()
+    from threadkeeper import config
+    assert seen["sock"] == config.HOST_SOCK_PATH
+    # the wired encoder delegates to embeddings._encode
+    assert callable(seen["enc"])
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `PYTHONPATH="$PWD" /Users/dmytro/ai-memory/.venv/bin/python -m pytest tests/test_host_main.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'threadkeeper.host'`.
+
+- [ ] **Step 3: Write `host.py`**
+
+Move the daemon-start block verbatim from `identity._ensure_session` (lines ~128–217, the `try: from . import X; X.start_*_daemon(); except: pass` series **plus** `ingest._start_background_ingester`) into `start_daemons()`. Keep the one-shot session ingest reads (`_ingest_all`, `_backfill_dialog_fts_if_empty`) in `identity` (Task 5) — only the *daemon* starters move.
+
+```python
+# threadkeeper/host.py
+"""The daemon-host (Phase 1): one headless process per machine that owns the
+background loops + the warm ONNX model + the embed socket. Elected via a flock;
+always-on (the loops must run with no active CLI session)."""
+from __future__ import annotations
+
+import logging
+import os
+import signal
+import time
+from pathlib import Path
+
+from . import config
+from . import host_embed
+from .helpers import single_flight_lock
+
+logger = logging.getLogger(__name__)
+
+_DAEMON_STARTERS = [
+    ("retention", "start_retention_daemon"),
+    ("search_proxy", "start_search_proxy"),
+    ("spawn_budget", "start_budget_daemon"),
+    ("memory_guard", "start_memory_guard_daemon"),
+    ("auto_update", "start_auto_update_daemon"),
+    ("skill_watcher", "start_skill_watcher"),
+    ("skill_updater", "start_skill_update_daemon"),
+    ("config_watcher", "start_config_watcher"),
+    ("shadow_review", "start_shadow_daemon"),
+    ("curator", "start_curator_daemon"),
+    ("extract_daemon", "start_extract_daemon"),
+    ("candidate_reviewer", "start_candidate_reviewer_daemon"),
+    ("probe_daemon", "start_probe_daemon"),
+    ("evolve_daemon", "start_evolve_daemon"),
+    ("evolve_applier", "start_evolve_applier_daemon"),
+    ("thread_janitor", "start_thread_janitor"),
+    ("dialectic_miner", "start_dialectic_miner_daemon"),
+    ("dialectic_validator", "start_dialectic_validator_daemon"),
+]
+
+
+def start_daemons() -> list[str]:
+    """Start every background loop once, in THIS process. Mirrors the block
+    that used to live in identity._ensure_session; each starter is idempotent
+    and single-flight-guarded, so a double call is safe."""
+    started: list[str] = []
+    # periodic background ingester (moved from _ensure_session)
+    try:
+        from . import ingest
+        ingest._start_background_ingester()
+        started.append("ingest")
+    except Exception:
+        logger.debug("host: ingest start failed", exc_info=True)
+    for modname, fn in _DAEMON_STARTERS:
+        try:
+            mod = __import__(f"threadkeeper.{modname}", fromlist=[fn])
+            getattr(mod, fn)()
+            started.append(modname)
+        except Exception:
+            logger.debug("host: start %s failed", modname, exc_info=True)
+    return started
+
+
+def start_embed_server():
+    """Bind the embed socket, wiring the LOCAL encoder (host role)."""
+    from . import embeddings
+
+    def _encode_texts(texts):
+        arr = embeddings._encode(list(texts))
+        return None if arr is None else [list(map(float, row)) for row in arr]
+
+    return host_embed.serve_embed_socket(config.HOST_SOCK_PATH, _encode_texts)
+
+
+def main() -> int:
+    """Elected headless host. Exits 0 immediately if another host holds the
+    lock (idempotent spawn)."""
+    os.environ["THREADKEEPER_ROLE"] = "host"
+    config.reload_settings()  # re-derive PROCESS_ROLE == "host"
+    with single_flight_lock("daemon-host") as locked:
+        if not locked:
+            return 0
+        start_daemons()
+        start_embed_server()
+        stop = {"v": False}
+        signal.signal(signal.SIGTERM, lambda *_: stop.__setitem__("v", True))
+        while not stop["v"]:
+            _heartbeat()
+            time.sleep(min(30.0, config.HOST_HEARTBEAT_TTL_S / 2))
+    return 0
+
+
+def _heartbeat() -> None:
+    from .db import get_db
+    from . import identity
+    try:
+        # `_ensure_session(conn, client=)` (identity.py:83) registers/refreshes
+        # a presence row under the given client label — used here to stamp the
+        # host's own row that `_host_alive()` (Task 5) reads back.
+        identity._ensure_session(get_db(), client="daemon-host")
+    except Exception:
+        logger.debug("host: heartbeat failed", exc_info=True)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `PYTHONPATH="$PWD" /Users/dmytro/ai-memory/.venv/bin/python -m pytest tests/test_host_main.py -v`
+Expected: PASS (2 passed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add threadkeeper/host.py tests/test_host_main.py
+git commit -m "feat(host): daemon-host main — election, daemons, embed server, heartbeat"
+```
+
+---
+
+### Task 5: `ensure_host_running()` + thin `_ensure_session` split
+
+**Files:**
+- Modify: `threadkeeper/host.py` (add `ensure_host_running`)
+- Modify: `threadkeeper/identity.py` (`_ensure_session`: gate the daemon-start block on the flag)
+- Test: `tests/test_thin_session.py`
+
+**Interfaces:**
+- Consumes: `config.DAEMON_HOST_ENABLED`, `config.PROCESS_ROLE`, `config.HOST_LOCK_PATH` (Tasks 1, 4).
+- Produces: `host.ensure_host_running() -> bool` — under the host lock, if no live host spawn one detached and return True (spawned) / False (already live or we are the host).
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_thin_session.py
+from __future__ import annotations
+import sys, importlib
+
+
+def _reimport(monkeypatch, tmp_path, flag="1", role="server"):
+    for k, v in {"THREADKEEPER_DB": str(tmp_path / "db.sqlite"),
+                 "THREADKEEPER_DAEMON_HOST": flag,
+                 "THREADKEEPER_ROLE": role,
+                 "THREADKEEPER_DISABLE_BG_DAEMONS": "1",
+                 "THREADKEEPER_INGEST_INTERVAL_S": "0",
+                 "THREADKEEPER_INGEST_CAP": "0"}.items():
+        monkeypatch.setenv(k, v)
+    for name in [m for m in list(sys.modules) if m.startswith("threadkeeper")]:
+        del sys.modules[name]
+    importlib.import_module("threadkeeper.server")
+    return (importlib.import_module("threadkeeper.identity"),
+            importlib.import_module("threadkeeper.host"))
+
+
+def test_thin_session_starts_no_daemons_and_ensures_host(monkeypatch, tmp_path):
+    identity, host = _reimport(monkeypatch, tmp_path, flag="1", role="server")
+    started = []
+    monkeypatch.setattr(host, "start_daemons", lambda: started.append("daemons") or [])
+    ensured = {"n": 0}
+    monkeypatch.setattr(host, "ensure_host_running", lambda: ensured.__setitem__("n", ensured["n"] + 1) or True)
+    # spy: no daemon starter should be invoked from a thin session
+    import threadkeeper.shadow_review as sr
+    monkeypatch.setattr(sr, "start_shadow_daemon", lambda: started.append("shadow"))
+    from threadkeeper.db import get_db
+    identity._ensure_session(get_db())
+    assert "shadow" not in started        # thin server started no daemon
+    assert ensured["n"] >= 1              # but ensured a host
+
+
+def test_flag_off_still_starts_daemons_inproc(monkeypatch, tmp_path):
+    identity, host = _reimport(monkeypatch, tmp_path, flag="0", role="server")
+    hits = []
+    import threadkeeper.shadow_review as sr
+    monkeypatch.setattr(sr, "start_shadow_daemon", lambda: hits.append("shadow"))
+    # other starters harmless under DISABLE_BG_DAEMONS; assert the gate path ran
+    from threadkeeper.db import get_db
+    identity._ensure_session(get_db())
+    # with the flag OFF the legacy in-process branch runs (shadow starter reached)
+    assert hits == ["shadow"]
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `PYTHONPATH="$PWD" /Users/dmytro/ai-memory/.venv/bin/python -m pytest tests/test_thin_session.py -v`
+Expected: FAIL — `ensure_host_running` missing / thin session still starts daemons.
+
+- [ ] **Step 3: Add `ensure_host_running` to `host.py`**
+
+```python
+import subprocess
+import sys as _sys
+
+
+def ensure_host_running() -> bool:
+    """Called by a thin server at session start. If no live host, spawn one
+    detached and return True; else False. Idempotent under the host lock."""
+    if config.PROCESS_ROLE == "host":
+        return False
+    if _host_alive():
+        return False
+    with single_flight_lock("daemon-host-spawn") as locked:
+        if not locked or _host_alive():
+            return False
+        log = open(config.HOST_LOCK_PATH.parent / "host.log", "ab", buffering=0)
+        subprocess.Popen(
+            [_sys.executable, "-m", "threadkeeper.host"],
+            stdin=subprocess.DEVNULL, stdout=log, stderr=log,
+            start_new_session=True, close_fds=True,
+        )
+        return True
+
+
+def _host_alive() -> bool:
+    """A live host heartbeat within the TTL."""
+    from .db import get_db
+    try:
+        row = get_db().execute(
+            "SELECT heartbeat_at FROM presence WHERE client='daemon-host' "
+            "ORDER BY heartbeat_at DESC LIMIT 1"
+        ).fetchone()
+    except Exception:
+        return False
+    if not row or row["heartbeat_at"] is None:
+        return False
+    return (time.time() - int(row["heartbeat_at"])) < config.HOST_HEARTBEAT_TTL_S
+```
+
+- [ ] **Step 4: Gate the daemon block in `identity._ensure_session`**
+
+Wrap the daemon-start block (lines ~128–217) so it only runs when the flag is OFF; when ON, ensure the host instead. Keep the one-shot ingest reads (lines ~113–122) unconditional (cheap SQLite, per-session freshness).
+
+```python
+        # ... one-shot ingest reads stay here (unchanged) ...
+        from . import config as _cfg
+        if _cfg.DAEMON_HOST_ENABLED and _cfg.PROCESS_ROLE == "server":
+            try:
+                from . import host
+                host.ensure_host_running()
+            except Exception:
+                pass  # a thin server must never fail to start on host trouble
+        else:
+            # legacy in-process daemons (flag off) — UNCHANGED existing block
+            try:
+                from . import ingest
+                ingest._start_background_ingester()
+            except Exception:
+                pass
+            # ... the rest of the existing start_*_daemon block, verbatim ...
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `PYTHONPATH="$PWD" /Users/dmytro/ai-memory/.venv/bin/python -m pytest tests/test_thin_session.py -v`
+Expected: PASS (2 passed).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add threadkeeper/host.py threadkeeper/identity.py tests/test_thin_session.py
+git commit -m "feat(host): thin _ensure_session ensures host, skips in-proc daemons"
+```
+
+---
+
+### Task 6: `memory_guard` — supervise host, stop thrashing thin
+
+**Files:**
+- Modify: `threadkeeper/memory_guard.py` (`_idle_retire_candidates` / `_retire_plan`; add host-liveness supervision)
+- Test: `tests/test_memory_guard_host.py`
+
+**Interfaces:**
+- Consumes: `config.DAEMON_HOST_ENABLED`, `config.HOST_HEARTBEAT_TTL_S` (Task 1); `host.ensure_host_running` (Task 5).
+- Produces: with the flag on, a memory-guard pass (a) never lists a thin (non-host) process as an idle-retire candidate, (b) calls `ensure_host_running()` when the host row is stale.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_memory_guard_host.py
+from __future__ import annotations
+import sys, importlib, time
+
+
+def _reimport(monkeypatch, tmp_path, flag="1"):
+    for k, v in {"THREADKEEPER_DB": str(tmp_path / "db.sqlite"),
+                 "THREADKEEPER_DAEMON_HOST": flag,
+                 "THREADKEEPER_DISABLE_BG_DAEMONS": "1"}.items():
+        monkeypatch.setenv(k, v)
+    for name in [m for m in list(sys.modules) if m.startswith("threadkeeper")]:
+        del sys.modules[name]
+    importlib.import_module("threadkeeper.server")
+    return importlib.import_module("threadkeeper.memory_guard")
+
+
+def test_thin_not_retired_when_flag_on(monkeypatch, tmp_path):
+    mg = _reimport(monkeypatch, tmp_path, flag="1")
+    procs = [{"pid": 111, "client": "claude", "heartbeat_age_s": 99999,
+              "parent_alive": False, "rss_kb": 120000}]
+    assert mg._idle_retire_candidates(procs) == []   # thin never retired under host mode
+
+
+def test_stale_host_triggers_respawn(monkeypatch, tmp_path):
+    mg = _reimport(monkeypatch, tmp_path, flag="1")
+    from threadkeeper import host
+    respawned = {"n": 0}
+    monkeypatch.setattr(host, "ensure_host_running",
+                        lambda: respawned.__setitem__("n", respawned["n"] + 1) or True)
+    monkeypatch.setattr(mg, "_host_alive", lambda: False)
+    mg.supervise_host()
+    assert respawned["n"] == 1
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `PYTHONPATH="$PWD" /Users/dmytro/ai-memory/.venv/bin/python -m pytest tests/test_memory_guard_host.py -v`
+Expected: FAIL — `supervise_host` missing; thin still a retire candidate.
+
+- [ ] **Step 3: Implement supervision + guard the retire path**
+
+In `_idle_retire_candidates`, short-circuit when the flag is on and the row is not the host:
+
+```python
+def _idle_retire_candidates(procs):
+    from . import config as _cfg
+    out = []
+    for p in procs:
+        if _cfg.DAEMON_HOST_ENABLED and p.get("client") != "daemon-host":
+            continue  # thin servers are cheap; never idle-retire under host mode
+        ...  # existing conditions unchanged
+    return out
+```
+
+Add:
+
+```python
+def _host_alive() -> bool:
+    from . import host
+    return host._host_alive()
+
+
+def supervise_host() -> None:
+    """Respawn the daemon-host if its heartbeat is stale (flag on only)."""
+    from . import config as _cfg
+    if not _cfg.DAEMON_HOST_ENABLED:
+        return
+    if _host_alive():
+        return
+    try:
+        from . import host
+        host.ensure_host_running()
+    except Exception:
+        pass
+```
+
+Call `supervise_host()` once per `run_memory_guard` pass (near the top, before RSS work).
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `PYTHONPATH="$PWD" /Users/dmytro/ai-memory/.venv/bin/python -m pytest tests/test_memory_guard_host.py -v`
+Expected: PASS (2 passed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add threadkeeper/memory_guard.py tests/test_memory_guard_host.py
+git commit -m "feat(host): memory_guard supervises host, stops thin-server thrash"
+```
+
+---
+
+### Task 7: Integration — host + two thin servers, end to end
+
+**Files:**
+- Test: `tests/test_daemon_host_integration.py`
+
+**Interfaces:**
+- Consumes: everything above.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_daemon_host_integration.py
+"""End-to-end: a host process + two thin sessions against one tmp DB."""
+from __future__ import annotations
+import sys, importlib, time
+import numpy as np
+
+
+def _reimport(monkeypatch, tmp_path, role="server"):
+    for k, v in {"THREADKEEPER_DB": str(tmp_path / "db.sqlite"),
+                 "THREADKEEPER_DAEMON_HOST": "1",
+                 "THREADKEEPER_ROLE": role,
+                 "THREADKEEPER_DISABLE_BG_DAEMONS": "1",
+                 "THREADKEEPER_INGEST_INTERVAL_S": "0"}.items():
+        monkeypatch.setenv(k, v)
+    for name in [m for m in list(sys.modules) if m.startswith("threadkeeper")]:
+        del sys.modules[name]
+    importlib.import_module("threadkeeper.server")
+    return importlib
+
+
+def test_thin_search_embeds_via_host_socket(monkeypatch, tmp_path):
+    # host side: bind the embed socket with a deterministic encoder
+    _reimport(monkeypatch, tmp_path, role="host")
+    from threadkeeper import host_embed, config
+    enc = lambda texts: [[1.0, 0.0] for _ in texts]
+    t = host_embed.serve_embed_socket(config.HOST_SOCK_PATH, enc)
+    try:
+        for _ in range(50):
+            if config.HOST_SOCK_PATH.exists():
+                break
+            time.sleep(0.02)
+        # thin side: same DB dir, server role -> _encode must use the socket
+        _reimport(monkeypatch, tmp_path, role="server")
+        from threadkeeper import embeddings as thin_emb
+        out = thin_emb._encode(["query"])
+        assert out is not None
+        np.testing.assert_allclose(out[0], [1.0, 0.0], atol=1e-6)
+    finally:
+        host_embed.stop_embed_socket()
+        t.join(timeout=2)
+```
+
+- [ ] **Step 2: Run test to verify it fails, then passes**
+
+Run: `PYTHONPATH="$PWD" /Users/dmytro/ai-memory/.venv/bin/python -m pytest tests/test_daemon_host_integration.py -v`
+Expected: FAIL before Tasks 2–3 land; PASS after (the socket path + routing exist).
+
+- [ ] **Step 3: Full-suite regression (flag off is the default everywhere)**
+
+Run: `PYTHONPATH="$PWD" /Users/dmytro/ai-memory/.venv/bin/python -m pytest -q --forked`
+Expected: PASS — all existing tests green (nothing sets the flag except the new tests).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/test_daemon_host_integration.py
+git commit -m "test(host): end-to-end host socket + thin routing integration"
+```
+
+---
+
+### Task 8: Docs + rollout knobs surfaced
+
+**Files:**
+- Modify: `README.md` (env table + an architecture paragraph)
+- Modify: `docs/ARCHITECTURE.md` (a "daemon-host / thin servers" section)
+- Modify: `.env.example` (the five new knobs, commented, flag off)
+- Modify: `CHANGELOG.md` (Unreleased → Added)
+
+- [ ] **Step 1: Add the knobs to `.env.example`**
+
+```bash
+# ── Phase 1: daemon-host + thin servers (dark by default) ──
+# THREADKEEPER_DAEMON_HOST=0            # 1 = one headless host owns the loops+model; per-session servers go thin
+# THREADKEEPER_HOST_SOCK=              # embed socket path (default <db dir>/host.sock)
+# THREADKEEPER_HOST_HEARTBEAT_TTL_S=120 # host liveness window for supervision/respawn
+# THREADKEEPER_THIN_EMBED_FALLBACK=fts # fts | local — how a thin server embeds a query if the host is unreachable
+# THREADKEEPER_ROLE=server             # set to 'host' only by `python -m threadkeeper.host` (do not set by hand)
+```
+
+- [ ] **Step 2: README env table rows + one architecture paragraph**
+
+Add the five rows to the env-var table and a short paragraph under the architecture section describing the host/thin split, the embed socket, and the flag (dark by default; no CLI config change).
+
+- [ ] **Step 3: `docs/ARCHITECTURE.md` section**
+
+Add a "daemon-host + thin servers (#Phase-1)" subsection mirroring the design spec: election flock, moved daemon block, embed socket + FTS fallback, memory_guard supervision, always-on host.
+
+- [ ] **Step 4: CHANGELOG entry**
+
+```markdown
+### Added
+
+- **Daemon-host + thin per-session servers (dark, `THREADKEEPER_DAEMON_HOST`).**
+  One headless host per machine owns the 15 background loops + the warm ONNX
+  model + a narrow embed unix-socket; per-session servers go thin (stdio MCP +
+  direct SQLite, no daemons, no ONNX) and route only query-embedding to the
+  host, falling back to FTS when it is unreachable. Elected via a flock, spawned
+  detached by the first thin server, supervised by memory_guard. Off by default;
+  no CLI config change. Removes the per-session RAM multiplier and the
+  reclaim-thrash root.
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add README.md docs/ARCHITECTURE.md .env.example CHANGELOG.md
+git commit -m "docs(host): document daemon-host + thin servers + rollout flag"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:** host.py (T4), embed IPC (T2), embed_text routing (T3), _ensure_session split + ensure_host_running (T5), memory_guard supervision (T6), config knobs (T1), integration + failover (T7), rollout flag + docs (T1/T8). Every spec §Components item maps to a task.
+
+**Placeholder scan:** New-file code is complete. Two existing-file edits ("the rest of the existing start_*_daemon block, verbatim" in T5; "unchanged remainder" in T3) reference real, quoted current code the implementer copies in place — not invented behavior. Presence writer resolved: `identity._ensure_session(conn, client="daemon-host")` (identity.py:83).
+
+**Type consistency:** `embed_via_host(texts, sock_path, timeout)` and `serve_embed_socket(sock_path, encode_fn)` are used identically in T2/T3/T4/T7. `ensure_host_running() -> bool`, `_host_alive() -> bool`, `start_daemons() -> list[str]` consistent across T4/T5/T6. `_encode` returns a normalized `np.ndarray | None` on every branch.
+
+**Open confirmation for the implementer:** copy the current `_ensure_session` daemon-start block (identity.py ~128–217) verbatim into `host.start_daemons()` (T4) and the flag-off branch (T5) — the `_DAEMON_STARTERS` list in T4 already mirrors it; diff the two before committing T4 so no starter is dropped or added.

--- a/docs/superpowers/plans/2026-07-07-daemon-host-thin-servers.md
+++ b/docs/superpowers/plans/2026-07-07-daemon-host-thin-servers.md
@@ -743,24 +743,34 @@ def _host_alive() -> bool:
 
 Wrap the daemon-start block (lines ~128–217) so it only runs when the flag is OFF; when ON, ensure the host instead. Keep the one-shot ingest reads (lines ~113–122) unconditional (cheap SQLite, per-session freshness).
 
+Replace the existing in-line `try: from . import X; X.start_*_daemon()` series
+(lines ~128–217) with a call to the single shared `host.start_daemons()` (Task
+4), gated on the flag. No logic is duplicated — `host.start_daemons()` starts
+the loops in *whatever process calls it*, so the flag-off path runs them
+in-process exactly as before, and the host path runs them in the host. Both use
+lazy `from . import host` (no import cycle).
+
 ```python
-        # ... one-shot ingest reads stay here (unchanged) ...
+        # ... one-shot ingest reads stay here (unchanged: _ingest_all,
+        #     _backfill_dialog_fts_if_empty) ...
         from . import config as _cfg
+        from . import host
         if _cfg.DAEMON_HOST_ENABLED and _cfg.PROCESS_ROLE == "server":
             try:
-                from . import host
-                host.ensure_host_running()
+                host.ensure_host_running()   # thin: delegate loops to the host
             except Exception:
                 pass  # a thin server must never fail to start on host trouble
         else:
-            # legacy in-process daemons (flag off) — UNCHANGED existing block
             try:
-                from . import ingest
-                ingest._start_background_ingester()
+                host.start_daemons()         # flag off / host role: in-process (legacy)
             except Exception:
                 pass
-            # ... the rest of the existing start_*_daemon block, verbatim ...
 ```
+
+Note: the current code starts the background ingester via
+`ingest._start_background_ingester()` and each daemon in its own `try/except`;
+`host.start_daemons()` (Task 4) already wraps the ingester + all 18 starters the
+same way, so this is the *same* behavior with the flag off, just centralized.
 
 - [ ] **Step 5: Run tests to verify they pass**
 
@@ -1008,8 +1018,8 @@ git commit -m "docs(host): document daemon-host + thin servers + rollout flag"
 
 **Spec coverage:** host.py (T4), embed IPC (T2), embed_text routing (T3), _ensure_session split + ensure_host_running (T5), memory_guard supervision (T6), config knobs (T1), integration + failover (T7), rollout flag + docs (T1/T8). Every spec §Components item maps to a task.
 
-**Placeholder scan:** New-file code is complete. Two existing-file edits ("the rest of the existing start_*_daemon block, verbatim" in T5; "unchanged remainder" in T3) reference real, quoted current code the implementer copies in place — not invented behavior. Presence writer resolved: `identity._ensure_session(conn, client="daemon-host")` (identity.py:83).
+**Placeholder scan:** New-file code is complete. The daemon-start block is centralized in `host.start_daemons()` (T4) and called from both the host main and the flag-off branch (T5) — no verbatim duplication. T3's "unchanged remainder" references the real current `_encode` model path the implementer keeps in place. Presence writer resolved: `identity._ensure_session(conn, client="daemon-host")` (identity.py:83).
 
 **Type consistency:** `embed_via_host(texts, sock_path, timeout)` and `serve_embed_socket(sock_path, encode_fn)` are used identically in T2/T3/T4/T7. `ensure_host_running() -> bool`, `_host_alive() -> bool`, `start_daemons() -> list[str]` consistent across T4/T5/T6. `_encode` returns a normalized `np.ndarray | None` on every branch.
 
-**Open confirmation for the implementer:** copy the current `_ensure_session` daemon-start block (identity.py ~128–217) verbatim into `host.start_daemons()` (T4) and the flag-off branch (T5) — the `_DAEMON_STARTERS` list in T4 already mirrors it; diff the two before committing T4 so no starter is dropped or added.
+**Open confirmation for the implementer:** the `_DAEMON_STARTERS` list in T4 must mirror the current `_ensure_session` daemon-start block (identity.py ~128–217) exactly — diff the two before committing T4 so no starter is dropped or added, then T5 replaces that block with a single `host.start_daemons()` call (no duplication).

--- a/docs/superpowers/specs/2026-07-07-daemon-host-thin-servers-design.md
+++ b/docs/superpowers/specs/2026-07-07-daemon-host-thin-servers-design.md
@@ -138,9 +138,14 @@ CLI session C ─ python -m threadkeeper.server (THIN) ┘                     �
 
 - Thin servers are cheap (no ONNX, no daemons); drop them from the aggressive
   idle-retire path (still reap truly-dead rows).
-- New responsibility: **host supervision** — if the host row is stale (no
-  heartbeat past a TTL) or its RSS exceeds the kill threshold, SIGTERM it; the
-  next thin-server tick re-spawns it via `ensure_host_running()`.
+- New responsibility: **host supervision** — `supervise_host()` calls
+  `ensure_host_running()` once the host's heartbeat is stale past a TTL. That
+  respawn only takes effect when no live host still holds the election lock,
+  so end-to-end this recovers a fully-dead host; a thin session's own
+  `ensure_host_running()` call at session start is the primary recovery path.
+  **As implemented:** recovering a wedged-but-alive host (stale heartbeat,
+  process still up, lock still held) via SIGTERM-by-pid is not yet built —
+  tracked as a pre-enable follow-up, not part of this pass.
 - `TARGET_SERVERS` reinterpreted: the host is the one heavy process; thin
   servers are ephemeral and light, not retire targets.
 

--- a/docs/superpowers/specs/2026-07-07-daemon-host-thin-servers-design.md
+++ b/docs/superpowers/specs/2026-07-07-daemon-host-thin-servers-design.md
@@ -1,0 +1,223 @@
+# Phase 1 — Single daemon-host + thin per-session servers
+
+**Status:** design / approved shape, pending spec review
+**Date:** 2026-07-07
+**Roadmap:** audit Phase 1 ("единый daemon-host вместо «полный сервер на каждую сессию»").
+
+## Problem
+
+Every CLI session (Claude Code / Desktop, Codex, Antigravity, Gemini, Copilot,
+VS Code) launches its own **full** MCP server: `python -m threadkeeper.server`
+→ `mcp.run()`. In each such foreground process, `identity._ensure_session`
+starts **all ~15 background daemons** (retention, curator, shadow, extract,
+candidate-reviewer, probe, evolve reviewer/applier, dialectic miner/validator,
+thread-janitor, spawn-budget, memory-guard, auto-update, skill-updater,
+config-watcher) and the process lazily loads the ONNX embedding model
+(fastembed + onnxruntime + tokenizers native thread pools).
+
+Consequences observed in the audit:
+
+- **~3.4 GB aggregate RAM** — N concurrent sessions ⇒ N heavy processes
+  (~300–340 MB each: interpreter + package + FastMCP + embedding model + DB
+  connections + 15 daemon threads).
+- **reclaim-thrash** — `memory_guard` targets `TARGET_SERVERS=1` and SIGTERMs
+  *idle* servers (heartbeat past `RETIRE_IDLE_S`), but a live session's server
+  can't be killed (it owns the stdio channel), so the guard can never collapse
+  to 1. Sessions come and go ⇒ constant spawn/retire churn.
+
+Machine-wide `single_flight_lock(...)` (used by several daemons) and the
+`daemon_state` cadence gate (#209) already ensure the *work* of some loops runs
+once; but every server still **starts the threads**, **loads the model**, and
+**is a full process**. The RAM and thrash come from N full processes, not from
+duplicated loop work.
+
+## Goal / success criteria
+
+1. Exactly **one** heavy process per machine (the daemon-host) regardless of
+   how many CLI sessions are open.
+2. Per-session servers are **thin**: no daemon threads, no ONNX model; RSS a
+   fraction of today's full server.
+3. `memory_guard` no longer thrashes: nothing to aggressively retire; it
+   supervises the single host instead.
+4. **No CLI config change** — the launch command stays `python -m
+   threadkeeper.server`.
+5. Semantic search still works from a thin server (via the host), degrading to
+   FTS only when the host is transiently unreachable.
+6. Ships behind a flag, dark by default; reversible.
+
+Non-goals (later phases): DB storage dedup (−1.3 GB, Phase 2), trigger-scoped
+memory, durable work-ledger, event-sourced child resume. This spec is **only**
+the process-topology split.
+
+## Topology
+
+```
+CLI session A ─ python -m threadkeeper.server (THIN) ┐
+CLI session B ─ python -m threadkeeper.server (THIN) ┼─ embed socket ─► daemon-host  (1/machine, headless)
+CLI session C ─ python -m threadkeeper.server (THIN) ┘                     ├─ 15 daemons (the loops)
+        └─────────── all read/write ──────────► shared SQLite (WAL) ◄──────┤─ warm ONNX model
+                                                                           └─ embed socket listener
+```
+
+## Components (isolated units)
+
+### 1. `threadkeeper/host.py` (new) — the daemon-host
+
+- **Purpose:** own the background loops + the warm embedding model + the embed
+  socket for one machine.
+- **Entry:** `python -m threadkeeper.host` (also callable as `host.main()`).
+- **Startup:**
+  1. Acquire the machine-wide **host lock** (`single_flight_lock("daemon-host")`
+     / flock on `~/.threadkeeper/host.lock`). If already held by a live host,
+     exit 0 (idempotent — someone beat us).
+  2. Set role = host (`THREADKEEPER_ROLE=host` in-process) so `embed_text()`
+     uses the local model, not the socket.
+  3. Start all 15 daemons (the exact `start_*_daemon()` calls currently in
+     `identity._ensure_session`'s foreground branch).
+  4. Bind the **embed socket** listener (below).
+  5. Write/refresh a `presence` row with `client='daemon-host'` and heartbeat.
+- **Lifecycle:** **always-on** (decided). The host persists after every CLI
+  session closes — the loops (retention daily, curator weekly, probe, etc.)
+  must run even with no active session; that is the product ("autonomous
+  background agents"). No idle-exit. It exits only on SIGTERM (memory-guard
+  restart) or host-lock loss.
+- **Depends on:** `single_flight_lock`, the daemon modules, `embeddings`
+  (local model), `db`.
+
+### 2. Embed IPC — `threadkeeper/host_embed.py` (new)
+
+- **Socket:** `~/.threadkeeper/host.sock` (unix domain; override
+  `THREADKEEPER_HOST_SOCK`). Path lives next to the DB, so a custom
+  `THREADKEEPER_DB` dir keeps host + servers co-located.
+- **Wire format:** newline-delimited JSON, versioned.
+  - request: `{"v":1,"op":"embed","texts":["...", "..."]}`
+  - reply:   `{"v":1,"vectors":[[...],[...]]}` or `{"v":1,"error":"..."}`
+- **Server side** (runs in host): a small threaded socket server; each request
+  embeds via the local warm model and replies. Batch-first (`texts`) so ingest
+  backfill and multi-text calls are one round-trip.
+- **Client side** (runs in thin server): `embed_via_host(texts) ->
+  list[vector] | None`. Connects with a short timeout; returns `None` on any
+  failure (no host, timeout, malformed reply) so the caller can fall back.
+- **Depends on:** stdlib `socket`, `json`. No new third-party dep.
+
+### 3. `embeddings.embed_text()` — role-aware routing (change)
+
+- Today: loads the local model lazily and embeds.
+- New: branch on role.
+  - **host role:** unchanged (local warm model).
+  - **thin role:** call `embed_via_host(...)`. On `None`:
+    **fallback = FTS-only** (decided) — the caller (`search`, `neighbors`, …)
+    proceeds without a query vector and returns FTS results, logging a
+    one-line "host unreachable, semantic degraded to FTS" note. A config knob
+    `THREADKEEPER_THIN_EMBED_FALLBACK = fts | local` lets an operator opt into
+    lazy-local ONNX instead, but `fts` is the default (keeps thin thin at the
+    worst moment).
+- Ingest embedding (content vectors) is produced by the host's ingest daemon,
+  so thin servers never embed content — only, at most, a query.
+
+### 4. `identity._ensure_session` — split daemon-start from session-register (change)
+
+- Today (foreground branch): register presence **and** start all 15 daemons.
+- New: register presence + heartbeat as today, but **do not** start daemons.
+  Instead call `host.ensure_host_running()`:
+  - Under the host lock: if a live host heartbeat exists, no-op. Else
+    **spawn a detached** `python -m threadkeeper.host` via
+    `subprocess.Popen(..., start_new_session=True)` with stdin/stdout/stderr
+    redirected (own session, no inherited stdio), then return. The thin server
+    never becomes the host itself (keeps the stdio server light and lets the
+    host outlive the session).
+- `BACKGROUND_DAEMONS_ALLOWED` semantics fold into role: daemons start **only**
+  in the host process. Spawned review children stay daemon-free as today.
+- **Manual pass triggers still work from thin servers.** MCP tools like
+  `curator_run` / `shadow_review_run` / `evolve_apply` call the pass function
+  synchronously, not the daemon thread; they remain callable from a thin server
+  and stay single-flight-safe against the host's loops via the existing
+  `single_flight_lock` + `daemon_state` gate — no double-run.
+
+### 5. `memory_guard` — supervise, don't thrash (change)
+
+- Thin servers are cheap (no ONNX, no daemons); drop them from the aggressive
+  idle-retire path (still reap truly-dead rows).
+- New responsibility: **host supervision** — if the host row is stale (no
+  heartbeat past a TTL) or its RSS exceeds the kill threshold, SIGTERM it; the
+  next thin-server tick re-spawns it via `ensure_host_running()`.
+- `TARGET_SERVERS` reinterpreted: the host is the one heavy process; thin
+  servers are ephemeral and light, not retire targets.
+
+### 6. Config (change) — `threadkeeper/config.py`
+
+- `THREADKEEPER_ROLE` = `server` (default) | `host`. Set to `host` by
+  `host.main()`; thin servers keep `server`.
+- `THREADKEEPER_DAEMON_HOST` = `0` (default, dark) | `1`. When `0`, everything
+  behaves as today (each foreground server starts daemons; `embed_text` local).
+  When `1`, the split above is active. **Rollout flag.**
+- `THREADKEEPER_HOST_SOCK` (default `<db dir>/host.sock`).
+- `THREADKEEPER_HOST_HEARTBEAT_TTL_S` (host liveness window for supervision).
+- `THREADKEEPER_THIN_EMBED_FALLBACK` = `fts` (default) | `local`.
+
+## Data flow
+
+- **Light tool call** (brief/note/open_thread/core_*/FTS search): thin server →
+  shared SQLite (WAL) directly. No host involvement. (Unchanged code paths;
+  they just run in a process that didn't start daemons.)
+- **Semantic search**: thin server → `embed_via_host(query)` over the socket →
+  host embeds with warm model → vector back → thin server runs the vec0 search
+  on the shared DB. Host down ⇒ FTS-only.
+- **Content ingest / backfill embeddings**: host's ingest daemon reads new
+  dialog rows and writes vectors — same as today, but now only in the host.
+- **Loop work** (retention, curator, …): host only.
+
+## Failure handling
+
+- **No host at thin startup:** `ensure_host_running()` spawns one; the first
+  semantic search in the race window falls back to FTS. Idempotent under the
+  host lock (two thin servers racing ⇒ one host).
+- **Host crash:** lock released; next thin-server `_ensure_session` (every new
+  tool session) or `memory_guard` re-spawns it. Loops resume from
+  `daemon_state` cadence (no double-fire).
+- **Socket present but host dead** (stale sock file): client connect fails →
+  `None` → fallback; supervision SIGTERM + respawn cleans the stale sock on
+  next host bind (`unlink` before bind).
+- **Flag off:** zero behavior change (current per-server daemons + local embed).
+
+## Testing
+
+- **Unit**
+  - host lock election: two `ensure_host_running()` calls ⇒ exactly one spawn.
+  - embed socket round-trip: host server + client `embed_via_host` returns a
+    correct-dim vector; malformed/no-host ⇒ `None`.
+  - `embed_text` routing: role=host → local; role=server → socket; socket
+    `None` + fallback=fts → caller gets FTS path; fallback=local → lazy model.
+  - thin `_ensure_session` starts **zero** daemons (assert no
+    `start_*_daemon` called); host `main` starts all 15.
+- **Integration**
+  - spawn a host + 2 thin servers against a tmp DB: assert (a) each daemon
+    ran once (single-flight/host-only), (b) a semantic search from a thin
+    server returns host-embedded results, (c) `kill host` ⇒ next thin call
+    re-spawns it and search recovers.
+  - flag off ⇒ existing suite behavior unchanged.
+- Reuse `fresh_mp` (thin server) + a new `fresh_host` fixture. All host/socket
+  paths under `tmp_path`; no real `~/.threadkeeper`.
+
+## Rollout
+
+1. Land dark (`THREADKEEPER_DAEMON_HOST=0`), full test coverage.
+2. Enable locally (`.env`), watch: one `daemon-host` process, thin server RSS,
+   embed-socket latency, loop liveness, `memory_guard` no longer retiring.
+3. Flip default to `1` in a later release once soaked.
+4. Menubar/env-editor surfaces the flag + host status.
+
+## Open sub-decisions (defaults chosen; flip at review)
+
+- **Host shutdown:** always-on ✅ (vs idle-exit TTL).
+- **Thin embed fallback:** FTS-only ✅ (vs lazy-local ONNX).
+
+## Risks
+
+- A detached host spawned from a stdio child must fully daemonize (no inherited
+  stdio, own session) or a CLI closing could HUP it — covered by
+  `start_new_session` + redirected fds.
+- SQLite write concurrency: thin servers + host all write. Already WAL + the
+  code already runs N writers today; net writer count does not increase.
+- Socket security: unix socket under the user's `~/.threadkeeper` (0700 dir),
+  local-only; no network surface.

--- a/tests/test_daemon_host_config.py
+++ b/tests/test_daemon_host_config.py
@@ -1,0 +1,43 @@
+"""Phase 1 config knobs (daemon-host)."""
+from __future__ import annotations
+import importlib, sys
+from pathlib import Path
+
+
+def _reimport(monkeypatch, tmp_path, **env):
+    base = {
+        "THREADKEEPER_DB": str(tmp_path / "db.sqlite"),
+        "THREADKEEPER_DISABLE_BG_DAEMONS": "1",
+        "THREADKEEPER_INGEST_INTERVAL_S": "0",
+    }
+    base.update(env)
+    for k, v in base.items():
+        monkeypatch.setenv(k, v)
+    for name in [m for m in list(sys.modules) if m.startswith("threadkeeper")]:
+        del sys.modules[name]
+    return importlib.import_module("threadkeeper.config")
+
+
+def test_defaults_are_dark(monkeypatch, tmp_path):
+    cfg = _reimport(monkeypatch, tmp_path)
+    assert cfg.DAEMON_HOST_ENABLED is False
+    assert cfg.PROCESS_ROLE == "server"
+    assert cfg.THIN_EMBED_FALLBACK == "fts"
+    assert cfg.HOST_SOCK_PATH == (tmp_path / "host.sock")
+    assert cfg.HOST_LOCK_PATH == (tmp_path / "host.lock")
+    assert cfg.HOST_HEARTBEAT_TTL_S > 0
+
+
+def test_flag_and_role_and_sock_override(monkeypatch, tmp_path):
+    sock = tmp_path / "custom.sock"
+    cfg = _reimport(
+        monkeypatch, tmp_path,
+        THREADKEEPER_DAEMON_HOST="1",
+        THREADKEEPER_ROLE="host",
+        THREADKEEPER_HOST_SOCK=str(sock),
+        THREADKEEPER_THIN_EMBED_FALLBACK="local",
+    )
+    assert cfg.DAEMON_HOST_ENABLED is True
+    assert cfg.PROCESS_ROLE == "host"
+    assert cfg.HOST_SOCK_PATH == sock
+    assert cfg.THIN_EMBED_FALLBACK == "local"

--- a/tests/test_daemon_host_integration.py
+++ b/tests/test_daemon_host_integration.py
@@ -1,0 +1,57 @@
+# tests/test_daemon_host_integration.py
+"""End-to-end: a host process + two thin sessions against one tmp DB."""
+from __future__ import annotations
+import sys, importlib, tempfile, time
+from pathlib import Path
+import numpy as np
+
+
+def _short_sock() -> Path:
+    # AF_UNIX sun_path is limited to ~104 bytes (macOS/BSD) / 108 (Linux);
+    # pytest's tmp_path nests deep enough to exceed that. Bind under a short
+    # /tmp dir instead (same fix as tests/test_host_embed.py) so the host and
+    # thin reimports below can still share one real socket.
+    d = tempfile.mkdtemp(prefix="tk", dir="/tmp")
+    return Path(d) / "host.sock"
+
+
+def _reimport(monkeypatch, tmp_path, role="server", host_sock: Path | None = None):
+    env = {"THREADKEEPER_DB": str(tmp_path / "db.sqlite"),
+           "THREADKEEPER_DAEMON_HOST": "1",
+           "THREADKEEPER_ROLE": role,
+           "THREADKEEPER_DISABLE_BG_DAEMONS": "1",
+           "THREADKEEPER_INGEST_INTERVAL_S": "0"}
+    if host_sock is not None:
+        # Both host and thin reimports must agree on HOST_SOCK_PATH, so pin
+        # it explicitly rather than relying on the (too-long) tmp_path-derived
+        # default of <db dir>/host.sock.
+        env["THREADKEEPER_HOST_SOCK"] = str(host_sock)
+    for k, v in env.items():
+        monkeypatch.setenv(k, v)
+    for name in [m for m in list(sys.modules) if m.startswith("threadkeeper")]:
+        del sys.modules[name]
+    importlib.import_module("threadkeeper.server")
+    return importlib
+
+
+def test_thin_search_embeds_via_host_socket(monkeypatch, tmp_path):
+    sock = _short_sock()
+    # host side: bind the embed socket with a deterministic encoder
+    _reimport(monkeypatch, tmp_path, role="host", host_sock=sock)
+    from threadkeeper import host_embed, config
+    enc = lambda texts: [[1.0, 0.0] for _ in texts]
+    t = host_embed.serve_embed_socket(config.HOST_SOCK_PATH, enc)
+    try:
+        for _ in range(50):
+            if config.HOST_SOCK_PATH.exists():
+                break
+            time.sleep(0.02)
+        # thin side: same DB dir, server role -> _encode must use the socket
+        _reimport(monkeypatch, tmp_path, role="server", host_sock=sock)
+        from threadkeeper import embeddings as thin_emb
+        out = thin_emb._encode(["query"])
+        assert out is not None
+        np.testing.assert_allclose(out[0], [1.0, 0.0], atol=1e-6)
+    finally:
+        host_embed.stop_embed_socket()
+        t.join(timeout=2)

--- a/tests/test_daemon_host_integration.py
+++ b/tests/test_daemon_host_integration.py
@@ -1,6 +1,7 @@
 # tests/test_daemon_host_integration.py
 """End-to-end: a host process + two thin sessions against one tmp DB."""
 from __future__ import annotations
+import shutil
 import sys, importlib, tempfile, time
 from pathlib import Path
 import numpy as np
@@ -55,3 +56,4 @@ def test_thin_search_embeds_via_host_socket(monkeypatch, tmp_path):
     finally:
         host_embed.stop_embed_socket()
         t.join(timeout=2)
+        shutil.rmtree(sock.parent, ignore_errors=True)

--- a/tests/test_delegated_search.py
+++ b/tests/test_delegated_search.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import json
 import os
+import threading
 import time
 
 import pytest
@@ -153,6 +154,20 @@ def test_search_proxy_handles_empty_query(mp_with_cid):
     ).fetchone()
     body = json.loads(resp["content"])
     assert body.get("error") == "empty_query"
+
+
+def test_start_search_proxy_respects_disable_bg_daemons(mp_with_cid, monkeypatch):
+    """BACKGROUND_DAEMONS_ALLOWED=False must block the daemon thread even
+    when SEMANTIC_AVAILABLE and the poll interval would otherwise allow it."""
+    mp_with_cid(_PARENT_CID)
+    from threadkeeper import search_proxy
+    monkeypatch.setattr(search_proxy, "SEMANTIC_AVAILABLE", True)
+    monkeypatch.setattr(search_proxy, "_POLL_INTERVAL_S", 0.5)
+
+    before = {t.name for t in threading.enumerate()}
+    search_proxy.start_search_proxy()
+    after = {t.name for t in threading.enumerate()}
+    assert "search_proxy" not in (after - before)
 
 
 # ─────────────────────────────────────────────────────────────────────

--- a/tests/test_embed_routing.py
+++ b/tests/test_embed_routing.py
@@ -1,0 +1,44 @@
+# tests/test_embed_routing.py
+from __future__ import annotations
+import sys, importlib
+import numpy as np
+
+
+def _reimport(monkeypatch, tmp_path, **env):
+    base = {"THREADKEEPER_DB": str(tmp_path / "db.sqlite"),
+            "THREADKEEPER_DISABLE_BG_DAEMONS": "1"}
+    base.update(env)
+    for k, v in base.items():
+        monkeypatch.setenv(k, v)
+    for name in [m for m in list(sys.modules) if m.startswith("threadkeeper")]:
+        del sys.modules[name]
+    return importlib.import_module("threadkeeper.embeddings")
+
+
+def test_thin_role_uses_socket(monkeypatch, tmp_path):
+    emb = _reimport(monkeypatch, tmp_path,
+                    THREADKEEPER_DAEMON_HOST="1", THREADKEEPER_ROLE="server")
+    monkeypatch.setattr(emb.host_embed, "embed_via_host",
+                        lambda texts, sock, timeout=3.0: [[3.0, 4.0]] * len(texts))
+    out = emb._encode(["hello"])
+    # returned vector is L2-normalized: [3,4] -> [0.6,0.8]
+    assert out is not None
+    np.testing.assert_allclose(out[0], [0.6, 0.8], atol=1e-6)
+
+
+def test_thin_role_fts_fallback_returns_none(monkeypatch, tmp_path):
+    emb = _reimport(monkeypatch, tmp_path,
+                    THREADKEEPER_DAEMON_HOST="1", THREADKEEPER_ROLE="server",
+                    THREADKEEPER_THIN_EMBED_FALLBACK="fts")
+    monkeypatch.setattr(emb.host_embed, "embed_via_host",
+                        lambda texts, sock, timeout=3.0: None)
+    assert emb._encode(["hello"]) is None
+
+
+def test_flag_off_uses_local(monkeypatch, tmp_path):
+    emb = _reimport(monkeypatch, tmp_path, THREADKEEPER_DAEMON_HOST="0",
+                    THREADKEEPER_ROLE="server")
+    called = {"local": 0}
+    monkeypatch.setattr(emb, "_get_model", lambda: called.__setitem__("local", called["local"] + 1) or None)
+    emb._encode(["hello"])  # flag off -> local path (model None here -> None)
+    assert called["local"] == 1

--- a/tests/test_host_embed.py
+++ b/tests/test_host_embed.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+import time
+from pathlib import Path
+from threadkeeper import host_embed
+
+
+def test_roundtrip_and_batch(tmp_path):
+    sock = tmp_path / "h.sock"
+    # deterministic fake encoder: vector = [len(text), first-ord]
+    enc = lambda texts: [[float(len(t)), float(ord(t[0]) if t else 0)] for t in texts]
+    t = host_embed.serve_embed_socket(sock, enc)
+    try:
+        for _ in range(50):
+            if sock.exists():
+                break
+            time.sleep(0.02)
+        out = host_embed.embed_via_host(["ab", "xyz"], sock)
+        assert out == [[2.0, 97.0], [3.0, 120.0]]
+    finally:
+        host_embed.stop_embed_socket()
+        t.join(timeout=2)
+
+
+def test_client_returns_none_when_no_host(tmp_path):
+    assert host_embed.embed_via_host(["q"], tmp_path / "absent.sock", timeout=0.3) is None
+
+
+def test_server_error_maps_to_none(tmp_path):
+    sock = tmp_path / "h.sock"
+    enc = lambda texts: (_ for _ in ()).throw(RuntimeError("boom"))
+    t = host_embed.serve_embed_socket(sock, enc)
+    try:
+        for _ in range(50):
+            if sock.exists():
+                break
+            time.sleep(0.02)
+        assert host_embed.embed_via_host(["q"], sock) is None
+    finally:
+        host_embed.stop_embed_socket()
+        t.join(timeout=2)

--- a/tests/test_host_embed.py
+++ b/tests/test_host_embed.py
@@ -1,11 +1,20 @@
 from __future__ import annotations
+import tempfile
 import time
 from pathlib import Path
 from threadkeeper import host_embed
 
 
+def _short_sock():
+    # AF_UNIX sun_path is limited to ~104 bytes (macOS/BSD) / 108 (Linux);
+    # pytest's tmp_path nests deep enough to exceed that. Bind under a short
+    # /tmp dir instead so the test exercises the real bind/connect path.
+    d = tempfile.mkdtemp(prefix="tk", dir="/tmp")
+    return Path(d) / "h.sock"
+
+
 def test_roundtrip_and_batch(tmp_path):
-    sock = tmp_path / "h.sock"
+    sock = _short_sock()
     # deterministic fake encoder: vector = [len(text), first-ord]
     enc = lambda texts: [[float(len(t)), float(ord(t[0]) if t else 0)] for t in texts]
     t = host_embed.serve_embed_socket(sock, enc)
@@ -26,7 +35,7 @@ def test_client_returns_none_when_no_host(tmp_path):
 
 
 def test_server_error_maps_to_none(tmp_path):
-    sock = tmp_path / "h.sock"
+    sock = _short_sock()
     enc = lambda texts: (_ for _ in ()).throw(RuntimeError("boom"))
     t = host_embed.serve_embed_socket(sock, enc)
     try:

--- a/tests/test_host_embed.py
+++ b/tests/test_host_embed.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+import shutil
 import tempfile
 import time
 from pathlib import Path
@@ -28,6 +29,7 @@ def test_roundtrip_and_batch(tmp_path):
     finally:
         host_embed.stop_embed_socket()
         t.join(timeout=2)
+        shutil.rmtree(sock.parent, ignore_errors=True)
 
 
 def test_client_returns_none_when_no_host(tmp_path):
@@ -47,3 +49,4 @@ def test_server_error_maps_to_none(tmp_path):
     finally:
         host_embed.stop_embed_socket()
         t.join(timeout=2)
+        shutil.rmtree(sock.parent, ignore_errors=True)

--- a/tests/test_host_env.py
+++ b/tests/test_host_env.py
@@ -1,0 +1,49 @@
+# tests/test_host_env.py
+"""ensure_host_running() must not let a spawned review child's env markers
+leak into the detached daemon-host process (Task 8 fix #1). Left unsanitized,
+an inherited THREADKEEPER_SPAWNED_CHILD=1 / non-foreground WRITE_ORIGIN would
+make config.BACKGROUND_DAEMONS_ALLOWED false in the host too, so ~13 of its 18
+daemon starters would self-gate off — a loop-less zombie host that still binds
+the embed socket and heartbeats (looks alive, holds the election lock)."""
+from __future__ import annotations
+import sys, importlib
+
+
+def _reimport(monkeypatch, tmp_path, **env_overrides):
+    env = {"THREADKEEPER_DB": str(tmp_path / "db.sqlite"),
+           "THREADKEEPER_DAEMON_HOST": "1",
+           "THREADKEEPER_DISABLE_BG_DAEMONS": "1"}
+    env.update(env_overrides)
+    for k, v in env.items():
+        monkeypatch.setenv(k, v)
+    for name in [m for m in list(sys.modules) if m.startswith("threadkeeper")]:
+        del sys.modules[name]
+    importlib.import_module("threadkeeper.server")
+    return importlib.import_module("threadkeeper.host")
+
+
+def test_ensure_host_running_sanitizes_spawned_child_env(monkeypatch, tmp_path):
+    # Simulate a spawned review child (a background_review evolve/curator
+    # fork, carrying THREADKEEPER_SPAWNED_CHILD=1 + a non-foreground
+    # WRITE_ORIGIN) being the first process to call ensure_host_running().
+    host = _reimport(
+        monkeypatch, tmp_path,
+        THREADKEEPER_SPAWNED_CHILD="1",
+        THREADKEEPER_WRITE_ORIGIN="background_review",
+    )
+    monkeypatch.setattr(host, "_host_alive", lambda: False)
+
+    captured: dict = {}
+
+    def fake_popen(args, **kwargs):
+        captured["env"] = kwargs.get("env")
+        return None
+
+    monkeypatch.setattr(host.subprocess, "Popen", fake_popen)
+
+    assert host.ensure_host_running() is True
+    env = captured.get("env")
+    assert env is not None
+    assert "THREADKEEPER_SPAWNED_CHILD" not in env
+    assert env.get("THREADKEEPER_WRITE_ORIGIN") == "foreground"
+    assert env.get("THREADKEEPER_ROLE") == "host"

--- a/tests/test_host_main.py
+++ b/tests/test_host_main.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+import sys, importlib
+
+
+def _reimport(monkeypatch, tmp_path):
+    for k, v in {"THREADKEEPER_DB": str(tmp_path / "db.sqlite"),
+                 "THREADKEEPER_DAEMON_HOST": "1",
+                 "THREADKEEPER_DISABLE_BG_DAEMONS": "1"}.items():
+        monkeypatch.setenv(k, v)
+    for name in [m for m in list(sys.modules) if m.startswith("threadkeeper")]:
+        del sys.modules[name]
+    importlib.import_module("threadkeeper.server")  # register runtime
+    return importlib.import_module("threadkeeper.host")
+
+
+def test_start_daemons_calls_each_starter(monkeypatch, tmp_path):
+    host = _reimport(monkeypatch, tmp_path)
+    calls = []
+    for modname, fn in [("retention", "start_retention_daemon"),
+                        ("curator", "start_curator_daemon"),
+                        ("shadow_review", "start_shadow_daemon")]:
+        mod = importlib.import_module(f"threadkeeper.{modname}")
+        monkeypatch.setattr(mod, fn, (lambda n: (lambda: calls.append(n)))(modname))
+    started = host.start_daemons()
+    assert "retention" in started and "curator" in started and "shadow_review" in started
+    assert set(calls) >= {"retention", "curator", "shadow_review"}
+
+
+def test_serve_wires_local_encoder(monkeypatch, tmp_path):
+    host = _reimport(monkeypatch, tmp_path)
+    seen = {}
+    monkeypatch.setattr(host.host_embed, "serve_embed_socket",
+                        lambda sock, enc: seen.update(sock=sock, enc=enc) or __import__("threading").Thread(target=lambda: None))
+    host.start_embed_server()
+    from threadkeeper import config
+    assert seen["sock"] == config.HOST_SOCK_PATH
+    # the wired encoder delegates to embeddings._encode
+    assert callable(seen["enc"])

--- a/tests/test_ingest_status.py
+++ b/tests/test_ingest_status.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import threading
+
 
 _FAKE_CID = "77778888-9999-aaaa-bbbb-ccccdddd0000"
 
@@ -27,3 +29,16 @@ def test_ingest_pass_event_recorded_for_status_ui(mp_with_cid):
     assert row["kind"] == "ingest_pass"
     assert row["target"]
     assert row["summary"] == "ok mode=recent new=2 files=5"
+
+
+def test_start_background_ingester_respects_disable_bg_daemons(mp_with_cid, monkeypatch):
+    """BACKGROUND_DAEMONS_ALLOWED=False must block the daemon thread even
+    when the ingest interval is positive."""
+    mp_with_cid(_FAKE_CID)
+    from threadkeeper import ingest
+    monkeypatch.setattr(ingest, "_ingest_interval_s", 3.0)
+
+    before = {t.name for t in threading.enumerate()}
+    ingest._start_background_ingester()
+    after = {t.name for t in threading.enumerate()}
+    assert "thread-keeper-live-ingest" not in (after - before)

--- a/tests/test_memory_guard_host.py
+++ b/tests/test_memory_guard_host.py
@@ -1,0 +1,37 @@
+"""memory_guard host supervision (Phase 1 daemon-host, Task 6).
+
+With THREADKEEPER_DAEMON_HOST on: thin (non-host) processes are never
+idle-retire candidates, and a stale host heartbeat triggers a respawn via
+host.ensure_host_running().
+"""
+from __future__ import annotations
+import sys, importlib, time
+
+
+def _reimport(monkeypatch, tmp_path, flag="1"):
+    for k, v in {"THREADKEEPER_DB": str(tmp_path / "db.sqlite"),
+                 "THREADKEEPER_DAEMON_HOST": flag,
+                 "THREADKEEPER_DISABLE_BG_DAEMONS": "1"}.items():
+        monkeypatch.setenv(k, v)
+    for name in [m for m in list(sys.modules) if m.startswith("threadkeeper")]:
+        del sys.modules[name]
+    importlib.import_module("threadkeeper.server")
+    return importlib.import_module("threadkeeper.memory_guard")
+
+
+def test_thin_not_retired_when_flag_on(monkeypatch, tmp_path):
+    mg = _reimport(monkeypatch, tmp_path, flag="1")
+    procs = [{"pid": 111, "client": "claude", "heartbeat_age_s": 99999,
+              "parent_alive": False, "rss_kb": 120000}]
+    assert mg._idle_retire_candidates(procs) == []   # thin never retired under host mode
+
+
+def test_stale_host_triggers_respawn(monkeypatch, tmp_path):
+    mg = _reimport(monkeypatch, tmp_path, flag="1")
+    from threadkeeper import host
+    respawned = {"n": 0}
+    monkeypatch.setattr(host, "ensure_host_running",
+                        lambda: respawned.__setitem__("n", respawned["n"] + 1) or True)
+    monkeypatch.setattr(mg, "_host_alive", lambda: False)
+    mg.supervise_host()
+    assert respawned["n"] == 1

--- a/tests/test_memory_guard_host.py
+++ b/tests/test_memory_guard_host.py
@@ -5,7 +5,7 @@ idle-retire candidates, and a stale host heartbeat triggers a respawn via
 host.ensure_host_running().
 """
 from __future__ import annotations
-import sys, importlib, time
+import sys, importlib
 
 
 def _reimport(monkeypatch, tmp_path, flag="1"):
@@ -21,8 +21,11 @@ def _reimport(monkeypatch, tmp_path, flag="1"):
 
 def test_thin_not_retired_when_flag_on(monkeypatch, tmp_path):
     mg = _reimport(monkeypatch, tmp_path, flag="1")
-    procs = [{"pid": 111, "client": "claude", "heartbeat_age_s": 99999,
-              "parent_alive": False, "rss_kb": 120000}]
+    # Realistic process_health.scan() row shape: process_health.classify()
+    # never adds a "client" key, so the check must not depend on one.
+    procs = [{"pid": 111, "ppid": 1, "rss_kb": 120000,
+              "parent_alive": False, "heartbeat_age_s": 99999,
+              "is_self": False, "is_orphaned": True}]
     assert mg._idle_retire_candidates(procs) == []   # thin never retired under host mode
 
 

--- a/tests/test_probe_daemon.py
+++ b/tests/test_probe_daemon.py
@@ -262,3 +262,12 @@ def test_run_probe_pass_single_flight_lock_race(tmp_path, monkeypatch):
         results.count("graded=0 probe_child_running n=1 (single-flight lock)")
         == 1
     )
+
+
+# ── daemon loop tick (regression: silent thread death) ─────────────────
+
+def test_daemon_sleep_is_importable(tmp_path, monkeypatch):
+    # _serve_loop calls daemon_sleep() outside run_probe_pass's try/except;
+    # a missing import kills the daemon thread via NameError on tick 1.
+    pkg = _bootstrap(tmp_path, monkeypatch)
+    pkg["pd"].daemon_sleep(0.01)

--- a/tests/test_skill_watcher.py
+++ b/tests/test_skill_watcher.py
@@ -180,6 +180,19 @@ def test_start_skill_watcher_disabled_when_interval_zero(tmp_path, monkeypatch):
     assert not any(n == "skill_watcher" for n in new_threads)
 
 
+def test_start_skill_watcher_respects_disable_bg_daemons(tmp_path, monkeypatch):
+    """BACKGROUND_DAEMONS_ALLOWED=False must block the daemon thread even
+    when the poll interval is positive."""
+    monkeypatch.setenv("THREADKEEPER_DISABLE_BG_DAEMONS", "1")
+    pkg = _bootstrap(tmp_path, monkeypatch, interval_s="10")
+    sw = pkg["skill_watcher"]
+    import threading
+    before = {t.name for t in threading.enumerate()}
+    sw.start_skill_watcher()
+    after = {t.name for t in threading.enumerate()}
+    assert not any(n == "skill_watcher" for n in (after - before))
+
+
 def test_scan_once_preserves_existing_origin(tmp_path, monkeypatch):
     """If a skill already has an agent-created provenance row, the watcher
     must NOT overwrite created_by_origin — INSERT … ON CONFLICT DO NOTHING."""

--- a/tests/test_spawn_budget.py
+++ b/tests/test_spawn_budget.py
@@ -452,3 +452,21 @@ def test_spawn_budget_set_rejects_negative(mp_with_cid):
     pkg = mp_with_cid(_FAKE_CID)
     r = _tool(pkg, "spawn_budget_set")(limit_mb=-1)
     assert r.startswith("ERR")
+
+
+# ─────────────────────────────────────────────────────────────────────
+# start_budget_daemon — background-daemon kill switch
+# ─────────────────────────────────────────────────────────────────────
+
+def test_start_budget_daemon_respects_disable_bg_daemons(mp_with_cid, monkeypatch):
+    """BACKGROUND_DAEMONS_ALLOWED=False must block the daemon thread even
+    when the poll interval and budget would otherwise allow it."""
+    mp_with_cid(_FAKE_CID)
+    import threadkeeper.spawn_budget as sb
+    monkeypatch.setattr(sb, "SPAWN_BUDGET_POLL_S", 10.0)
+    monkeypatch.setattr(sb, "SPAWN_BUDGET_MB", 3072)
+
+    before = {t.name for t in threading.enumerate()}
+    sb.start_budget_daemon()
+    after = {t.name for t in threading.enumerate()}
+    assert "spawn_budget" not in (after - before)

--- a/tests/test_thin_session.py
+++ b/tests/test_thin_session.py
@@ -27,9 +27,16 @@ def test_thin_session_starts_no_daemons_and_ensures_host(monkeypatch, tmp_path):
     # spy: no daemon starter should be invoked from a thin session
     import threadkeeper.shadow_review as sr
     monkeypatch.setattr(sr, "start_shadow_daemon", lambda: started.append("shadow"))
+    # spy: the periodic background ingester (a daemon thread, not a one-shot
+    # read) must also not be started locally by a thin session — it belongs
+    # solely to host.start_daemons().
+    from threadkeeper import ingest
+    ing_calls = []
+    monkeypatch.setattr(ingest, "_start_background_ingester", lambda *a, **k: ing_calls.append(1))
     from threadkeeper.db import get_db
     identity._ensure_session(get_db())
     assert "shadow" not in started        # thin server started no daemon
+    assert ing_calls == []                # thin server started no background ingester
     assert ensured["n"] >= 1              # but ensured a host
 
 

--- a/tests/test_thin_session.py
+++ b/tests/test_thin_session.py
@@ -1,0 +1,45 @@
+# tests/test_thin_session.py
+from __future__ import annotations
+import sys, importlib
+
+
+def _reimport(monkeypatch, tmp_path, flag="1", role="server"):
+    for k, v in {"THREADKEEPER_DB": str(tmp_path / "db.sqlite"),
+                 "THREADKEEPER_DAEMON_HOST": flag,
+                 "THREADKEEPER_ROLE": role,
+                 "THREADKEEPER_DISABLE_BG_DAEMONS": "1",
+                 "THREADKEEPER_INGEST_INTERVAL_S": "0",
+                 "THREADKEEPER_INGEST_CAP": "0"}.items():
+        monkeypatch.setenv(k, v)
+    for name in [m for m in list(sys.modules) if m.startswith("threadkeeper")]:
+        del sys.modules[name]
+    importlib.import_module("threadkeeper.server")
+    return (importlib.import_module("threadkeeper.identity"),
+            importlib.import_module("threadkeeper.host"))
+
+
+def test_thin_session_starts_no_daemons_and_ensures_host(monkeypatch, tmp_path):
+    identity, host = _reimport(monkeypatch, tmp_path, flag="1", role="server")
+    started = []
+    monkeypatch.setattr(host, "start_daemons", lambda: started.append("daemons") or [])
+    ensured = {"n": 0}
+    monkeypatch.setattr(host, "ensure_host_running", lambda: ensured.__setitem__("n", ensured["n"] + 1) or True)
+    # spy: no daemon starter should be invoked from a thin session
+    import threadkeeper.shadow_review as sr
+    monkeypatch.setattr(sr, "start_shadow_daemon", lambda: started.append("shadow"))
+    from threadkeeper.db import get_db
+    identity._ensure_session(get_db())
+    assert "shadow" not in started        # thin server started no daemon
+    assert ensured["n"] >= 1              # but ensured a host
+
+
+def test_flag_off_still_starts_daemons_inproc(monkeypatch, tmp_path):
+    identity, host = _reimport(monkeypatch, tmp_path, flag="0", role="server")
+    hits = []
+    import threadkeeper.shadow_review as sr
+    monkeypatch.setattr(sr, "start_shadow_daemon", lambda: hits.append("shadow"))
+    # other starters harmless under DISABLE_BG_DAEMONS; assert the gate path ran
+    from threadkeeper.db import get_db
+    identity._ensure_session(get_db())
+    # with the flag OFF the legacy in-process branch runs (shadow starter reached)
+    assert hits == ["shadow"]

--- a/threadkeeper/config.py
+++ b/threadkeeper/config.py
@@ -130,6 +130,13 @@ class Settings(BaseSettings):
     auto_update_expected_publisher_workflow: str = "publish.yml"
     auto_update_expected_publisher_environment: str = "pypi"
 
+    # ── Phase 1: daemon-host + thin servers (dark by default) ──
+    daemon_host: bool = False              # THREADKEEPER_DAEMON_HOST
+    role: str = "server"                   # THREADKEEPER_ROLE: server | host
+    host_sock: str = ""                    # "" -> <db dir>/host.sock
+    host_heartbeat_ttl_s: float = 120.0
+    thin_embed_fallback: str = "fts"       # fts | local
+
     # ── Skill update daemon ─────────────────────────────────────────────────
     # Twice weekly by default. It syncs installed skills across known CLI roots
     # and can update GitHub-backed skills from configured source roots.
@@ -638,6 +645,10 @@ def _derive_constants(s: "Settings") -> dict:
         "AUTO_UPDATE_EXPECTED_PUBLISHER_ENVIRONMENT": (
             s.auto_update_expected_publisher_environment
         ),
+        "DAEMON_HOST_ENABLED": bool(s.daemon_host),
+        "PROCESS_ROLE": (s.role or "server").strip().lower(),
+        "HOST_HEARTBEAT_TTL_S": float(s.host_heartbeat_ttl_s),
+        "THIN_EMBED_FALLBACK": (s.thin_embed_fallback or "fts").strip().lower(),
         "SKILL_UPDATE_INTERVAL_S": s.skill_update_interval_s,
         "SKILL_UPDATE_TIMEOUT_S": s.skill_update_timeout_s,
         "SKILL_UPDATE_SOURCES": s.skill_update_sources,
@@ -744,6 +755,18 @@ def _derive_constants(s: "Settings") -> dict:
 
 # Publish the initial constants into this module's namespace.
 globals().update(_derive_constants(settings))
+
+# Phase 1: daemon-host socket/lock paths. Module-scope, computed once from
+# DB_PATH right after it is published above — like FASTEMBED_MODEL_ID/EMBED_DIM
+# below, these are intentionally NOT part of _derive_constants (not
+# hot-reloaded): moving a running host's socket/lock path mid-process would
+# desync it from servers already connected to the old path.
+_HOST_SOCK_OVERRIDE = (settings.host_sock or "").strip()
+HOST_SOCK_PATH: Path = (
+    Path(_HOST_SOCK_OVERRIDE).expanduser() if _HOST_SOCK_OVERRIDE
+    else DB_PATH.parent / "host.sock"
+)
+HOST_LOCK_PATH: Path = DB_PATH.parent / "host.lock"
 
 
 def _harden_current_storage() -> None:

--- a/threadkeeper/embeddings.py
+++ b/threadkeeper/embeddings.py
@@ -27,6 +27,7 @@ from .config import (
     FASTEMBED_MODEL_ID,
 )
 from . import db as _db
+from . import host_embed
 
 logger = logging.getLogger(__name__)
 
@@ -138,6 +139,21 @@ def _encode(texts: list[str]):
     whether the backend already normalizes.
     """
     global _last_used_at
+    from . import config as _cfg  # read live (hot-reloadable flag)
+    if _cfg.DAEMON_HOST_ENABLED and _cfg.PROCESS_ROLE == "server":
+        vecs = host_embed.embed_via_host(list(texts), _cfg.HOST_SOCK_PATH)
+        if vecs is None:
+            if _cfg.THIN_EMBED_FALLBACK == "local":
+                pass  # fall through to the local model below
+            else:
+                return None  # fts fallback: caller degrades to FTS
+        else:
+            import numpy as np  # type: ignore
+            arr = np.asarray(vecs, dtype="float32")
+            norms = np.linalg.norm(arr, axis=1, keepdims=True)
+            norms[norms == 0] = 1.0
+            _last_used_at = time.time()
+            return (arr / norms).astype("float32")
     with _model_lock:
         m = _get_model()
         if m is None:

--- a/threadkeeper/host.py
+++ b/threadkeeper/host.py
@@ -10,7 +10,6 @@ import subprocess
 import sys
 import threading
 import time
-from pathlib import Path
 
 from . import config
 from . import host_embed
@@ -126,10 +125,27 @@ def ensure_host_running() -> bool:
         if not locked or _host_alive():
             return False
         log = open(config.HOST_LOCK_PATH.parent / "host.log", "ab", buffering=0)
+        # Sanitize the env for the detached host. If a spawned review child
+        # (THREADKEEPER_SPAWNED_CHILD=1, non-foreground THREADKEEPER_WRITE_ORIGIN)
+        # is the first process to call ensure_host_running(), a bare env
+        # inheritance would carry those markers into the host. Since
+        # config.BACKGROUND_DAEMONS_ALLOWED = not SPAWNED_CHILD and
+        # WRITE_ORIGIN=="foreground" and not DISABLE_BG_DAEMONS, that would make
+        # ~13 of the 18 daemon starters self-gate off in the host process — it
+        # would still bind the embed socket and heartbeat (looks alive, holds
+        # the election lock) while running almost none of its loops. Force a
+        # clean foreground-equivalent env instead, regardless of who spawned it.
+        env = os.environ.copy()
+        env.pop("THREADKEEPER_SPAWNED_CHILD", None)
+        env["THREADKEEPER_WRITE_ORIGIN"] = "foreground"
+        env.pop("THREADKEEPER_DISABLE_BG_DAEMONS", None)
+        env.pop("THREADKEEPER_NO_EMBEDDINGS", None)
+        env["THREADKEEPER_ROLE"] = "host"  # belt-and-suspenders; main() also sets this
         subprocess.Popen(
             [sys.executable, "-m", "threadkeeper.host"],
             stdin=subprocess.DEVNULL, stdout=log, stderr=log,
             start_new_session=True, close_fds=True,
+            env=env,
         )
         return True
 

--- a/threadkeeper/host.py
+++ b/threadkeeper/host.py
@@ -6,7 +6,10 @@ from __future__ import annotations
 import logging
 import os
 import signal
+import subprocess
+import sys
 import threading
+import time
 from pathlib import Path
 
 from . import config
@@ -110,6 +113,40 @@ def _heartbeat() -> None:
         identity._ensure_session(get_db(), client="daemon-host")
     except Exception:
         logger.debug("host: heartbeat failed", exc_info=True)
+
+
+def ensure_host_running() -> bool:
+    """Called by a thin server at session start. If no live host, spawn one
+    detached and return True; else False. Idempotent under the host lock."""
+    if config.PROCESS_ROLE == "host":
+        return False
+    if _host_alive():
+        return False
+    with single_flight_lock("daemon-host-spawn") as locked:
+        if not locked or _host_alive():
+            return False
+        log = open(config.HOST_LOCK_PATH.parent / "host.log", "ab", buffering=0)
+        subprocess.Popen(
+            [sys.executable, "-m", "threadkeeper.host"],
+            stdin=subprocess.DEVNULL, stdout=log, stderr=log,
+            start_new_session=True, close_fds=True,
+        )
+        return True
+
+
+def _host_alive() -> bool:
+    """A live host heartbeat within the TTL."""
+    from .db import get_db
+    try:
+        row = get_db().execute(
+            "SELECT heartbeat_at FROM presence WHERE client='daemon-host' "
+            "ORDER BY heartbeat_at DESC LIMIT 1"
+        ).fetchone()
+    except Exception:
+        return False
+    if not row or row["heartbeat_at"] is None:
+        return False
+    return (time.time() - int(row["heartbeat_at"])) < config.HOST_HEARTBEAT_TTL_S
 
 
 if __name__ == "__main__":

--- a/threadkeeper/host.py
+++ b/threadkeeper/host.py
@@ -1,0 +1,116 @@
+"""The daemon-host (Phase 1): one headless process per machine that owns the
+background loops + the warm ONNX model + the embed socket. Elected via a flock;
+always-on (the loops must run with no active CLI session)."""
+from __future__ import annotations
+
+import logging
+import os
+import signal
+import threading
+from pathlib import Path
+
+from . import config
+from . import host_embed
+from .helpers import single_flight_lock
+
+logger = logging.getLogger(__name__)
+
+_DAEMON_STARTERS = [
+    ("retention", "start_retention_daemon"),
+    ("search_proxy", "start_search_proxy"),
+    ("spawn_budget", "start_budget_daemon"),
+    ("memory_guard", "start_memory_guard_daemon"),
+    ("auto_update", "start_auto_update_daemon"),
+    ("skill_watcher", "start_skill_watcher"),
+    ("skill_updater", "start_skill_update_daemon"),
+    ("config_watcher", "start_config_watcher"),
+    ("shadow_review", "start_shadow_daemon"),
+    ("curator", "start_curator_daemon"),
+    ("extract_daemon", "start_extract_daemon"),
+    ("candidate_reviewer", "start_candidate_reviewer_daemon"),
+    ("probe_daemon", "start_probe_daemon"),
+    ("evolve_daemon", "start_evolve_daemon"),
+    ("evolve_applier", "start_evolve_applier_daemon"),
+    ("thread_janitor", "start_thread_janitor"),
+    ("dialectic_miner", "start_dialectic_miner_daemon"),
+    ("dialectic_validator", "start_dialectic_validator_daemon"),
+]
+
+
+def start_daemons() -> list[str]:
+    """Start every background loop once, in THIS process. Mirrors the block
+    that used to live in identity._ensure_session; each starter is idempotent
+    and single-flight-guarded, so a double call is safe."""
+    started: list[str] = []
+    # periodic background ingester (moved from _ensure_session)
+    try:
+        from . import ingest
+        ingest._start_background_ingester()
+        started.append("ingest")
+    except Exception:
+        logger.debug("host: ingest start failed", exc_info=True)
+    for modname, fn in _DAEMON_STARTERS:
+        try:
+            mod = __import__(f"threadkeeper.{modname}", fromlist=[fn])
+            getattr(mod, fn)()
+            started.append(modname)
+        except Exception:
+            logger.debug("host: start %s failed", modname, exc_info=True)
+    return started
+
+
+def start_embed_server():
+    """Bind the embed socket, wiring the LOCAL encoder (host role)."""
+    from . import embeddings
+
+    def _encode_texts(texts):
+        arr = embeddings._encode(list(texts))
+        return None if arr is None else [list(map(float, row)) for row in arr]
+
+    return host_embed.serve_embed_socket(config.HOST_SOCK_PATH, _encode_texts)
+
+
+def main() -> int:
+    """Elected headless host. Exits 0 immediately if another host holds the
+    lock (idempotent spawn)."""
+    os.environ["THREADKEEPER_ROLE"] = "host"
+    config.reload_settings()  # re-derive PROCESS_ROLE == "host"
+    # Lock exactly `config.HOST_LOCK_PATH` (Task 1's shared host-election
+    # path) rather than a separately-named lock, so a future liveness check
+    # (Task 5's ensure_host_running()) that inspects HOST_LOCK_PATH observes
+    # the same file this process holds.
+    with single_flight_lock(config.HOST_LOCK_PATH.stem,
+                            lock_dir=config.HOST_LOCK_PATH.parent) as locked:
+        if not locked:
+            return 0
+        start_daemons()
+        start_embed_server()
+        # threading.Event (not a plain flag) so SIGTERM wakes the loop
+        # immediately: Event.set() inside the handler releases the same
+        # condition Event.wait() is blocked on, so the PEP-475 EINTR-retry
+        # resumes against an already-satisfied wait instead of sleeping out
+        # the rest of the interval (a bare time.sleep() + flag would not
+        # return until the full sleep duration elapsed — up to ~30s here,
+        # confirmed empirically while building this).
+        stop = threading.Event()
+        signal.signal(signal.SIGTERM, lambda *_: stop.set())
+        while not stop.is_set():
+            _heartbeat()
+            stop.wait(min(30.0, config.HOST_HEARTBEAT_TTL_S / 2))
+    return 0
+
+
+def _heartbeat() -> None:
+    from .db import get_db
+    from . import identity
+    try:
+        # `_ensure_session(conn, client=)` (identity.py:83) registers/refreshes
+        # a presence row under the given client label — used here to stamp the
+        # host's own row that `_host_alive()` (Task 5) reads back.
+        identity._ensure_session(get_db(), client="daemon-host")
+    except Exception:
+        logger.debug("host: heartbeat failed", exc_info=True)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/threadkeeper/host_embed.py
+++ b/threadkeeper/host_embed.py
@@ -25,35 +25,9 @@ logger = logging.getLogger(__name__)
 _WIRE_V = 1
 _server_sock: Optional[socket.socket] = None
 _stop = threading.Event()
-_chdir_lock = threading.Lock()
 
 
-def _bind_or_connect(fn: Callable[[str], None], sock_path: Path) -> None:
-    """Call `fn(path_str)` (a socket's `.bind` or `.connect`), working around
-    AF_UNIX's `sun_path` length limit (~104 bytes on macOS/BSD, 108 on Linux).
-
-    A deeply nested socket dir (e.g. pytest's `tmp_path`, or a long-path
-    production config) can exceed that limit; CPython's socket module then
-    raises a bare `OSError("AF_UNIX path too long")` before ever reaching the
-    OS. Retry once with the process cwd switched to the socket's parent dir
-    so only the short filename is passed. `chdir` is process-wide, so the
-    swap is serialized via a lock rather than attempted concurrently.
-    """
-    try:
-        fn(str(sock_path))
-    except OSError as e:
-        if str(e) != "AF_UNIX path too long":
-            raise
-        with _chdir_lock:
-            cwd = os.getcwd()
-            os.chdir(sock_path.parent)
-            try:
-                fn(sock_path.name)
-            finally:
-                os.chdir(cwd)
-
-
-def _handle(conn: socket.socket, encode_fn: Callable[[list], Optional[list]]) -> None:
+def _handle(conn: socket.socket, encode_fn: Callable[[list[str]], Optional[list[list[float]]]]) -> None:
     with conn:
         buf = b""
         while b"\n" not in buf:
@@ -70,6 +44,7 @@ def _handle(conn: socket.socket, encode_fn: Callable[[list], Optional[list]]) ->
             else:
                 reply = {"v": _WIRE_V, "vectors": [list(map(float, v)) for v in vecs]}
         except Exception as e:  # never crash the host on a bad request
+            logger.warning("embed request failed: %s", e)
             reply = {"v": _WIRE_V, "error": f"{type(e).__name__}: {e}"}
         try:
             conn.sendall((json.dumps(reply) + "\n").encode("utf-8"))
@@ -86,7 +61,7 @@ def _serve_loop(srv: socket.socket, encode_fn) -> None:
         threading.Thread(target=_handle, args=(conn, encode_fn), daemon=True).start()
 
 
-def serve_embed_socket(sock_path: Path, encode_fn: Callable[[list], Optional[list]]) -> threading.Thread:
+def serve_embed_socket(sock_path: Path, encode_fn: Callable[[list[str]], Optional[list[list[float]]]]) -> threading.Thread:
     """Bind `sock_path` and serve embed requests via `encode_fn`. Idempotent
     cleanup of a stale socket file; returns the started accept thread."""
     global _server_sock
@@ -97,9 +72,13 @@ def serve_embed_socket(sock_path: Path, encode_fn: Callable[[list], Optional[lis
     except FileNotFoundError:
         pass
     srv = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-    _bind_or_connect(srv.bind, sock_path)
-    os.chmod(sock_path, 0o600)
-    srv.listen(64)
+    try:
+        srv.bind(str(sock_path))
+        os.chmod(sock_path, 0o600)
+        srv.listen(64)
+    except OSError:
+        srv.close()
+        raise
     _server_sock = srv
     t = threading.Thread(target=_serve_loop, args=(srv, encode_fn),
                          name="embed-socket", daemon=True)
@@ -117,14 +96,14 @@ def stop_embed_socket() -> None:
             _server_sock = None
 
 
-def embed_via_host(texts: list, sock_path: Path, timeout: float = 3.0) -> Optional[list]:
+def embed_via_host(texts: list[str], sock_path: Path, timeout: float = 3.0) -> Optional[list[list[float]]]:
     """Client: ask the host to embed `texts`. Returns a list of vectors, or
     None on ANY failure (no host / timeout / malformed) so the caller can fall
     back to FTS."""
     try:
         with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as c:
             c.settimeout(timeout)
-            _bind_or_connect(c.connect, sock_path)
+            c.connect(str(sock_path))
             c.sendall((json.dumps({"v": _WIRE_V, "op": "embed",
                                    "texts": list(texts)}) + "\n").encode("utf-8"))
             buf = b""

--- a/threadkeeper/host_embed.py
+++ b/threadkeeper/host_embed.py
@@ -1,0 +1,141 @@
+"""Narrow embed-only IPC between thin servers and the daemon-host (Phase 1).
+
+Thin servers do not load the ONNX model; to embed a search query they send the
+text to the host over a unix socket and get the vector back. Wire format is
+newline-delimited, versioned JSON:
+
+    req  {"v":1,"op":"embed","texts":["...", "..."]}
+    resp {"v":1,"vectors":[[...],[...]]}  |  {"v":1,"error":"..."}
+
+The socket layer is dependency-injected with `encode_fn` so it never imports
+`embeddings` (no cycle); the host wires the real encoder in.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import socket
+import threading
+from pathlib import Path
+from typing import Callable, Optional
+
+logger = logging.getLogger(__name__)
+
+_WIRE_V = 1
+_server_sock: Optional[socket.socket] = None
+_stop = threading.Event()
+_chdir_lock = threading.Lock()
+
+
+def _bind_or_connect(fn: Callable[[str], None], sock_path: Path) -> None:
+    """Call `fn(path_str)` (a socket's `.bind` or `.connect`), working around
+    AF_UNIX's `sun_path` length limit (~104 bytes on macOS/BSD, 108 on Linux).
+
+    A deeply nested socket dir (e.g. pytest's `tmp_path`, or a long-path
+    production config) can exceed that limit; CPython's socket module then
+    raises a bare `OSError("AF_UNIX path too long")` before ever reaching the
+    OS. Retry once with the process cwd switched to the socket's parent dir
+    so only the short filename is passed. `chdir` is process-wide, so the
+    swap is serialized via a lock rather than attempted concurrently.
+    """
+    try:
+        fn(str(sock_path))
+    except OSError as e:
+        if str(e) != "AF_UNIX path too long":
+            raise
+        with _chdir_lock:
+            cwd = os.getcwd()
+            os.chdir(sock_path.parent)
+            try:
+                fn(sock_path.name)
+            finally:
+                os.chdir(cwd)
+
+
+def _handle(conn: socket.socket, encode_fn: Callable[[list], Optional[list]]) -> None:
+    with conn:
+        buf = b""
+        while b"\n" not in buf:
+            chunk = conn.recv(65536)
+            if not chunk:
+                return
+            buf += chunk
+        try:
+            req = json.loads(buf.split(b"\n", 1)[0].decode("utf-8"))
+            texts = list(req.get("texts") or [])
+            vecs = encode_fn(texts)
+            if vecs is None:
+                reply = {"v": _WIRE_V, "error": "embeddings_unavailable"}
+            else:
+                reply = {"v": _WIRE_V, "vectors": [list(map(float, v)) for v in vecs]}
+        except Exception as e:  # never crash the host on a bad request
+            reply = {"v": _WIRE_V, "error": f"{type(e).__name__}: {e}"}
+        try:
+            conn.sendall((json.dumps(reply) + "\n").encode("utf-8"))
+        except OSError:
+            pass
+
+
+def _serve_loop(srv: socket.socket, encode_fn) -> None:
+    while not _stop.is_set():
+        try:
+            conn, _ = srv.accept()
+        except OSError:
+            break
+        threading.Thread(target=_handle, args=(conn, encode_fn), daemon=True).start()
+
+
+def serve_embed_socket(sock_path: Path, encode_fn: Callable[[list], Optional[list]]) -> threading.Thread:
+    """Bind `sock_path` and serve embed requests via `encode_fn`. Idempotent
+    cleanup of a stale socket file; returns the started accept thread."""
+    global _server_sock
+    _stop.clear()
+    sock_path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        sock_path.unlink()          # clear a stale socket from a dead host
+    except FileNotFoundError:
+        pass
+    srv = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    _bind_or_connect(srv.bind, sock_path)
+    os.chmod(sock_path, 0o600)
+    srv.listen(64)
+    _server_sock = srv
+    t = threading.Thread(target=_serve_loop, args=(srv, encode_fn),
+                         name="embed-socket", daemon=True)
+    t.start()
+    return t
+
+
+def stop_embed_socket() -> None:
+    _stop.set()
+    global _server_sock
+    if _server_sock is not None:
+        try:
+            _server_sock.close()
+        finally:
+            _server_sock = None
+
+
+def embed_via_host(texts: list, sock_path: Path, timeout: float = 3.0) -> Optional[list]:
+    """Client: ask the host to embed `texts`. Returns a list of vectors, or
+    None on ANY failure (no host / timeout / malformed) so the caller can fall
+    back to FTS."""
+    try:
+        with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as c:
+            c.settimeout(timeout)
+            _bind_or_connect(c.connect, sock_path)
+            c.sendall((json.dumps({"v": _WIRE_V, "op": "embed",
+                                   "texts": list(texts)}) + "\n").encode("utf-8"))
+            buf = b""
+            while b"\n" not in buf:
+                chunk = c.recv(65536)
+                if not chunk:
+                    return None
+                buf += chunk
+        resp = json.loads(buf.split(b"\n", 1)[0].decode("utf-8"))
+        if resp.get("error") or "vectors" not in resp:
+            return None
+        return resp["vectors"]
+    except (OSError, ValueError, json.JSONDecodeError):
+        return None

--- a/threadkeeper/identity.py
+++ b/threadkeeper/identity.py
@@ -125,96 +125,28 @@ def _ensure_session(conn: sqlite3.Connection, client: Optional[str] = None) -> s
             ingest._start_background_ingester()
         except Exception:
             pass
-        try:
-            from . import retention
-            retention.start_retention_daemon()
-        except Exception:
-            pass
-        try:
-            from . import search_proxy
-            search_proxy.start_search_proxy()
-        except Exception:
-            pass
-        try:
-            from . import spawn_budget
-            spawn_budget.start_budget_daemon()
-        except Exception:
-            pass
-        try:
-            from . import memory_guard
-            memory_guard.start_memory_guard_daemon()
-        except Exception:
-            pass
-        try:
-            from . import auto_update
-            auto_update.start_auto_update_daemon()
-        except Exception:
-            pass
-        try:
-            from . import skill_watcher
-            skill_watcher.start_skill_watcher()
-        except Exception:
-            pass
-        try:
-            from . import skill_updater
-            skill_updater.start_skill_update_daemon()
-        except Exception:
-            pass
-        try:
-            from . import config_watcher
-            config_watcher.start_config_watcher()
-        except Exception:
-            pass
-        try:
-            from . import shadow_review
-            shadow_review.start_shadow_daemon()
-        except Exception:
-            pass
-        try:
-            from . import curator
-            curator.start_curator_daemon()
-        except Exception:
-            pass
-        try:
-            from . import extract_daemon
-            extract_daemon.start_extract_daemon()
-        except Exception:
-            pass
-        try:
-            from . import candidate_reviewer
-            candidate_reviewer.start_candidate_reviewer_daemon()
-        except Exception:
-            pass
-        try:
-            from . import probe_daemon
-            probe_daemon.start_probe_daemon()
-        except Exception:
-            pass
-        try:
-            from . import evolve_daemon
-            evolve_daemon.start_evolve_daemon()
-        except Exception:
-            pass
-        try:
-            from . import evolve_applier
-            evolve_applier.start_evolve_applier_daemon()
-        except Exception:
-            pass
-        try:
-            from . import thread_janitor
-            thread_janitor.start_thread_janitor()
-        except Exception:
-            pass
-        try:
-            from . import dialectic_miner
-            dialectic_miner.start_dialectic_miner_daemon()
-        except Exception:
-            pass
-        try:
-            from . import dialectic_validator
-            dialectic_validator.start_dialectic_validator_daemon()
-        except Exception:
-            pass
+        # Phase 1 (daemon-host): who actually runs the loops depends on the
+        # flag + this process's role. `host.start_daemons()` (Task 4) starts
+        # the ingester + all 18 daemon starters that used to be in-lined here
+        # — in WHATEVER process calls it — so the flag-off branch below is
+        # the same behavior as before, just centralized in one function.
+        from . import config as _cfg
+        from . import host
+        if not _cfg.DAEMON_HOST_ENABLED:
+            # legacy (flag off): run every loop in THIS process, as before.
+            try:
+                host.start_daemons()
+            except Exception:
+                pass
+        elif _cfg.PROCESS_ROLE == "server":
+            # thin server: delegate the loops to the shared host.
+            try:
+                host.ensure_host_running()
+            except Exception:
+                pass  # a thin server must never fail to start on host trouble
+        # else: flag on + role == "host" — host.main() already started the
+        # loops; a re-entrant _ensure_session (e.g. the host heartbeat) must
+        # NOT restart them. Do nothing.
         try:
             # One-shot self-heal: claims seeded before the tier machinery
             # never got their tier recomputed (see recompute_all_tiers). Cheap

--- a/threadkeeper/identity.py
+++ b/threadkeeper/identity.py
@@ -120,11 +120,6 @@ def _ensure_session(conn: sqlite3.Connection, client: Optional[str] = None) -> s
             ingest._backfill_dialog_fts_if_empty(conn)
         except Exception:
             pass  # FTS unavailable shouldn't block session start
-        try:
-            from . import ingest
-            ingest._start_background_ingester()
-        except Exception:
-            pass
         # Phase 1 (daemon-host): who actually runs the loops depends on the
         # flag + this process's role. `host.start_daemons()` (Task 4) starts
         # the ingester + all 18 daemon starters that used to be in-lined here

--- a/threadkeeper/ingest.py
+++ b/threadkeeper/ingest.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from typing import Optional
 
 from .config import (
+    BACKGROUND_DAEMONS_ALLOWED,
     INGEST_CAP_PER_CALL,
     INGEST_INTERVAL_S,
     INGEST_RECENT_WINDOW_S,
@@ -674,6 +675,8 @@ def _start_background_ingester() -> None:
         return
     if _ingest_interval_s <= 0:
         return  # disabled via env
+    if not BACKGROUND_DAEMONS_ALLOWED:
+        return
 
     def _loop() -> None:
         while True:

--- a/threadkeeper/memory_guard.py
+++ b/threadkeeper/memory_guard.py
@@ -439,10 +439,14 @@ def is_global_guard_coordinator(procs: list[dict]) -> bool:
 def _idle_retire_candidates(procs: list[dict]) -> list[dict]:
     from . import config as _cfg
 
+    if _cfg.DAEMON_HOST_ENABLED:
+        # Under daemon-host mode, thin servers are cheap and are never
+        # idle-retired; the single host is supervised separately via
+        # supervise_host(), not this path.
+        return []
+
     candidates: list[dict] = []
     for p in procs:
-        if _cfg.DAEMON_HOST_ENABLED and p.get("client") != "daemon-host":
-            continue  # thin servers are cheap; never idle-retire under host mode
         if p.get("is_self"):
             continue
         if p.get("parent_alive") and not MEMORY_GUARD_RETIRE_LIVE:

--- a/threadkeeper/memory_guard.py
+++ b/threadkeeper/memory_guard.py
@@ -437,8 +437,12 @@ def is_global_guard_coordinator(procs: list[dict]) -> bool:
 
 
 def _idle_retire_candidates(procs: list[dict]) -> list[dict]:
+    from . import config as _cfg
+
     candidates: list[dict] = []
     for p in procs:
+        if _cfg.DAEMON_HOST_ENABLED and p.get("client") != "daemon-host":
+            continue  # thin servers are cheap; never idle-retire under host mode
         if p.get("is_self"):
             continue
         if p.get("parent_alive") and not MEMORY_GUARD_RETIRE_LIVE:
@@ -475,6 +479,32 @@ def _retire_plan(procs: list[dict], aggregate: dict) -> list[dict]:
         total -= int(p.get("rss_mb") or 0)
         count -= 1
     return plan
+
+
+def _host_alive() -> bool:
+    from . import host
+    return host._host_alive()
+
+
+def supervise_host() -> None:
+    """Respawn the daemon-host if its heartbeat is stale (flag on only).
+
+    Phase 1: with THREADKEEPER_DAEMON_HOST on, thin per-session servers are
+    never idle-retire targets (see `_idle_retire_candidates`), so the guard
+    against a wedged/crashed host is this: if the host's presence heartbeat
+    has gone stale, spawn a replacement. No-op when the flag is off or the
+    host is already alive.
+    """
+    from . import config as _cfg
+    if not _cfg.DAEMON_HOST_ENABLED:
+        return
+    if _host_alive():
+        return
+    try:
+        from . import host
+        host.ensure_host_running()
+    except Exception:
+        pass
 
 
 def scan_over_limit() -> dict:
@@ -649,6 +679,10 @@ def check_once(*, dry_run: bool = True, notify: bool = True) -> dict:
 
 def _daemon_loop() -> None:
     while True:
+        try:
+            supervise_host()
+        except Exception:
+            logger.debug("memory_guard: supervise_host failed", exc_info=True)
         try:
             check_once(dry_run=False, notify=True)
         except Exception:

--- a/threadkeeper/probe_daemon.py
+++ b/threadkeeper/probe_daemon.py
@@ -36,7 +36,7 @@ from .config import PROBE_INTERVAL_S, PROBE_COOLDOWN_S, TASK_LOG_DIR
 from .db import get_db
 from . import daemon_state, identity
 from .identity import _detect_self_cid, _emit
-from .helpers import alive, single_flight_lock
+from .helpers import alive, daemon_sleep, single_flight_lock
 
 logger = logging.getLogger(__name__)
 

--- a/threadkeeper/search_proxy.py
+++ b/threadkeeper/search_proxy.py
@@ -29,7 +29,7 @@ import threading
 import time
 from typing import Optional
 
-from .config import SEMANTIC_AVAILABLE
+from .config import BACKGROUND_DAEMONS_ALLOWED, SEMANTIC_AVAILABLE
 from .db import get_db
 from . import identity
 
@@ -153,6 +153,8 @@ def start_search_proxy() -> None:
         return
     if _POLL_INTERVAL_S <= 0:
         return  # disabled via env (test environments, or explicit opt-out)
+    if not BACKGROUND_DAEMONS_ALLOWED:
+        return
     t = threading.Thread(
         target=_serve_loop, name="search_proxy", daemon=True,
     )

--- a/threadkeeper/skill_watcher.py
+++ b/threadkeeper/skill_watcher.py
@@ -13,7 +13,7 @@ import os
 import threading
 from typing import Optional
 
-from .config import CLAUDE_SKILLS_DIR
+from .config import BACKGROUND_DAEMONS_ALLOWED, CLAUDE_SKILLS_DIR
 from .db import get_db
 from .helpers import daemon_sleep
 
@@ -88,6 +88,8 @@ def start_skill_watcher() -> None:
     if _started:
         return
     if _tick_interval_s <= 0:
+        return
+    if not BACKGROUND_DAEMONS_ALLOWED:
         return
     t = threading.Thread(
         target=_watch_loop, name='skill_watcher', daemon=True,

--- a/threadkeeper/spawn_budget.py
+++ b/threadkeeper/spawn_budget.py
@@ -39,6 +39,7 @@ import time
 from typing import Optional, Tuple
 
 from .config import (
+    BACKGROUND_DAEMONS_ALLOWED,
     SPAWN_BUDGET_MB,
     SPAWN_ESTIMATE_SLIM_MB,
     SPAWN_ESTIMATE_FULL_MB,
@@ -633,6 +634,8 @@ def start_budget_daemon() -> None:
         return
     if SPAWN_BUDGET_MB <= 0 and SPAWN_MAX_RUNTIME_S <= 0:
         return  # both RSS budget and wall-clock watchdog (#80) off — nothing to do
+    if not BACKGROUND_DAEMONS_ALLOWED:
+        return
     t = threading.Thread(
         target=_daemon_loop, name="spawn_budget", daemon=True,
     )


### PR DESCRIPTION
## What & why (audit Phase 1)

Today every CLI session spawns a **full** MCP server (`python -m threadkeeper.server`) that starts ~18 background daemons + lazily loads an ONNX embedding model → N heavy processes (~3.4 GB aggregate) + `memory_guard` reclaim-thrash (idle servers churn as sessions come and go).

This lands, **behind `THREADKEEPER_DAEMON_HOST` (dark by default)**:

- **One headless daemon-host per machine** (`python -m threadkeeper.host`) owns the background loops (18 daemon starters + the ingester) + the warm ONNX model + a narrow **embed unix-socket**. Elected via a flock; spawned detached by the first thin server; always-on.
- **Thin per-session servers**: stdio MCP + direct SQLite (WAL), no daemons, no ONNX under the default `fts` fallback. They route the embeddings they need (a search query, and content ingested during the session) to the host over the socket, **falling back to FTS** when the host is transiently unreachable.
- **`memory_guard`** stops idle-retiring thin servers (the thrash root) and supervises the host instead.
- **No CLI config change** — the launch command stays `python -m threadkeeper.server`.

Topology:
```
CLI A ─ threadkeeper.server (THIN) ┐
CLI B ─ threadkeeper.server (THIN) ┼─ embed socket ─► daemon-host (1/machine, headless)
CLI C ─ threadkeeper.server (THIN) ┘                    ├─ 18 daemons + ingester
    └────── all read/write ──────► shared SQLite (WAL) ◄┤─ warm ONNX model + embed listener
```

## Safety / status

- **Flag OFF (default) = byte-for-byte current behavior.** Full suite green with the flag off: **1149 passed, 1 skipped**.
- **Flag ON is not yet enable-ready.** The final whole-branch review found (and this PR fixes) 3 flag-ON defects: a zombie loop-less host from inherited spawned-child env (now env-sanitized), an accidental retire-exemption (now explicit), and docs that overstated supervision (now honest). **One deferred pre-enable blocker** remains — recovering a *wedged-but-alive* host via SIGTERM-by-pid — tracked in #223. Do not flip the flag on until #223 lands.

## Folded-in fixes (pre-existing, surfaced during this work)

- **All background daemon starters now honor `BACKGROUND_DAEMONS_ALLOWED`** (`search_proxy`, `skill_watcher`, `spawn_budget`, ingester previously ignored it). Complements the host env-sanitization and lets the daemon-host cleanly own them. *(Supersedes #225, folded here.)*
- **`probe_daemon` no longer crashes on its first tick** — it called `daemon_sleep()` without importing it.

## How it was built

8-task plan (`docs/superpowers/plans/2026-07-07-daemon-host-thin-servers.md`), subagent-driven: a fresh implementer per task, an independent per-task review (spec + quality), fix loops where needed, and a final whole-branch review. Design spec: `docs/superpowers/specs/2026-07-07-daemon-host-thin-servers-design.md`.

New: `threadkeeper/host.py`, `threadkeeper/host_embed.py`. Touched: `config.py`, `embeddings.py`, `identity.py`, `memory_guard.py` (+ the 4 daemon-gating modules). ~10 new test files; no new third-party dependency.

Relates to #223 (pre-enable blocker). Supersedes #225.

🤖 Generated with [Claude Code](https://claude.com/claude-code)