### PR TITLE
fix: throttle curator and candidate reviewer restarts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -98,14 +98,14 @@
 # THREADKEEPER_SHADOW_REVIEW_INTERVAL_S=0
 # THREADKEEPER_SHADOW_REVIEW_WINDOW_S=900
 # THREADKEEPER_SHADOW_REVIEW_MIN_CHARS=500
-# THREADKEEPER_CURATOR_INTERVAL_S=0
+# THREADKEEPER_CURATOR_INTERVAL_S=0            # restart-throttled by last curator_pass; force=True bypasses
 # THREADKEEPER_CURATOR_MIN_LESSONS=3
 # THREADKEEPER_CURATOR_REPORTS_DIR=             # default: <db dir>/curator
 # THREADKEEPER_CURATOR_DESTRUCTIVE=1            # default 1: curator applies its own changes; set 0 for advisory REPORT-only
 # THREADKEEPER_CURATOR_SNAPSHOT_RETENTION=10    # destructive pre-mutation snapshots retained under <reports_dir>/snapshots
 # THREADKEEPER_EXTRACT_INTERVAL_S=0
 # THREADKEEPER_EXTRACT_WINDOW_MIN=30
-# THREADKEEPER_CANDIDATE_REVIEW_INTERVAL_S=0
+# THREADKEEPER_CANDIDATE_REVIEW_INTERVAL_S=0   # restart-throttled by last candidate_review_pass; force=True bypasses
 # THREADKEEPER_CANDIDATE_REVIEW_MIN=3
 # THREADKEEPER_PROBE_INTERVAL_S=0             # 1800 = 30 min active reliability tracking
 # THREADKEEPER_PROBE_COOLDOWN_S=604800       # 86400 = 1d active per-category cooldown

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,11 @@ version bumps follow semver per the policy in
 
 ### Fixed
 
