### PR TITLE
fix: migrate legacy db via sqlite backup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,11 @@ version bumps follow semver per the policy in
 
 ### Fixed
 
+- **Legacy DB migration no longer copies live WAL sidecars (#95).** Startup
+  migration from `~/.memory_partner/db.sqlite` to `~/.threadkeeper/db.sqlite`
+  now uses SQLite's online backup API, producing a consistent destination main
+  DB from dirty-WAL sources without copying machine-local `-shm` files.
+
 - **Transcript ingest no longer loses capped or same-second messages (#89).**
   `_ingest_file` now leaves the per-file cursor behind when `max_msgs` stops a
   pass before the transcript is fully consumed, so later passes reread and drain

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -800,9 +800,10 @@ deduplicated against the issues above):
   with `exist_ok=True` and no owner/`O_NOFOLLOW` check, then per-file
   create-then-`chmod` — a symlink + brief-disclosure vector for spawn-prompt
   content on shared hosts. Distinct from #21 (`~/.threadkeeper`) and #68 (#94).
-- Legacy **DB migration** copies the live `-wal`/`-shm` sidecars with non-atomic
-  `shutil.copy2` and no checkpoint — pairing a stale `-shm` with a copied `-wal`
-  can produce a torn/corrupt DB at the new path (#95).
+- ✅ DONE (#95): Legacy **DB migration** now uses SQLite's online backup API
+  instead of copying live `-wal`/`-shm` sidecars, so dirty-WAL source databases
+  migrate into a consistent main DB and machine-local `-shm` state is never
+  imported.
 - Codex adapter: the fallback message **UUID** has no per-line offset, so
   timestamp-colliding messages collapse to one uuid and the later ones are
   deduped away; separately, each rollout file is fully scanned twice per ingest

--- a/tests/test_config_settings.py
+++ b/tests/test_config_settings.py
@@ -5,6 +5,7 @@ Uses importlib.reload so each test can set/clear env before re-importing.
 import importlib
 import logging
 import os
+import sqlite3
 import tempfile
 
 import pytest
@@ -150,6 +151,45 @@ def test_dotenv_read_and_env_wins(monkeypatch):
 def test_claude_dir_bare_alias(monkeypatch):
     c = _fresh_config(monkeypatch, env={"CLAUDE_SKILLS_DIR": "/tmp/x"})
     assert str(c.CLAUDE_SKILLS_DIR) == "/tmp/x"
+
+
+def test_legacy_db_migration_uses_online_backup_for_dirty_wal(
+    tmp_path, monkeypatch
+):
+    c = _fresh_config(
+        monkeypatch,
+        env={"THREADKEEPER_DB": str(tmp_path / "unused.sqlite")},
+    )
+    legacy_dir = tmp_path / "legacy"
+    legacy_dir.mkdir()
+    legacy_db = legacy_dir / "db.sqlite"
+    migrated_db = tmp_path / "new" / "db.sqlite"
+
+    writer = sqlite3.connect(str(legacy_db))
+    try:
+        writer.execute("PRAGMA journal_mode=WAL")
+        writer.execute("PRAGMA wal_autocheckpoint=0")
+        writer.execute("CREATE TABLE memories (id INTEGER PRIMARY KEY, body TEXT)")
+        writer.execute("INSERT INTO memories (body) VALUES ('committed in wal')")
+        writer.commit()
+
+        assert legacy_db.with_name(legacy_db.name + "-wal").exists()
+        assert legacy_db.with_name(legacy_db.name + "-shm").exists()
+
+        c._migrate_legacy_db(legacy_db, migrated_db)
+    finally:
+        writer.close()
+
+    migrated_wal = migrated_db.with_name(migrated_db.name + "-wal")
+    migrated_shm = migrated_db.with_name(migrated_db.name + "-shm")
+    assert migrated_db.exists()
+    assert not migrated_wal.exists()
+    assert not migrated_shm.exists()
+
+    with sqlite3.connect(str(migrated_db)) as migrated:
+        assert migrated.execute("PRAGMA integrity_check").fetchone()[0] == "ok"
+        row = migrated.execute("SELECT body FROM memories").fetchone()
+    assert row == ("committed in wal",)
 
 
 def test_bad_type_raises(monkeypatch):

--- a/threadkeeper/config.py
+++ b/threadkeeper/config.py
@@ -875,8 +875,9 @@ DB_PATH.parent.mkdir(parents=True, exist_ok=True)
 _harden_current_storage()
 
 # One-shot migration from the historical name `memory_partner`. If the new
-# DB doesn't exist yet but the legacy one does, copy it (including the WAL
-# sidecars) so users can rename mid-life without losing memory. After this
+# DB doesn't exist yet but the legacy one does, take a SQLite online backup so
+# uncheckpointed WAL frames are copied into a consistent destination database
+# without copying machine-local `-shm` state or racing sidecar files. After this
 # import the legacy directory is left in place — caller can `rm -rf` once
 # they've verified the new path is working.
 #
@@ -886,14 +887,49 @@ _harden_current_storage()
 _DEFAULT_DB = Path("~/.threadkeeper/db.sqlite").expanduser()
 _LEGACY_DIR = Path("~/.memory_partner").expanduser()
 _LEGACY_DB = _LEGACY_DIR / "db.sqlite"
+
+
+def _remove_sqlite_files(db_path: Path) -> None:
+    for path in (
+        db_path,
+        db_path.with_name(db_path.name + "-wal"),
+        db_path.with_name(db_path.name + "-shm"),
+    ):
+        try:
+            path.unlink()
+        except FileNotFoundError:
+            pass
+
+
+def _migrate_legacy_db(legacy_db: Path, db_path: Path) -> None:
+    import sqlite3
+
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_db = db_path.with_name(f".{db_path.name}.migrating-{os.getpid()}")
+    _remove_sqlite_files(tmp_db)
+
+    try:
+        with sqlite3.connect(str(legacy_db), timeout=10.0) as src:
+            src.execute("PRAGMA busy_timeout=10000")
+            with sqlite3.connect(str(tmp_db), timeout=10.0) as dst:
+                dst.execute("PRAGMA busy_timeout=10000")
+                src.backup(dst)
+                integrity = dst.execute("PRAGMA integrity_check").fetchone()
+                if integrity is None or integrity[0] != "ok":
+                    raise RuntimeError(
+                        "legacy DB migration integrity_check failed: "
+                        f"{integrity[0] if integrity else 'no result'}"
+                    )
+        os.replace(tmp_db, db_path)
+    except Exception:
+        _remove_sqlite_files(tmp_db)
+        raise
+
+
 if (
     DB_PATH == _DEFAULT_DB
     and not DB_PATH.exists()
     and _LEGACY_DB.exists()
 ):
-    import shutil
-    for fname in ("db.sqlite", "db.sqlite-wal", "db.sqlite-shm"):
-        src = _LEGACY_DIR / fname
-        if src.exists():
-            shutil.copy2(src, DB_PATH.parent / fname)
+    _migrate_legacy_db(_LEGACY_DB, DB_PATH)
     _harden_current_storage()


### PR DESCRIPTION
## Summary
- Replace legacy DB sidecar copying with SQLite online backup.
- Preserve dirty-WAL source data in the migrated main DB without copying -shm or -wal files.
- Update the roadmap and changelog for the fix.

## Tests
- `env -u THREADKEEPER_NO_EMBEDDINGS .venv/bin/python -m pytest -q` (exit 0; project double-quiet config suppresses pass-count line)
- `env -u THREADKEEPER_NO_EMBEDDINGS .venv/bin/python -m pytest -q -o addopts=--strict-markers` -> 1149 passed, 1 skipped, 95 warnings

Closes #95