### PR TITLE
docs: add rule-enforcement escalation roadmap item

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -230,6 +230,12 @@ sentence-transformers similarity scorer plus a classifier, bootstrap from
 the current ledger. But: review_candidates is not actively used yet,
 first need to understand — why. Possibly a UX problem, not ML. Scope: M.
 
+**Rule-enforcement escalation.** Repeatedly re-broken class-level rules
+should stop living only as passive memory. When the same lesson keeps
+getting violated despite an existing entry, mark it `memory-insufficient`
+and surface a recommendation to escalate the rule into an active hard
+guard such as a `PreToolUse` hook. Scope: M. Tracked in issue #228.
+
 **ACL (former Phase 4).** Folded into the "Multi-user / remote
 deployment" item above — see the ACL sub-bullet there.
 


### PR DESCRIPTION
## Summary
Add a roadmap entry for the new rule-enforcement escalation backlog item.

## Context
This documents issue #228, which asks thread-keeper to flag repeated rule violations as `memory-insufficient` and recommend escalating passive memory into an active hard guard such as a `PreToolUse` hook.

## Scope
Docs only. No runtime code changes.