### PR TITLE
fix: preserve ingest cursor on capped reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,13 @@ version bumps follow semver per the policy in
 
 ### Fixed
 
+- **Transcript ingest no longer loses capped or same-second messages (#89).**
+  `_ingest_file` now leaves the per-file cursor behind when `max_msgs` stops a
+  pass before the transcript is fully consumed, so later passes reread and drain
+  the remaining messages through UUID dedup. The skip guard also compares file
+  size in addition to integer mtime, picking up appends written in the same
+  wall-clock second.
+
 - **Auto-update no longer silently rewrites CLI setup config (#87).**
   Post-update setup now defaults to a dry-run check
   (`THREADKEEPER_AUTO_UPDATE_SETUP=check`) that records unchanged vs pending

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -45,6 +45,10 @@ remains a live question.
 - `extract_recent` + review/accept/reject ledger — regex candidates with
   manual approval (mem0-style without LLM on this side).
 - ingest fix — Skill-tool-only messages are no longer skipped.
+- Per-file ingest cursor safety (#89): capped ingest passes now preserve the
+  previous file cursor until the transcript is fully drained, and same-second
+  appends are detected by comparing file size as well as integer mtime. Re-reading
+  remains idempotent through `dialog_messages.uuid` dedup.
 - Issue-backed evolve loop: Evolve reviewer audits thread-keeper for safety,
   leaks, cost, reliability, optimizations, and current agent/MCP ideas, then
   creates/updates roadmap issues; Evolve applier drains one open issue at a
@@ -758,11 +762,6 @@ even when `_run_setup` reports `setup=failed` (✅ DONE via #19);
 Deep code-audit pass (2026-06-17, evolve_reviewer third pass; five parallel
 read-only subsystem audits, each finding re-verified at the cited file:line and
 deduplicated against the issues above):
-- Per-file **ingest cursor loses messages**: `_ingest_file` advances
-  `last_mtime` even when the `max_msgs` cap truncates the read (default 50 at
-  session start), and the skip guard compares only mtime — never the stored
-  `last_size` — so same-second appends are dropped. Distinct from the global
-  out-of-order cursor #69 (#89).
 - Two learning daemons **drop dialog windows**: `shadow_review` records its
   high-water cursor even when `spawn()` returns an `ERR ...` budget-cap string
   (a value, not an exception, so the `try/except` misses it), and the `extract`

--- a/tests/test_ingest_cursor.py
+++ b/tests/test_ingest_cursor.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from threadkeeper.adapters.base import NormalizedMessage
+
+
+class _FakeAdapter:
+    name = "fake-cli"
+
+    def __init__(self, messages: list[NormalizedMessage]) -> None:
+        self._messages = messages
+
+    def iter_messages(self, _fp: Path):
+        yield from self._messages
+
+    def project_label(self, _fp: Path) -> str:
+        return "fake-project"
+
+
+def _message(idx: int) -> NormalizedMessage:
+    return NormalizedMessage(
+        uuid=f"cursor-msg-{idx}",
+        session_id="cursor-session",
+        role="user",
+        content=f"cursor regression message {idx}",
+        model="",
+        created_at=1_800_000_000 + idx,
+        raw={"role": "user", "content": f"cursor regression message {idx}"},
+    )
+
+
+def _row_count(conn) -> int:
+    return conn.execute("SELECT COUNT(*) c FROM dialog_messages").fetchone()["c"]
+
+
+def test_ingest_cap_preserves_cursor_until_file_is_fully_drained(
+    fresh_mp, tmp_path
+):
+    from threadkeeper import ingest
+
+    ingest.SEMANTIC_AVAILABLE = False
+    conn = fresh_mp["db"].get_db()
+    fp = tmp_path / "session.jsonl"
+    fp.write_text("synthetic transcript marker\n", encoding="utf-8")
+    adapter = _FakeAdapter([_message(i) for i in range(5)])
+
+    assert ingest._ingest_file(conn, fp, max_msgs=2, adapter=adapter) == 2
+    conn.commit()
+    state = conn.execute(
+        "SELECT last_size, last_mtime, msg_count FROM ingest_state "
+        "WHERE file_path=?",
+        (str(fp),),
+    ).fetchone()
+    assert state["last_size"] == 0
+    assert state["last_mtime"] == 0
+    assert state["msg_count"] == 2
+
+    assert ingest._ingest_file(conn, fp, max_msgs=2, adapter=adapter) == 2
+    conn.commit()
+    assert _row_count(conn) == 4
+
+    assert ingest._ingest_file(conn, fp, max_msgs=2, adapter=adapter) == 1
+    conn.commit()
+    assert _row_count(conn) == 5
+    state = conn.execute(
+        "SELECT last_size, last_mtime, msg_count FROM ingest_state "
+        "WHERE file_path=?",
+        (str(fp),),
+    ).fetchone()
+    assert state["last_size"] == fp.stat().st_size
+    assert state["last_mtime"] == int(fp.stat().st_mtime)
+    assert state["msg_count"] == 5
+
+    assert ingest._ingest_file(conn, fp, max_msgs=2, adapter=adapter) == 0
+    conn.commit()
+    assert _row_count(conn) == 5
+
+
+def test_ingest_same_second_append_uses_size_to_avoid_mtime_skip(
+    fresh_mp, tmp_path
+):
+    from threadkeeper import ingest
+
+    ingest.SEMANTIC_AVAILABLE = False
+    conn = fresh_mp["db"].get_db()
+    fp = tmp_path / "session.jsonl"
+    fixed_mtime = 1_900_000_000
+    fp.write_text("first\n", encoding="utf-8")
+    os.utime(fp, (fixed_mtime, fixed_mtime))
+
+    assert ingest._ingest_file(
+        conn, fp, max_msgs=100, adapter=_FakeAdapter([_message(0)])
+    ) == 1
+    conn.commit()
+    first_state = conn.execute(
+        "SELECT last_size, last_mtime FROM ingest_state WHERE file_path=?",
+        (str(fp),),
+    ).fetchone()
+    assert first_state["last_mtime"] == fixed_mtime
+
+    fp.write_text("first\nsecond\n", encoding="utf-8")
+    os.utime(fp, (fixed_mtime, fixed_mtime))
+    assert fp.stat().st_size > first_state["last_size"]
+    assert int(fp.stat().st_mtime) == fixed_mtime
+
+    assert ingest._ingest_file(
+        conn, fp, max_msgs=100, adapter=_FakeAdapter([_message(0), _message(1)])
+    ) == 1
+    conn.commit()
+    assert _row_count(conn) == 2
+
+    assert ingest._ingest_file(
+        conn, fp, max_msgs=100, adapter=_FakeAdapter([_message(0), _message(1)])
+    ) == 0
+    conn.commit()
+    assert _row_count(conn) == 2

--- a/threadkeeper/ingest.py
+++ b/threadkeeper/ingest.py
@@ -384,9 +384,11 @@ def _ingest_file(conn: sqlite3.Connection, fp: Path, max_msgs: int,
     When `adapter` is None (legacy callers), the Claude Code adapter is
     used so the function's old contract still holds.
 
-    Strategy: skip the file entirely if mtime hasn't advanced past
-    ingest_state.last_mtime. Otherwise use `adapter.iter_messages(fp)`
+    Strategy: skip the file entirely if neither its mtime nor size has
+    advanced past ingest_state. Otherwise use `adapter.iter_messages(fp)`
     to enumerate normalized messages and dedup via dialog_messages.uuid.
+    If max_msgs is hit, preserve the prior cursor so the next pass rereads
+    the file and drains more messages instead of losing the tail.
     """
     if adapter is None:
         from .adapters import _CLAUDE_CODE as _claude_default  # type: ignore
@@ -396,15 +398,19 @@ def _ingest_file(conn: sqlite3.Connection, fp: Path, max_msgs: int,
     stat = fp.stat()
     mtime = int(stat.st_mtime)
     state = conn.execute(
-        "SELECT last_mtime FROM ingest_state WHERE file_path=?", (str(fp),)
+        "SELECT last_size, last_mtime FROM ingest_state WHERE file_path=?",
+        (str(fp),)
     ).fetchone()
     last_mtime = state["last_mtime"] if state else 0
-    if mtime <= last_mtime:
+    last_size = state["last_size"] if state else 0
+    if mtime <= last_mtime and stat.st_size <= last_size:
         return 0
     added = 0
+    hit_cap = False
     try:
         for nm in adapter.iter_messages(fp):
             if added >= max_msgs:
+                hit_cap = True
                 break
             if not nm.uuid:
                 continue
@@ -447,13 +453,15 @@ def _ingest_file(conn: sqlite3.Connection, fp: Path, max_msgs: int,
             added += 1
     except OSError:
         return added
+    next_size = last_size if hit_cap else stat.st_size
+    next_mtime = last_mtime if hit_cap else mtime
     conn.execute(
         "INSERT INTO ingest_state (file_path, last_size, last_mtime, ingested_at, msg_count) "
         "VALUES (?,?,?,?,?) "
         "ON CONFLICT(file_path) DO UPDATE SET "
         "  last_size=excluded.last_size, last_mtime=excluded.last_mtime, "
         "  ingested_at=excluded.ingested_at, msg_count=ingest_state.msg_count+excluded.msg_count",
-        (str(fp), stat.st_size, mtime, int(time.time()), added)
+        (str(fp), next_size, next_mtime, int(time.time()), added)
     )
     return added
 


### PR DESCRIPTION
## Summary
- preserve the prior ingest_state cursor when _ingest_file stops because max_msgs was reached
- include last_size in the skip guard so same-second appends are processed
- add focused cursor regression tests and move the roadmap item to closed

## Tests
- env -u THREADKEEPER_NO_EMBEDDINGS .venv/bin/python -m pytest -q
- env -u THREADKEEPER_NO_EMBEDDINGS .venv/bin/python -m pytest -q -o addopts=--strict-markers (visible summary: 1136 passed, 1 skipped, 95 warnings)

Closes #89