### PR TITLE
fix: harden task spool path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,12 @@ version bumps follow semver per the policy in
 
 ### Fixed
 
+- **Task spool no longer defaults to a predictable shared `/tmp` directory
+  (#94).** `THREADKEEPER_TASK_LOG_DIR` now defaults to
+  `~/.threadkeeper/tasks`, the spool directory is verified as a non-symlink
+  owned by the current user and created `0700`, and predictable spawn files are
+  opened through no-follow owner-only helpers instead of create-then-`chmod`.
+
 - **Transcript ingest no longer loses capped or same-second messages (#89).**
   `_ingest_file` now leaves the per-file cursor behind when `max_msgs` stops a
   pass before the transcript is fully consumed, so later passes reread and drain

--- a/README.md
+++ b/README.md
@@ -926,6 +926,7 @@ The most-used env knobs (full list in `threadkeeper/config.py`):
 | Knob | Default | Purpose |
 |---|---|---|
 | `THREADKEEPER_DB` | `~/.threadkeeper/db.sqlite` | SQLite file |
+| `THREADKEEPER_TASK_LOG_DIR` | `~/.threadkeeper/tasks` | owner-only task spool for spawn logs, stdin prompts, command scripts, and small runtime logs |
 | `THREADKEEPER_RETENTION_INTERVAL_S` | 0 (off) | SQLite retention/compaction daemon tick; 0 disables the daemon |
 | `THREADKEEPER_DIALOG_RETENTION_DAYS` | 0 | prune aged `dialog_messages` plus `dialog_fts` / `dialog_vec` mirrors; 0 keeps forever |
 | `THREADKEEPER_TASK_RETENTION_DAYS` | 30 | prune completed `tasks` rows older than this many days; 0 keeps forever |
@@ -1187,9 +1188,12 @@ becomes a problem.
 Hooks and small runtime artifacts: `~/.threadkeeper/hooks/`.
 
 Spawn task spool files live in `THREADKEEPER_TASK_LOG_DIR` (default
-`/tmp/thread-keeper-tasks`). `spawn()` creates captured headless `.log` files
-with mode `0600`, matching stdin prompt spools. `consolidate()` garbage-collects
-task spool files once their task row is no longer retained.
+`~/.threadkeeper/tasks`). The directory is created owner-only (`0700`) inside
+the hardened `~/.threadkeeper` perimeter by default; explicit overrides are
+refused when the configured directory is a symlink or is not owned by the
+current user. `spawn()` creates captured headless `.log`, stdin prompt spool,
+and visible `.command` files with no-follow owner-only opens. `consolidate()`
+garbage-collects task spool files once their task row is no longer retained.
 
 ---
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -687,8 +687,10 @@ optional 24h spawned-child token and dollar ceilings when
   stores `tokens_in`, `tokens_out`, `tokens_total`, and `cost_usd`, and always
   stores `duration_s` from the task timestamps. If no usage trailer is emitted,
   the row still has wall-time for cost/benefit triage. Captured `.log` files
-  in `THREADKEEPER_TASK_LOG_DIR` are created owner-only (`0600`), matching the
-  stdin prompt spool.
+  in `THREADKEEPER_TASK_LOG_DIR` are created with no-follow owner-only opens
+  (`0600`), matching the stdin prompt spool. The task spool defaults to
+  `~/.threadkeeper/tasks` (`0700`) and configured directories are refused when
+  symlinked or owned by another user.
 - Daemon ticks run only in foreground parent processes and update real RSS via
   `ps`; unreadable RSS samples preserve the last-known `rss_kb`, and every open
   row is swept for dead root pids → `ended_at`.
@@ -1398,6 +1400,7 @@ unsupported CLI overrides still fall through to the next priority, and
 | Knob | Default | Purpose |
 |---|---|---|
 | `THREADKEEPER_DB` | `~/.threadkeeper/db.sqlite` | sqlite file |
+| `THREADKEEPER_TASK_LOG_DIR` | `~/.threadkeeper/tasks` | owner-only task spool for spawn logs, stdin prompts, command scripts, and runtime logs |
 | `THREADKEEPER_RETENTION_INTERVAL_S` | 0 | retention/compaction daemon tick; 0 disables |
 | `THREADKEEPER_DIALOG_RETENTION_DAYS` | 0 | prune old dialog rows plus `dialog_fts` / `dialog_vec` mirrors; 0 keeps forever |
 | `THREADKEEPER_TASK_RETENTION_DAYS` | 30 | prune completed `tasks` older than this many days; 0 keeps forever |

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -796,10 +796,11 @@ deduplicated against the issues above):
   RSS samples as 0 MB. Spawn-budget refresh preserves last-known child RSS on
   measurement failure and sweeps every open task row for liveness, so a >100-row
   stale tail cannot pin the budget.