+- **Curator and candidate-reviewer honor restart intervals (#99).** Both
+  dispatchers now consult their recorded pass high-water before taking the
+  single-flight lock, so a fresh MCP server inside the configured interval
+  returns `not_due` and spawns no child. Forced runs still bypass the due gate.
+
 - **Transcript ingest no longer loses capped or same-second messages (#89).**
   `_ingest_file` now leaves the per-file cursor behind when `max_msgs` stops a
   pass before the transcript is fully consumed, so later passes reread and drain

--- a/README.md
+++ b/README.md
@@ -596,6 +596,11 @@ candidates accumulated indefinitely waiting for an agent to call
 while one reviewer child is running, or while another process holds the shared
 dispatch lock, other foreground servers/ticks report `candidate_review_running`
 instead of spawning another child for the same queue.
+Before that lock, the pass also checks the last recorded
+`candidate_review_pass` high-water. A fresh MCP server restart, or a
+non-forced direct `candidate_review_run()`, returns `not_due` inside the
+configured interval and records that status without spawning; use
+`candidate_review_run(force=True)` for an immediate one-shot.
 
 All spawning learning-loop daemons that enforce single-flight use the same
 non-blocking `helpers.single_flight_lock()` helper around the
@@ -617,8 +622,11 @@ never proposes destructive changes against them. The pass is
 single-flight across processes — a non-blocking `fcntl.flock` pidfile
 (`<db dir>/curator.lock`) plus a running-children check serialize it, so
 multiple MCP server instances can't run overlapping (now destructive) passes
-against the same store. A manual `curator_run(force=True)` bypasses the
-interval but still respects the lock.
+against the same store. Before that lock, the pass also checks the last
+recorded `curator_pass` high-water, so fresh MCP server restarts and
+non-forced direct `curator_review()` calls return `not_due` inside the
+configured interval and record that status without spawning. A manual
+`curator_review(force=True)` bypasses the interval but still respects the lock.
 
 Before spawning, the scheduler hashes the stable inventory state (lessons,
 lesson usage, active/stale skills, and concepts). If the hash matches the last
@@ -956,9 +964,9 @@ The most-used env knobs (full list in `threadkeeper/config.py`):
 | `THREADKEEPER_SHADOW_REVIEW_WINDOW_S` | 900 | sliding window for shadow scan (s) |
 | `THREADKEEPER_EXTRACT_INTERVAL_S` | 0 (off) | extract daemon tick (s); 600 = 10 min recommended; if this exceeds the base window, the daemon extends from the previous successful `extract_pass` cursor so ticks do not leave gaps |
 | `THREADKEEPER_EXTRACT_WINDOW_MIN` | 30 | base sliding dialog window per extract pass (min); daemon runs may scan farther back only to cover an interval/window gap |
-| `THREADKEEPER_CANDIDATE_REVIEW_INTERVAL_S` | 0 (off) | candidate-reviewer daemon tick (s); 3600 = 1h recommended |
+| `THREADKEEPER_CANDIDATE_REVIEW_INTERVAL_S` | 0 (off) | candidate-reviewer daemon tick (s), restart-throttled by the last `candidate_review_pass`; 3600 = 1h recommended |
 | `THREADKEEPER_CANDIDATE_REVIEW_MIN` | 3 | min pending candidates before reviewer engages |
-| `THREADKEEPER_CURATOR_INTERVAL_S` | 0 (off) | curator daemon tick (s); 604800 = 7d recommended |
+| `THREADKEEPER_CURATOR_INTERVAL_S` | 0 (off) | curator daemon tick (s), restart-throttled by the last `curator_pass`; 604800 = 7d recommended |
 | `THREADKEEPER_CURATOR_MIN_LESSONS` | 3 | min lessons before curator engages |
 | `THREADKEEPER_CURATOR_DESTRUCTIVE` | `1` (on) | curator child writes its REPORT then applies its own PATCH/PRUNE/CONSOLIDATE directly (incl. `lesson_remove` for prune/consolidate); set `0` for advisory REPORT-only. `[PROTECTED]` entries never mutated |
 | `THREADKEEPER_CURATOR_SNAPSHOT_RETENTION` | 10 | number of destructive curator pre-mutation snapshots to retain under `<reports_dir>/snapshots`; current pass is always retained |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -342,11 +342,19 @@ not treat every interval daemon as overdue and refire it (pre-fix, every new
 CLI session ran its own "overdue" curator/probe/shadow pass — the flock only
 stops *concurrent* passes, not *frequent sequential* ones). Scheduled ticks
 that lose the claim return `not_due`; manual / tool-invoked passes bypass
-the gate but still record the run, pushing the next scheduled fire a full
-interval out. Applies to shadow_review, curator, candidate_reviewer,
+this `daemon_state` claim gate but still record the run, pushing the next
+scheduled fire a full interval out. Applies to shadow_review, curator,
+candidate_reviewer,
 extract, dialectic miner/validator, probe, thread_janitor, and retention;
 evolve reviewer/applier, skill_updater, and auto_update keep their own
 pre-existing due gates.
+
+The destructive/expensive curator and candidate-reviewer dispatchers also
+consult their recorded pass high-water (`curator_pass` /
+`candidate_review_pass`) before taking the single-flight lock, matching the
+evolve reviewer/applier contract. A recent pass makes a fresh MCP server or
+non-forced direct tool call return `not_due` and record that status without
+moving the high-water forward; `force=True` bypasses this due gate.
 
 - **shadow_review** — once per `SHADOW_REVIEW_INTERVAL_S` (default 0 = off),
   scans a dialog window and, if needed, spawns a slim-child evaluator behind
@@ -358,7 +366,8 @@ pre-existing due gates.
   queue is machine-wide single-flight through the shared helper's
   `candidate-reviewer.lock` plus running-task detection, preventing multiple
   foreground MCP servers from spawning duplicate reviewers for the same
-  pending candidates.
+  pending candidates. The last `candidate_review_pass` timestamp is also an
+  interval high-water, so restarts inside the interval return `not_due`.
 - **probe_daemon** — once per `PROBE_INTERVAL_S` (default 0 = off) grades
   finished probe answers, then spawns at most one due objective probe runner
   behind `probe-daemon.lock` plus the running probe-child check. A busy lock
@@ -374,6 +383,8 @@ pre-existing due gates.
   spawning, it hashes the stable inventory state and compares it to the last
   recorded complete/endorsed pass; unchanged snapshots record an
   `unchanged_inventory` no-op event instead of re-deriving the same report.
+  The last `curator_pass` timestamp is also an interval high-water, so restarts
+  inside the interval return `not_due` before any snapshot or child spawn.
   Wake-ups also coalesce behind the shared helper's non-blocking
   `curator.lock` plus the running curator-task check, so multiple foreground
   servers do not re-read and spawn against the same snapshot.
@@ -1457,7 +1468,9 @@ unsupported CLI overrides still fall through to the next priority, and
 | `THREADKEEPER_SHADOW_REVIEW_INTERVAL_S` | 0 | shadow daemon tick; 0 disables |
 | `THREADKEEPER_SHADOW_REVIEW_WINDOW_S` | 900 | sliding window for shadow |
 | `THREADKEEPER_SHADOW_REVIEW_MIN_CHARS` | 500 | spawn threshold |
-| `THREADKEEPER_CURATOR_INTERVAL_S` | 0 | curator daemon tick; 604800 = 7d recommended |
+| `THREADKEEPER_CANDIDATE_REVIEW_INTERVAL_S` | 0 | candidate-reviewer daemon tick, restart-throttled by the last `candidate_review_pass`; 3600 = 1h recommended |
+| `THREADKEEPER_CANDIDATE_REVIEW_MIN` | 3 | min pending candidates before reviewer engages |
+| `THREADKEEPER_CURATOR_INTERVAL_S` | 0 | curator daemon tick, restart-throttled by the last `curator_pass`; 604800 = 7d recommended |
 | `THREADKEEPER_CURATOR_MIN_LESSONS` | 3 | min lessons before curator engages |
 | `THREADKEEPER_CURATOR_DESTRUCTIVE` | `1` | curator child writes its REPORT then applies PATCH/PRUNE/CONSOLIDATE directly; set `0` for advisory-only |
 | `THREADKEEPER_CURATOR_TRASH_TTL_DAYS` | 30 | days to retain `lesson_remove` / `skill_manage(delete)` recovery artifacts under `<db dir>/curator/trash` |

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -366,6 +366,12 @@ dispatch lock and running-child guard coalesce concurrent foreground wake-ups
 before they re-read the inventory, and `curator_review_status()` surfaces the
 last endorsed `inventory_sha256` plus the current hash for quiescence checks.
 
+✅ DONE (#99): curator and candidate_reviewer now honor their recorded pass
+high-water before spawning. A recent `curator_pass` or
+`candidate_review_pass` makes fresh MCP-server restarts and non-forced direct
+checks return `not_due` without launching another destructive/expensive child;
+`force=True` still bypasses the interval.
+
 Lesson-store decay/eviction scoring is also in place (#27): `lesson_list` /
 `lesson_get` update `lesson_usage` counters, and curator dry runs include a
 ranked `STALE LESSONS` advisory section using

--- a/tests/test_candidate_reviewer.py
+++ b/tests/test_candidate_reviewer.py
@@ -212,6 +212,94 @@ def test_run_spawns_when_threshold_met(tmp_path, monkeypatch):
     assert "Edit" not in tool_list
 
 
+def test_run_recent_high_water_is_not_due(tmp_path, monkeypatch):
+    pkg = _bootstrap(
+        tmp_path, monkeypatch, interval="3600", min_n="3",
+    )
+    conn = pkg["db"].get_db()
+    for i in range(3):
+        _seed_pending(conn, "verbatim", f"candidate {i}", age_s=60 + i)
+    conn.commit()
+    last = 2_000_000
+    pkg["candidate_reviewer"]._record_review_pass(
+        conn, last, "spawned previous",
+    )
+    monkeypatch.setattr(
+        pkg["candidate_reviewer"].time, "time", lambda: last + 10,
+    )
+
+    import threadkeeper.tools.spawn as spawn_mod
+
+    def fail_spawn(**kwargs):  # pragma: no cover - should not be called
+        raise AssertionError("spawn should not run before interval elapses")
+
+    monkeypatch.setattr(spawn_mod, "spawn", fail_spawn)
+
+    assert pkg["candidate_reviewer"].run_review_pass() == "not_due"
+    rows = conn.execute(
+        "SELECT target, summary FROM events "
+        "WHERE kind='candidate_review_pass' ORDER BY id ASC"
+    ).fetchall()
+    assert rows[-1]["summary"] == "not_due"
+    assert rows[-1]["target"] == str(last)
+
+
+def test_run_stale_high_water_spawns(tmp_path, monkeypatch):
+    pkg = _bootstrap(
+        tmp_path, monkeypatch, interval="3600", min_n="3",
+    )
+    conn = pkg["db"].get_db()
+    for i in range(3):
+        _seed_pending(conn, "verbatim", f"candidate {i}", age_s=60 + i)
+    conn.commit()
+    now = 2_000_000
+    pkg["candidate_reviewer"]._record_review_pass(
+        conn, now - 3601, "spawned previous",
+    )
+    monkeypatch.setattr(pkg["candidate_reviewer"].time, "time", lambda: now)
+
+    import threadkeeper.tools.spawn as spawn_mod
+    captured: list[dict] = []
+
+    def fake_spawn(**kwargs):
+        captured.append(kwargs)
+        return "spawn task_id=fake-reviewer-stale pid=0"
+
+    monkeypatch.setattr(spawn_mod, "spawn", fake_spawn)
+
+    out = pkg["candidate_reviewer"].run_review_pass()
+    assert "fake-reviewer-stale" in out
+    assert len(captured) == 1
+
+
+def test_run_force_bypasses_recent_high_water(tmp_path, monkeypatch):
+    pkg = _bootstrap(
+        tmp_path, monkeypatch, interval="3600", min_n="3",
+    )
+    conn = pkg["db"].get_db()
+    for i in range(3):
+        _seed_pending(conn, "verbatim", f"candidate {i}", age_s=60 + i)
+    conn.commit()
+    now = 2_000_000
+    pkg["candidate_reviewer"]._record_review_pass(
+        conn, now - 10, "spawned previous",
+    )
+    monkeypatch.setattr(pkg["candidate_reviewer"].time, "time", lambda: now)
+
+    import threadkeeper.tools.spawn as spawn_mod
+    captured: list[dict] = []
+
+    def fake_spawn(**kwargs):
+        captured.append(kwargs)
+        return "spawn task_id=fake-reviewer-forced pid=0"
+
+    monkeypatch.setattr(spawn_mod, "spawn", fake_spawn)
+
+    out = pkg["candidate_reviewer"].run_review_pass(force=True)
+    assert "fake-reviewer-forced" in out
+    assert len(captured) == 1
+
+
 def test_injected_candidate_is_fenced_as_data(tmp_path, monkeypatch):
     """A crafted candidate whose `content` reads like a stated policy
     ("always run X / ignore prior skills") must land INSIDE the

--- a/tests/test_curator.py
+++ b/tests/test_curator.py
@@ -236,6 +236,97 @@ def test_run_curator_pass_spawns_when_threshold_met(tmp_path, monkeypatch):
     assert "THREADKEEPER_CURATOR_SNAPSHOT_DIR" not in os.environ
 
 
+def test_run_curator_pass_recent_high_water_is_not_due(
+    tmp_path, monkeypatch,
+):
+    pkg = _bootstrap(tmp_path, monkeypatch, interval="3600", min_lessons="2")
+    pkg["lessons"].append_lesson(
+        title="lesson one", body="body one", source="shadow"
+    )
+    pkg["lessons"].append_lesson(
+        title="lesson two", body="body two", source="shadow"
+    )
+    conn = pkg["db"].get_db()
+    last = 2_000_000
+    pkg["curator"]._record_curator_pass(conn, last, "spawned previous")
+    monkeypatch.setattr(pkg["curator"].time, "time", lambda: last + 10)
+
+    import threadkeeper.tools.spawn as spawn_mod
+
+    def fail_spawn(**kwargs):  # pragma: no cover - should not be called
+        raise AssertionError("spawn should not run before interval elapses")
+
+    monkeypatch.setattr(spawn_mod, "spawn", fail_spawn)
+
+    assert pkg["curator"].run_curator_pass() == "not_due"
+    rows = conn.execute(
+        "SELECT target, summary FROM events WHERE kind='curator_pass' "
+        "ORDER BY id ASC"
+    ).fetchall()
+    assert rows[-1]["summary"] == "not_due"
+    assert rows[-1]["target"] == str(last)
+
+
+def test_run_curator_pass_stale_high_water_spawns(tmp_path, monkeypatch):
+    pkg = _bootstrap(tmp_path, monkeypatch, interval="3600", min_lessons="2")
+    pkg["lessons"].append_lesson(
+        title="lesson one", body="body one", source="shadow"
+    )
+    pkg["lessons"].append_lesson(
+        title="lesson two", body="body two", source="shadow"
+    )
+    conn = pkg["db"].get_db()
+    now = 2_000_000
+    pkg["curator"]._record_curator_pass(
+        conn, now - 3601, "spawned previous"
+    )
+    monkeypatch.setattr(pkg["curator"].time, "time", lambda: now)
+
+    import threadkeeper.tools.spawn as spawn_mod
+    captured: list[dict] = []
+
+    def fake_spawn(**kwargs):
+        captured.append(kwargs)
+        return "spawn task_id=fake-curator-stale pid=0"
+
+    monkeypatch.setattr(spawn_mod, "spawn", fake_spawn)
+
+    out = pkg["curator"].run_curator_pass()
+    assert "fake-curator-stale" in out
+    assert len(captured) == 1
+
+
+def test_run_curator_pass_force_bypasses_recent_high_water(
+    tmp_path, monkeypatch,
+):
+    pkg = _bootstrap(tmp_path, monkeypatch, interval="3600", min_lessons="2")
+    pkg["lessons"].append_lesson(
+        title="lesson one", body="body one", source="shadow"
+    )
+    pkg["lessons"].append_lesson(
+        title="lesson two", body="body two", source="shadow"
+    )
+    conn = pkg["db"].get_db()
+    now = 2_000_000
+    pkg["curator"]._record_curator_pass(
+        conn, now - 10, "spawned previous"
+    )
+    monkeypatch.setattr(pkg["curator"].time, "time", lambda: now)
+
+    import threadkeeper.tools.spawn as spawn_mod
+    captured: list[dict] = []
+
+    def fake_spawn(**kwargs):
+        captured.append(kwargs)
+        return "spawn task_id=fake-curator-forced pid=0"
+
+    monkeypatch.setattr(spawn_mod, "spawn", fake_spawn)
+
+    out = pkg["curator"].run_curator_pass(force=True)
+    assert "fake-curator-forced" in out
+    assert len(captured) == 1
+
+
 def test_run_curator_pass_advisory_writes_no_snapshot(tmp_path, monkeypatch):
     pkg = _bootstrap(
         tmp_path, monkeypatch, min_lessons="2", destructive="0",

--- a/threadkeeper/candidate_reviewer.py
+++ b/threadkeeper/candidate_reviewer.py
@@ -173,6 +173,11 @@ def _record_review_pass(conn: sqlite3.Connection, ts: int,
                      exc_info=True)
 
 
+def _pass_due(conn: sqlite3.Connection, now_t: int) -> bool:
+    last = _last_review_ts(conn)
+    return last <= 0 or now_t >= last + int(CANDIDATE_REVIEW_INTERVAL_S)
+
+
 def _format_candidate(row: dict) -> str:
     """One inventory line per pending candidate."""
     snip = (row.get("content") or "")[:300].replace("\n", " ")
@@ -300,8 +305,7 @@ def run_review_pass(force: bool = False, *, scheduled: bool = False) -> str:
 
     Returns a short status string:
       - 'disabled'             — env knob off and not forced
-      - 'not_due'              — scheduled tick, but another server already
-                                 ran this loop within the interval
+      - 'not_due'              — checked recently; interval high-water not due
       - 'below_threshold n=X'  — fewer than CANDIDATE_REVIEW_MIN
                                  pending; skip the spawn
       - 'spawned task_id=…'    — reviewer child launched
@@ -309,16 +313,21 @@ def run_review_pass(force: bool = False, *, scheduled: bool = False) -> str:
     """
     if CANDIDATE_REVIEW_INTERVAL_S <= 0 and not force:
         return "disabled"
+    conn = get_db()
+    now = int(time.time())
+    if not force and not _pass_due(conn, now):
+        _record_review_pass(conn, _last_review_ts(conn), "not_due")
+        return "not_due"
     if not daemon_state.claim_pass(
         "candidate_review", CANDIDATE_REVIEW_INTERVAL_S, scheduled=scheduled,
+        conn=conn, now=now,
     ):
+        _record_review_pass(conn, _last_review_ts(conn), "not_due")
         return "not_due"
     with _review_spawn_lock() as locked:
         if not locked:
             return "candidate_review_running n=1 (single-flight lock)"
 
-        conn = get_db()
-        now = int(time.time())
         running = _running_reviewer_children(conn)
         if running:
             out = f"candidate_review_running n={len(running)} (single-flight)"

--- a/threadkeeper/curator.py
+++ b/threadkeeper/curator.py
@@ -251,6 +251,11 @@ def _record_curator_pass(conn: sqlite3.Connection,
         logger.debug("curator: failed to record pass", exc_info=True)
 
 
+def _pass_due(conn: sqlite3.Connection, now_t: int) -> bool:
+    last = _last_curator_ts(conn)
+    return last <= 0 or now_t >= last + int(CURATOR_INTERVAL_S)
+
+
 def _stable_int(value) -> int | None:
     if value is None:
         return None
@@ -630,8 +635,7 @@ def run_curator_pass(force: bool = False, *, scheduled: bool = False) -> str:
 
     Returns a short status string for observability:
       - 'disabled'        — env knob off and not forced
-      - 'not_due'         — scheduled tick, but another server already ran
-                            this loop within the interval (daemon_state)
+      - 'not_due'         — checked recently; interval high-water not due
       - 'curator_running n=…' — a curator child is already running; skip
       - 'below_threshold' — fewer than CURATOR_MIN_LESSONS lessons; skip
       - 'unchanged_inventory' — latest complete inventory already reviewed
@@ -640,9 +644,16 @@ def run_curator_pass(force: bool = False, *, scheduled: bool = False) -> str:
     """
     if CURATOR_INTERVAL_S <= 0 and not force:
         return "disabled"
+    conn = get_db()
+    now = int(time.time())
+    if not force and not _pass_due(conn, now):
+        _record_curator_pass(conn, _last_curator_ts(conn), "not_due")
+        return "not_due"
     if not daemon_state.claim_pass(
-        "curator", CURATOR_INTERVAL_S, scheduled=scheduled,
+        "curator", CURATOR_INTERVAL_S, scheduled=scheduled, conn=conn,
+        now=now,
     ):
+        _record_curator_pass(conn, _last_curator_ts(conn), "not_due")
         return "not_due"
 
     # Single-flight: the flock makes the running-children check + spawn atomic
@@ -653,8 +664,6 @@ def run_curator_pass(force: bool = False, *, scheduled: bool = False) -> str:
         if not locked:
             return "curator_running n=1 (single-flight lock)"
 
-        conn = get_db()
-        now = int(time.time())
         running = _running_curator_children(conn)
         if running:
             out = f"curator_running n={len(running)} (single-flight)"


### PR DESCRIPTION
## Summary
- add recorded high-water due gates to curator and candidate-reviewer pass dispatch
- record not_due status without moving the last actual pass timestamp forward
- add restart recency, stale interval, and force-bypass regression tests
- update daemon cadence docs and changelog

## Tests
- env -u THREADKEEPER_NO_EMBEDDINGS .venv/bin/python -m pytest -q (exit 0; double-quiet output suppressed pass count)
- env -u THREADKEEPER_NO_EMBEDDINGS .venv/bin/python -m pytest -o addopts=--strict-markers (1154 passed, 1 skipped, 95 warnings)

Closes #99