-- Security: the `/tmp/thread-keeper-tasks` **spool dir** is created world-knowable
-  with `exist_ok=True` and no owner/`O_NOFOLLOW` check, then per-file
-  create-then-`chmod` — a symlink + brief-disclosure vector for spawn-prompt
-  content on shared hosts. Distinct from #21 (`~/.threadkeeper`) and #68 (#94).
+- ✅ DONE (#94). The task spool now defaults to `~/.threadkeeper/tasks` inside
+  the hardened user-owned perimeter, verifies configured spool directories with
+  `lstat`/current-user ownership before use, creates them `0700`, and opens
+  predictable task files with no-follow owner-only helpers instead of
+  create-then-`chmod`.
 - Legacy **DB migration** copies the live `-wal`/`-shm` sidecars with non-atomic
   `shutil.copy2` and no checkpoint — pairing a stale `-shm` with a copied `-wal`
   can produce a torn/corrupt DB at the new path (#95).

--- a/tests/test_config_settings.py
+++ b/tests/test_config_settings.py
@@ -6,6 +6,7 @@ import importlib
 import logging
 import os
 import tempfile
+from pathlib import Path
 
 import pytest
 
@@ -56,6 +57,7 @@ def test_defaults_match(monkeypatch):
     assert c.SKILL_UPDATE_INFER_SOURCES is True
     assert c.CURATOR_SNAPSHOT_RETENTION == 10
     assert str(c.DB_PATH).endswith("/.threadkeeper/db.sqlite")
+    assert c.TASK_LOG_DIR == Path.home() / ".threadkeeper" / "tasks"
 
 
 def test_env_overrides_default(monkeypatch):
@@ -266,7 +268,6 @@ def test_all_exported_names_present(monkeypatch):
 
 def test_db_path_type(monkeypatch):
     """DB_PATH must be a pathlib.Path, not a string."""
-    from pathlib import Path
     c = _fresh_config(monkeypatch)
     assert isinstance(c.DB_PATH, Path)
 

--- a/tests/test_task_spool.py
+++ b/tests/test_task_spool.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from threadkeeper import task_spool
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX ownership/mode test")
+def test_ensure_task_spool_dir_creates_owner_only(tmp_path):
+    path = tmp_path / "tasks"
+
+    task_spool.ensure_task_spool_dir(path)
+
+    assert path.is_dir()
+    assert path.stat().st_mode & 0o777 == 0o700
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX symlink test")
+def test_ensure_task_spool_dir_refuses_symlink(tmp_path):
+    real = tmp_path / "real"
+    real.mkdir()
+    link = tmp_path / "tasks"
+    link.symlink_to(real, target_is_directory=True)
+
+    with pytest.raises(PermissionError, match="symlink"):
+        task_spool.ensure_task_spool_dir(link)
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX ownership test")
+def test_ensure_task_spool_dir_refuses_foreign_owned(monkeypatch, tmp_path):
+    path = tmp_path / "tasks"
+    path.mkdir()
+    owner_uid = path.stat().st_uid
+    monkeypatch.setattr(task_spool.os, "getuid", lambda: owner_uid + 1)
+
+    with pytest.raises(PermissionError, match="not owned"):
+        task_spool.ensure_task_spool_dir(path)
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX no-follow test")
+def test_write_spool_text_refuses_planted_symlink(tmp_path):
+    spool = task_spool.ensure_task_spool_dir(tmp_path / "tasks")
+    target = tmp_path / "target.txt"
+    target.write_text("keep\n", encoding="utf-8")
+    planted = spool / "dialog-tail.command"
+    planted.symlink_to(target)
+
+    with pytest.raises(OSError):
+        task_spool.write_spool_text(planted, "secret\n")
+
+    assert target.read_text(encoding="utf-8") == "keep\n"
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX ownership test")
+def test_write_spool_text_validates_before_truncate(monkeypatch, tmp_path):
+    spool = task_spool.ensure_task_spool_dir(tmp_path / "tasks")
+    path = spool / "dialog-tail.command"
+    path.write_text("keep\n", encoding="utf-8")
+    owner_uid = path.stat().st_uid
+    monkeypatch.setattr(task_spool.os, "getuid", lambda: owner_uid + 1)
+
+    with pytest.raises(PermissionError, match="not owned"):
+        task_spool.write_spool_text(path, "secret\n")
+
+    assert path.read_text(encoding="utf-8") == "keep\n"

--- a/threadkeeper/agent_status.py
+++ b/threadkeeper/agent_status.py
@@ -14,6 +14,7 @@ import time
 from typing import Any
 
 from .config import TASK_LOG_DIR
+from .task_spool import open_spool_binary_read
 from .db import get_db
 from .github_budget import format_github_budget, github_budget_state
 from .helpers import alive, fmt_age
@@ -626,7 +627,7 @@ def _role_to_loop() -> dict[str, dict[str, str]]:
 def _read_log_sample(task_id: str, max_head: int = 16_384, max_tail: int = 65_536) -> str:
     path = TASK_LOG_DIR / f"{task_id}.log"
     try:
-        with path.open("rb") as f:
+        with open_spool_binary_read(path) as f:
             head = f.read(max_head)
             try:
                 f.seek(0, 2)

--- a/threadkeeper/brief.py
+++ b/threadkeeper/brief.py
@@ -18,10 +18,11 @@ from datetime import datetime, timezone
 from typing import Optional
 
 from .config import (
-    SEMANTIC_AVAILABLE, DIALOG_LOG, TASK_LOG_DIR, BRIEF_LEAN, DB_PATH,
+    SEMANTIC_AVAILABLE, DIALOG_LOG, BRIEF_LEAN, DB_PATH,
     PICKUP_CLAIM_TTL_S,
 )
 from .helpers import fmt_age, q
+from .task_spool import append_spool_text
 from . import identity
 from .identity import _detect_self_cid, _ensure_cursor
 from .embeddings import _cosine_search
@@ -939,7 +940,6 @@ def _append_dialog_log(from_cid: Optional[str], to_cid: Optional[str],
     """Single-line log of every cross-session signal. Tailed by
     open_dialog_window() so the user sees the live conversation."""
     try:
-        TASK_LOG_DIR.mkdir(parents=True, exist_ok=True)
         ts = datetime.now().strftime("%H:%M:%S")
         f = (from_cid or "?")[:8]
         t = (to_cid or "*")[:8]
@@ -948,7 +948,6 @@ def _append_dialog_log(from_cid: Optional[str], to_cid: Optional[str],
         if len(body) > 280:
             body = body[:280] + "…"
         line = f"[{ts}] {f} → {t:<8} [{kind:<9}] {body}\n"
-        with DIALOG_LOG.open("a", encoding="utf-8") as fp:
-            fp.write(line)
+        append_spool_text(DIALOG_LOG, line)
     except OSError:
         pass

--- a/threadkeeper/config.py
+++ b/threadkeeper/config.py
@@ -77,7 +77,7 @@ class Settings(BaseSettings):
             "claude_projects_dir",
         ),
     )
-    task_log_dir: Path = Field(default=Path("/tmp/thread-keeper-tasks"))
+    task_log_dir: Path = Field(default=Path("~/.threadkeeper/tasks"))
 
     # ── Embeddings ───────────────────────────────────────────────────────────
     # env: THREADKEEPER_EMBED_MODEL (field name: embed_model → EMBED_MODEL_NAME)

--- a/threadkeeper/memory_guard.py
+++ b/threadkeeper/memory_guard.py
@@ -37,6 +37,7 @@ from .config import (
 from .db import get_db
 from .helpers import daemon_sleep
 from . import process_health
+from .task_spool import append_spool_text
 
 logger = logging.getLogger(__name__)
 
@@ -84,10 +85,8 @@ def _fmt_rss_mb(value: int | None) -> str:
 
 def _log_line(line: str) -> None:
     try:
-        TASK_LOG_DIR.mkdir(parents=True, exist_ok=True)
         fp = TASK_LOG_DIR / "memory-guard.log"
-        with fp.open("a", encoding="utf-8") as f:
-            f.write(line.rstrip() + "\n")
+        append_spool_text(fp, line.rstrip() + "\n")
     except OSError:
         logger.debug("memory_guard: failed to append log", exc_info=True)
 

--- a/threadkeeper/menubar_app.py
+++ b/threadkeeper/menubar_app.py
@@ -24,6 +24,7 @@ from .config import (
     WRITE_ORIGIN,
 )
 from .helpers import single_flight_lock
+from .task_spool import append_spool_text, ensure_task_spool_dir
 
 
 APP_NAME = "ThreadKeeperAgentStatus"
@@ -58,7 +59,7 @@ def _prepare_build_source(src: Path) -> Path:
     build_src = TASK_LOG_DIR / "menubar-build" / "source"
     if build_src.exists():
         shutil.rmtree(build_src)
-    build_src.mkdir(parents=True, exist_ok=True)
+    ensure_task_spool_dir(build_src)
     for name in SOURCE_FILES:
         shutil.copy2(src / name, build_src / name)
     return build_src
@@ -78,10 +79,8 @@ def _log_path() -> Path:
 
 def _log(message: str) -> None:
     try:
-        TASK_LOG_DIR.mkdir(parents=True, exist_ok=True)
-        with _log_path().open("a", encoding="utf-8") as f:
-            ts = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
-            f.write(f"{ts} {message}\n")
+        ts = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+        append_spool_text(_log_path(), f"{ts} {message}\n")
     except OSError:
         pass
 
@@ -332,7 +331,10 @@ def ensure_menubar_app() -> None:
         _log(f"source_missing path={src}")
         return
 
-    TASK_LOG_DIR.mkdir(parents=True, exist_ok=True)
+    try:
+        ensure_task_spool_dir(TASK_LOG_DIR)
+    except OSError:
+        return
     try:
         with single_flight_lock(
             "menubar-autolaunch", lock_dir=DB_PATH.parent

--- a/threadkeeper/probe_daemon.py
+++ b/threadkeeper/probe_daemon.py
@@ -37,6 +37,7 @@ from .db import get_db
 from . import daemon_state, identity
 from .identity import _detect_self_cid, _emit
 from .helpers import alive, single_flight_lock
+from .task_spool import ensure_task_spool_dir
 
 logger = logging.getLogger(__name__)
 
@@ -50,8 +51,7 @@ PROBE_PROMPT_PREFIX = "You are a PROBE RUNNER"
 
 def _answer_dir() -> Path:
     d = TASK_LOG_DIR / "probe-answers"
-    d.mkdir(parents=True, exist_ok=True)
-    return d
+    return ensure_task_spool_dir(d)
 
 
 def _last_probe_ts(conn: sqlite3.Connection) -> int:

--- a/threadkeeper/shadow_review.py
+++ b/threadkeeper/shadow_review.py
@@ -386,11 +386,12 @@ def _read_verdict(log_path: Path) -> str:
 
     The child's contract is a final line `MATERIALIZED: <slug>` or
     `SKIP: <reason>`; we take the LAST such line since tool output can
-    follow earlier prose. Missing/unreadable logs → 'unknown' (the task
-    log dir defaults to ephemeral /tmp, so older children legitimately
-    have no log left to read)."""
+    follow earlier prose. Missing/unreadable logs → 'unknown'."""
+    from .task_spool import open_spool_binary_read
+
     try:
-        text = log_path.read_text(encoding="utf-8", errors="replace")
+        with open_spool_binary_read(log_path) as fp:
+            text = fp.read().decode("utf-8", errors="replace")
     except (OSError, ValueError):
         return "unknown"
     verdict = "unknown"

--- a/threadkeeper/task_spool.py
+++ b/threadkeeper/task_spool.py
@@ -1,0 +1,177 @@
+"""Secure task-spool directory and file helpers."""
+from __future__ import annotations
+
+import os
+import stat
+from pathlib import Path
+from typing import BinaryIO
+
+TASK_SPOOL_DIR_MODE = 0o700
+TASK_SPOOL_FILE_MODE = 0o600
+TASK_SPOOL_EXEC_MODE = 0o700
+
+
+def _posix_owner_checks_available() -> bool:
+    return os.name == "posix" and hasattr(os, "getuid")
+
+
+def _nofollow_flag() -> int:
+    return int(getattr(os, "O_NOFOLLOW", 0))
+
+
+def _as_path(path: Path | str) -> Path:
+    return Path(path).expanduser()
+
+
+def _verify_owned_dir(path: Path) -> Path:
+    st = os.lstat(path)
+    if stat.S_ISLNK(st.st_mode):
+        raise PermissionError(f"refusing task spool symlink: {path}")
+    if not stat.S_ISDIR(st.st_mode):
+        raise NotADirectoryError(f"task spool path is not a directory: {path}")
+    if _posix_owner_checks_available() and st.st_uid != os.getuid():
+        raise PermissionError(
+            f"refusing task spool not owned by current user: {path}"
+        )
+    if os.name == "posix":
+        os.chmod(path, TASK_SPOOL_DIR_MODE)
+    return path
+
+
+def ensure_task_spool_dir(path: Path | str) -> Path:
+    """Create and verify a task-spool directory as owner-only.
+
+    The final path component is checked with lstat so an attacker-controlled
+    symlink is refused instead of followed. Existing directories must be owned
+    by the current user on POSIX.
+    """
+    p = _as_path(path)
+    try:
+        return _verify_owned_dir(p)
+    except FileNotFoundError:
+        p.parent.mkdir(parents=True, mode=TASK_SPOOL_DIR_MODE, exist_ok=True)
+        try:
+            os.mkdir(p, TASK_SPOOL_DIR_MODE)
+        except FileExistsError:
+            pass
+        return _verify_owned_dir(p)
+
+
+def _verify_private_file_fd(fd: int, path: Path, file_mode: int) -> None:
+    st = os.fstat(fd)
+    if not stat.S_ISREG(st.st_mode):
+        raise PermissionError(f"refusing non-regular task spool file: {path}")
+    if _posix_owner_checks_available() and st.st_uid != os.getuid():
+        raise PermissionError(
+            f"refusing task spool file not owned by current user: {path}"
+        )
+    if os.name == "posix" and st.st_nlink != 1:
+        raise PermissionError(f"refusing linked task spool file: {path}")
+    if os.name == "posix":
+        os.fchmod(fd, file_mode)
+
+
+def _open_private_fd(path: Path | str, flags: int, file_mode: int) -> int:
+    p = _as_path(path)
+    ensure_task_spool_dir(p.parent)
+    fd = os.open(p, flags | _nofollow_flag(), file_mode)
+    try:
+        _verify_private_file_fd(fd, p, file_mode)
+    except Exception:
+        os.close(fd)
+        raise
+    return fd
+
+
+def _open_existing_checked_fd(path: Path | str, flags: int) -> int:
+    p = _as_path(path)
+    ensure_task_spool_dir(p.parent)
+    fd = os.open(p, flags | _nofollow_flag())
+    try:
+        st = os.fstat(fd)
+        if not stat.S_ISREG(st.st_mode):
+            raise PermissionError(f"refusing non-regular task spool file: {p}")
+        if _posix_owner_checks_available() and st.st_uid != os.getuid():
+            raise PermissionError(
+                f"refusing task spool file not owned by current user: {p}"
+            )
+        if os.name == "posix" and st.st_nlink != 1:
+            raise PermissionError(f"refusing linked task spool file: {p}")
+    except Exception:
+        os.close(fd)
+        raise
+    return fd
+
+
+def write_spool_text(
+    path: Path | str,
+    text: str,
+    *,
+    file_mode: int = TASK_SPOOL_FILE_MODE,
+    exclusive: bool = False,
+    encoding: str = "utf-8",
+) -> None:
+    flags = os.O_WRONLY | os.O_CREAT
+    if exclusive:
+        flags |= os.O_EXCL
+    fd = _open_private_fd(path, flags, file_mode)
+    try:
+        if not exclusive:
+            os.ftruncate(fd, 0)
+        with os.fdopen(fd, "w", encoding=encoding) as fp:
+            fp.write(text)
+    except Exception:
+        try:
+            os.close(fd)
+        except OSError:
+            pass
+        raise
+
+
+def append_spool_text(
+    path: Path | str,
+    text: str,
+    *,
+    file_mode: int = TASK_SPOOL_FILE_MODE,
+    encoding: str = "utf-8",
+) -> None:
+    fd = _open_private_fd(path, os.O_WRONLY | os.O_CREAT | os.O_APPEND, file_mode)
+    try:
+        with os.fdopen(fd, "a", encoding=encoding) as fp:
+            fp.write(text)
+    except Exception:
+        try:
+            os.close(fd)
+        except OSError:
+            pass
+        raise
+
+
+def touch_spool_file(
+    path: Path | str,
+    *,
+    file_mode: int = TASK_SPOOL_FILE_MODE,
+) -> None:
+    append_spool_text(path, "", file_mode=file_mode)
+
+
+def open_new_spool_binary(
+    path: Path | str,
+    *,
+    file_mode: int = TASK_SPOOL_FILE_MODE,
+) -> BinaryIO:
+    fd = _open_private_fd(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, file_mode)
+    try:
+        return os.fdopen(fd, "wb")
+    except Exception:
+        os.close(fd)
+        raise
+
+
+def open_spool_binary_read(path: Path | str) -> BinaryIO:
+    fd = _open_existing_checked_fd(path, os.O_RDONLY)
+    try:
+        return os.fdopen(fd, "rb")
+    except Exception:
+        os.close(fd)
+        raise

--- a/threadkeeper/tools/consolidate.py
+++ b/threadkeeper/tools/consolidate.py
@@ -12,6 +12,7 @@ reports (and optionally applies) several kinds of cleanup:
 """
 
 import sqlite3
+import stat
 import time
 
 from .._mcp import read_tool, write_tool
@@ -25,6 +26,7 @@ from ..config import (
 from ..helpers import fmt_age, q, normalize_text
 from ..identity import _ensure_session, _emit
 from ..embeddings import _get_model, _encode, _vec_delete_note
+from ..task_spool import ensure_task_spool_dir
 
 
 CONSOLIDATE_NOTE_COSINE = 0.95
@@ -104,6 +106,7 @@ def _task_spool_gc_candidates(
         r["id"] for r in conn.execute("SELECT id FROM tasks").fetchall()
     } - pruned_task_ids
     try:
+        ensure_task_spool_dir(TASK_LOG_DIR)
         entries = sorted(TASK_LOG_DIR.iterdir(), key=lambda p: p.name)
     except (FileNotFoundError, OSError):
         return []
@@ -111,10 +114,10 @@ def _task_spool_gc_candidates(
     out = []
     for p in entries:
         try:
-            is_file = p.is_file()
+            st = p.lstat()
         except OSError:
             continue
-        if not is_file:
+        if not stat.S_ISREG(st.st_mode):
             continue
         parsed = _spool_task_id(p.name)
         if parsed is None:

--- a/threadkeeper/tools/dialog.py
+++ b/threadkeeper/tools/dialog.py
@@ -16,6 +16,12 @@ from ..config import TASK_LOG_DIR, DIALOG_LOG, SEMANTIC_AVAILABLE
 from ..db import get_db
 from ..helpers import fmt_age, q
 from ..identity import _ensure_session
+from ..task_spool import (
+    TASK_SPOOL_EXEC_MODE,
+    ensure_task_spool_dir,
+    touch_spool_file,
+    write_spool_text,
+)
 from ..embeddings import _dialog_cosine_search, _fts_search, _rrf_combine
 from ..ingest import _ingest_all
 
@@ -28,8 +34,11 @@ def open_dialog_window() -> str:
     time; this lets the user see the dialog between concurrent claude
     sessions as it happens. The window stays open until you close it (it's
     a `tail -F`, no exit). Title: 'thread-keeper-dialog'."""
-    TASK_LOG_DIR.mkdir(parents=True, exist_ok=True)
-    DIALOG_LOG.touch(exist_ok=True)
+    try:
+        ensure_task_spool_dir(TASK_LOG_DIR)
+        touch_spool_file(DIALOG_LOG)
+    except OSError as e:
+        return f"ERR task_spool_unavailable={e}"
     script_path = TASK_LOG_DIR / "dialog-tail.command"
     tag = "thread-keeper-dialog"
     script = (
@@ -41,8 +50,14 @@ def open_dialog_window() -> str:
         "echo\n"
         f"exec tail -n 50 -F {shlex.quote(str(DIALOG_LOG))}\n"
     )
-    script_path.write_text(script)
-    script_path.chmod(0o755)
+    try:
+        write_spool_text(
+            script_path,
+            script,
+            file_mode=TASK_SPOOL_EXEC_MODE,
+        )
+    except OSError as e:
+        return f"ERR write_failed={e}"
     try:
         subprocess.Popen(["open", "-a", "Terminal", str(script_path)])
     except (FileNotFoundError, OSError) as e:

--- a/threadkeeper/tools/distill.py
+++ b/threadkeeper/tools/distill.py
@@ -17,6 +17,7 @@ from ..db import get_db
 from ..config import TASK_LOG_DIR
 from ..helpers import fmt_age, q, gen_distill_id
 from ..identity import _ensure_session, _detect_self_cid, _emit
+from ..task_spool import append_spool_text
 
 
 DISTILL_KINDS = ("insight", "pattern", "anti-pattern", "fix",
@@ -143,11 +144,13 @@ def export_distillates(min_vote: float = 1.0,
                        output_path: str = "") -> str:
     """Write distillates with vote_sum >= min_vote to a jsonl bucket.
     Marks them exported_at so the same item isn't re-exported next call.
-    Default output: /tmp/thread-keeper-tasks/distillates.jsonl."""
-    out_path = Path(output_path.strip()) if output_path.strip() else (
+    Default output: ~/.threadkeeper/tasks/distillates.jsonl."""
+    custom_output = bool(output_path.strip())
+    out_path = Path(output_path.strip()) if custom_output else (
         TASK_LOG_DIR / "distillates.jsonl"
     )
-    out_path.parent.mkdir(parents=True, exist_ok=True)
+    if custom_output:
+        out_path.parent.mkdir(parents=True, exist_ok=True)
     conn = get_db()
     rows = conn.execute(
         "SELECT id, kind, confidence, content, vote_sum, vote_count, "
@@ -160,20 +163,26 @@ def export_distillates(min_vote: float = 1.0,
         return f"nothing_to_export min_vote={min_vote}"
     now_t = int(time.time())
     written = 0
-    with out_path.open("a", encoding="utf-8") as fp:
-        for r in rows:
-            obj = {
-                "id": r["id"], "kind": r["kind"],
-                "confidence": r["confidence"],
-                "content": r["content"],
-                "vote_sum": r["vote_sum"], "vote_count": r["vote_count"],
-                "source_thread": r["source_thread"],
-                "source_cid": r["source_cid"],
-                "created_at": r["created_at"],
-                "exported_at": now_t,
-            }
-            fp.write(_json.dumps(obj, ensure_ascii=False) + "\n")
-            written += 1
+    lines = []
+    for r in rows:
+        obj = {
+            "id": r["id"], "kind": r["kind"],
+            "confidence": r["confidence"],
+            "content": r["content"],
+            "vote_sum": r["vote_sum"], "vote_count": r["vote_count"],
+            "source_thread": r["source_thread"],
+            "source_cid": r["source_cid"],
+            "created_at": r["created_at"],
+            "exported_at": now_t,
+        }
+        lines.append(_json.dumps(obj, ensure_ascii=False) + "\n")
+        written += 1
+    payload = "".join(lines)
+    if custom_output:
+        with out_path.open("a", encoding="utf-8") as fp:
+            fp.write(payload)
+    else:
+        append_spool_text(out_path, payload)
     ids = [r["id"] for r in rows]
     conn.execute(
         f"UPDATE distill SET exported_at=? WHERE id IN "

--- a/threadkeeper/tools/spawn.py
+++ b/threadkeeper/tools/spawn.py
@@ -22,7 +22,13 @@ from typing import Optional
 from .._mcp import mcp, read_tool, write_tool, structured_result
 from ..db import get_db
 from ..config import TASK_LOG_DIR, CLAUDE_PROJECTS_DIR, DB_PATH
-from ..permissions import open_private_binary_write
+from ..task_spool import (
+    TASK_SPOOL_EXEC_MODE,
+    ensure_task_spool_dir,
+    open_new_spool_binary,
+    open_spool_binary_read,
+    write_spool_text,
+)
 from ..tool_schemas import (
     SpawnBudgetStatus,
     SpawnTaskRss,
@@ -65,15 +71,16 @@ def _install_gh_safety_wrapper(task_id: str) -> tuple[Optional[Path], str]:
     real_gh = shutil.which("gh") or ""
     wrapper_dir = TASK_LOG_DIR / f"gh-safe-{task_id}"
     try:
-        wrapper_dir.mkdir(parents=True, exist_ok=True)
+        ensure_task_spool_dir(wrapper_dir)
         script = wrapper_dir / "gh"
-        script.write_text(
+        write_spool_text(
+            script,
             "#!/bin/sh\n"
             f"exec {shlex.quote(sys.executable)} -m "
             "threadkeeper.github_safety \"$@\"\n",
+            file_mode=TASK_SPOOL_EXEC_MODE,
             encoding="utf-8",
         )
-        script.chmod(0o700)
     except OSError as e:
         return None, f"gh_safety_wrapper_failed={e}"
     return wrapper_dir, real_gh
@@ -329,8 +336,10 @@ def _build_slim_mcp_config(
     Returns the path to the slim config file, or None if neither path
     can produce a valid entry (caller should fall back to full config).
     """
-    slim_dir = TASK_LOG_DIR
-    slim_dir.mkdir(parents=True, exist_ok=True)
+    try:
+        slim_dir = ensure_task_spool_dir(TASK_LOG_DIR)
+    except OSError:
+        return None
     slim_path = slim_dir / f"slim-mcp-{task_id}.json"
     mp_entry = None
     claude_json = Path.home() / ".claude.json"
@@ -371,15 +380,13 @@ def _build_slim_mcp_config(
         env.update(env_overrides)
     mp_entry["env"] = env
     try:
-        slim_path.write_text(
+        write_spool_text(
+            slim_path,
             _json.dumps({"mcpServers": {"thread-keeper": mp_entry}},
                         indent=2),
+            exclusive=True,
             encoding="utf-8",
         )
-        # This file embeds the MCP server env — lock it down to owner-only,
-        # parity with the 0600 stdin spool file (#68). Not group/other
-        # readable.
-        slim_path.chmod(0o600)
     except OSError:
         return None
     return slim_path
@@ -711,16 +718,23 @@ def _spawn_impl(prompt: str, cwd: str = "", append_system: str = "",
                 cmd += ["--mcp-config", str(slim_cfg),
                         "--strict-mcp-config"]
     log_path: Optional[Path] = None
-    TASK_LOG_DIR.mkdir(parents=True, exist_ok=True)
+    try:
+        task_log_dir = ensure_task_spool_dir(TASK_LOG_DIR)
+    except OSError as e:
+        return f"ERR task_spool_unavailable={e}"
     if stdin_text is not None:
-        stdin_path = TASK_LOG_DIR / f"{task_id}.stdin.txt"
+        stdin_path = task_log_dir / f"{task_id}.stdin.txt"
         try:
-            stdin_path.write_text(stdin_text, encoding="utf-8")
-            stdin_path.chmod(0o600)
+            write_spool_text(
+                stdin_path,
+                stdin_text,
+                exclusive=True,
+                encoding="utf-8",
+            )
         except OSError as e:
             return f"ERR prompt_stdin_write_failed={e}"
     if capture_output and not visible:
-        log_path = TASK_LOG_DIR / f"{task_id}.log"
+        log_path = task_log_dir / f"{task_id}.log"
     proc_pid = 0
     now_t = int(time.time())
     conn = get_db()
@@ -755,7 +769,7 @@ def _spawn_impl(prompt: str, cwd: str = "", append_system: str = "",
             # Build a self-contained .command shell script that Terminal.app
             # will execute in a fresh window. We export env, cd, exec claude,
             # then `read` so the window stays open for inspection.
-            script_path = TASK_LOG_DIR / f"{task_id}.command"
+            script_path = task_log_dir / f"{task_id}.command"
             cmd_line = " \\\n    ".join(shlex.quote(a) for a in cmd)
             if stdin_path is not None:
                 cmd_line = f"{cmd_line} < {shlex.quote(str(stdin_path))}"
@@ -849,12 +863,17 @@ OSA
 )
 exit $rc
 """
-            script_path.write_text(script)
             # The script `export`s the child's env (FORCE_CID, write-origin,
             # etc.) and is run by Terminal.app as the current user, so it
-            # only needs owner rwx — not the world-readable/executable 0755
-            # it used to get. Parity with the 0600 stdin file (#68).
-            script_path.chmod(0o700)
+            # only needs owner rwx. Create it with no-follow/exclusive
+            # semantics because the task id is externally guessable enough to
+            # treat pre-planted spool entries as hostile.
+            write_spool_text(
+                script_path,
+                script,
+                file_mode=TASK_SPOOL_EXEC_MODE,
+                exclusive=True,
+            )
             try:
                 subprocess.Popen(
                     ["open", "-a", "Terminal", str(script_path)],
@@ -882,7 +901,7 @@ exit $rc
             if stdin_path is not None:
                 stdin_f = stdin_path.open("rb")
             if log_path is not None:
-                log_f = open_private_binary_write(log_path)
+                log_f = open_new_spool_binary(log_path)
                 proc = subprocess.Popen(
                     launch_cmd,
                     cwd=cwd,
@@ -1134,11 +1153,11 @@ def task_logs(task_id: str, tail_lines: int = 80) -> str:
     Returns the last `tail_lines` lines or 'no_log' if the task ran with
     capture_output=False or the log file is missing."""
     log_path = TASK_LOG_DIR / f"{task_id}.log"
-    if not log_path.exists():
-        return f"no_log path={log_path}"
     try:
-        with log_path.open("rb") as f:
+        with open_spool_binary_read(log_path) as f:
             data = f.read()
+    except FileNotFoundError:
+        return f"no_log path={log_path}"
     except OSError as e:
         return f"ERR read_failed={e}"
     text = data.decode("utf-8", errors="replace")


### PR DESCRIPTION
## Summary
- Default THREADKEEPER_TASK_LOG_DIR to ~/.threadkeeper/tasks
- Add task_spool helpers that refuse symlink or foreign-owned spool dirs and use no-follow owner-only opens for task files
- Update docs and roadmap status for #94

## Tests
- env -u THREADKEEPER_NO_EMBEDDINGS .venv/bin/python -m pytest -q
- env -u THREADKEEPER_NO_EMBEDDINGS .venv/bin/python -m pytest -o addopts="--strict-markers" -q (1153 passed, 1 skipped, 95 warnings)

Closes #94