### PR TITLE
feat: add consistent SQLite backup restore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,6 +125,13 @@ version bumps follow semver per the policy in
 
 ### Added
 
+- **Consistent SQLite backup/restore command (#102).** `tk-backup create`
+  now uses SQLite `VACUUM INTO` to write an integrity-checked single-file
+  snapshot of the live WAL store, including committed frames still in
+  `db.sqlite-wal` while background writers keep running. `tk-backup restore
+  --yes` verifies the snapshot, atomically replaces the target DB after the user
+  stops thread-keeper, and removes stale `-wal`/`-shm` sidecars around the swap.
+
 - **Reserve-before-spawn admission and dialectic leases (#58).** `spawn()` now
   reserves the `tasks` row with its RSS estimate inside a `BEGIN IMMEDIATE`
   admission transaction before `Popen`, so concurrent spawns serialize against

--- a/README.md
+++ b/README.md
@@ -1168,7 +1168,30 @@ best-effort: `~/.threadkeeper` is `0700`, while `db.sqlite`, SQLite
 `-wal`/`-shm` sidecars, `~/.threadkeeper/.env`, curator `REPORT-*.md`
 files, and headless spawn logs are owner-only (`0600`).
 
-One file. Backup = `cp`. Wipe memory = `rm`.
+Use `tk-backup` for disaster recovery. It uses SQLite `VACUUM INTO`, so
+committed frames still living in the live `-wal` sidecar are included in a
+compacted snapshot without quiescing background writers:
+
+```bash
+tk-backup create ~/threadkeeper-backup.sqlite
+THREADKEEPER_DB=/path/to/db.sqlite tk-backup create ./backup.sqlite
+```
+
+Restore is intentionally explicit because it replaces the store. Stop
+thread-keeper servers and CLI sessions first, then swap in the verified
+single-file backup; the command removes stale `db.sqlite-wal` and
+`db.sqlite-shm` sidecars around the swap.
+
+```bash
+tk-backup restore ~/threadkeeper-backup.sqlite --yes
+```
+
+A raw `cp ~/.threadkeeper/db.sqlite backup.sqlite` is not a safe live backup in
+WAL mode because recent committed transactions may exist only in
+`db.sqlite-wal`. If you insist on raw filesystem copies, stop every writer
+first and copy `db.sqlite`, `db.sqlite-wal`, and `db.sqlite-shm` together. To
+wipe memory, also stop thread-keeper first, then remove the main DB and both
+sidecars.
 
 ### Retention
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -26,6 +26,7 @@ threadkeeper/
 ├── helpers.py         ID generators, fmt_age, q-quoting, alive-pid check
 ├── elicitation.py     capability-gated MCP form confirmations (#26)
 ├── github_budget.py   shared gh API rate-limit/cooldown ledger
+├── backup.py          tk-backup VACUUM INTO snapshot/restore command
 ├── agent_status.py    structured loop/agent/recent-result status for UI clients
 ├── brief.py           render_brief() / render_context() — main digest
 ├── egress.py          cross-provider memory egress policy (issue #74)
@@ -142,6 +143,19 @@ startup and `get_db()` best-effort harden the default store:
 `~/.threadkeeper` is `0700`, while `db.sqlite`, SQLite `-wal`/`-shm`
 sidecars, `~/.threadkeeper/.env`, and curator `REPORT-*.md` files are
 `0600`. Logically six levels:
+
+Backups use the `tk-backup` console command, not raw file copies. `tk-backup
+create <dest.sqlite>` opens the live store through SQLite and runs
+`VACUUM INTO` into a temporary database beside the requested destination, runs
+`PRAGMA integrity_check`, then atomically moves the single-file result into
+place. Because the source is a SQLite connection, committed WAL frames are part
+of the snapshot even while ingest, shadow-review, curator, dialectic, retention,
+or other writer loops keep running. `tk-backup restore <backup.sqlite> --yes`
+verifies the backup, copies it next to the target DB, removes stale target
+`-wal`/`-shm` sidecars, atomically replaces the main file, removes sidecars
+again, and re-runs integrity_check. Restore still requires stopping live
+thread-keeper servers first; replacing a database under an open SQLite
+connection can strand that process on the old unlinked file.
 
 `get_db()` gates baseline schema setup and legacy column migrations with
 SQLite `PRAGMA user_version`. Databases at the current version skip the

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -108,6 +108,11 @@ remains a live question.
   completed `tasks`, handled/ephemeral `signals`, old `events`, and old
   `probe_results`; optional WAL checkpoint and VACUUM maintenance are wired,
   and `mp_dashboard()` reports DB size plus high-volume row counts.
+- Data-lifecycle backup/restore safety (#102): `tk-backup create` uses
+  SQLite `VACUUM INTO` to produce an integrity-checked single-file snapshot of
+  the live WAL store while writer loops continue, and `tk-backup restore --yes`
+  verifies the snapshot, atomically swaps the DB, and clears stale
+  `-wal`/`-shm` sidecars after the user stops thread-keeper.
 - Cross-CLI ingest production verification (issue #1): the contract test in
   `scripts/tk_verify_ingest.py` gained a read-only `--live` mode that scores
   the three acceptance criteria — all CLI slots have production rows, shadow-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,8 @@ thread-keeper-setup = "threadkeeper._setup:main"
 # Recompute stored embeddings with the active backend (e.g. after switching to
 # the ONNX default). Equivalent to `python -m threadkeeper.migrate_embeddings`.
 tk-migrate-embeddings = "threadkeeper.migrate_embeddings:main"
+# Create/restore consistent single-file snapshots of the live WAL SQLite store.
+tk-backup = "threadkeeper.backup:main"
 # JSON/text status feed for menu-bar widgets and terminal monitors.
 tk-agent-status = "threadkeeper.agent_status:main"
 

--- a/tests/test_backup.py
+++ b/tests/test_backup.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import sqlite3
+import threading
+import time
+from pathlib import Path
+
+from threadkeeper.backup import create_backup, restore_backup
+
+
+def _connect(path: Path) -> sqlite3.Connection:
+    conn = sqlite3.connect(str(path), timeout=10.0, isolation_level=None)
+    conn.execute("PRAGMA busy_timeout=10000")
+    return conn
+
+
+def test_vacuum_snapshot_is_clean_under_concurrent_writes(tmp_path):
+    src = tmp_path / "live.sqlite"
+    dst = tmp_path / "snapshot.sqlite"
+    conn = _connect(src)
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.execute("PRAGMA wal_autocheckpoint=0")
+    conn.execute("CREATE TABLE facts (id INTEGER PRIMARY KEY, body TEXT)")
+    payload = "x" * 4096
+    conn.executemany(
+        "INSERT INTO facts (body) VALUES (?)",
+        [(f"seed-{idx}-{payload}",) for idx in range(900)],
+    )
+    conn.execute("INSERT INTO facts (body) VALUES ('committed-before-snapshot')")
+    assert Path(f"{src}-wal").exists()
+
+    stop = threading.Event()
+    ready = threading.Event()
+    writes: list[int] = []
+    errors: list[str] = []
+
+    def writer() -> None:
+        writer_conn = _connect(src)
+        writer_conn.execute("PRAGMA journal_mode=WAL")
+        ready.set()
+        i = 0
+        try:
+            while not stop.is_set():
+                try:
+                    writer_conn.execute(
+                        "INSERT INTO facts (body) VALUES (?)",
+                        (f"writer-{i}",),
+                    )
+                    writes.append(i)
+                    i += 1
+                except sqlite3.OperationalError as exc:
+                    errors.append(str(exc))
+                time.sleep(0.001)
+        finally:
+            writer_conn.close()
+
+    thread = threading.Thread(target=writer)
+    thread.start()
+    assert ready.wait(timeout=5)
+    while not writes:
+        time.sleep(0.001)
+
+    try:
+        result = create_backup(dst, source=src)
+    finally:
+        stop.set()
+        thread.join(timeout=5)
+        conn.close()
+
+    assert result.integrity == "ok"
+    assert writes
+    assert not errors
+    assert not Path(f"{dst}-wal").exists()
+    assert not Path(f"{dst}-shm").exists()
+
+    snap = sqlite3.connect(str(dst))
+    try:
+        assert snap.execute("PRAGMA integrity_check").fetchone()[0] == "ok"
+        row = snap.execute(
+            "SELECT COUNT(*) FROM facts WHERE body='committed-before-snapshot'"
+        ).fetchone()
+        assert row[0] == 1
+    finally:
+        snap.close()
+
+
+def test_restore_replaces_store_and_removes_stale_sidecars(tmp_path):
+    db_path = tmp_path / "db.sqlite"
+    old = _connect(db_path)
+    old.execute("PRAGMA journal_mode=WAL")
+    old.execute("CREATE TABLE facts (body TEXT)")
+    old.execute("INSERT INTO facts VALUES ('old')")
+    old.close()
+    Path(f"{db_path}-wal").write_bytes(b"stale wal")
+    Path(f"{db_path}-shm").write_bytes(b"stale shm")
+
+    backup = tmp_path / "backup.sqlite"
+    src = _connect(backup)
+    src.execute("CREATE TABLE facts (body TEXT)")
+    src.execute("INSERT INTO facts VALUES ('restored')")
+    src.close()
+
+    result = restore_backup(backup, destination=db_path)
+
+    assert result.integrity == "ok"
+    assert not Path(f"{db_path}-wal").exists()
+    assert not Path(f"{db_path}-shm").exists()
+    restored = sqlite3.connect(str(db_path))
+    try:
+        assert restored.execute("PRAGMA integrity_check").fetchone()[0] == "ok"
+        assert restored.execute("SELECT body FROM facts").fetchone()[0] == "restored"
+    finally:
+        restored.close()

--- a/threadkeeper/backup.py
+++ b/threadkeeper/backup.py
@@ -1,0 +1,313 @@
+"""Consistent SQLite backup/restore helpers for the local thread-keeper store."""
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+import os
+from pathlib import Path
+import shutil
+import sqlite3
+import sys
+import tempfile
+import time
+from urllib.parse import quote
+
+
+class BackupError(RuntimeError):
+    """Raised when a backup or restore cannot be completed safely."""
+
+
+@dataclass(frozen=True)
+class BackupResult:
+    source: Path
+    destination: Path
+    integrity: str
+    bytes_written: int
+
+
+@dataclass(frozen=True)
+class RestoreResult:
+    source: Path
+    destination: Path
+    integrity: str
+    removed_sidecars: tuple[Path, ...]
+
+
+def _default_db_path() -> Path:
+    from .config import DB_PATH
+
+    return DB_PATH
+
+
+def _expand(path: str | os.PathLike[str]) -> Path:
+    return Path(path).expanduser()
+
+
+def _ro_uri(path: Path) -> str:
+    return f"file:{quote(str(path.resolve()), safe='/')}?mode=ro"
+
+
+def _connect_ro(path: Path, *, timeout: float) -> sqlite3.Connection:
+    return sqlite3.connect(_ro_uri(path), uri=True, timeout=timeout)
+
+
+def _sidecars(db_path: Path) -> tuple[Path, Path]:
+    return (Path(f"{db_path}-wal"), Path(f"{db_path}-shm"))
+
+
+def _single_file_mode(conn: sqlite3.Connection) -> None:
+    conn.commit()
+    try:
+        conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+    except sqlite3.OperationalError:
+        pass
+    conn.execute("PRAGMA journal_mode=DELETE").fetchone()
+    conn.commit()
+
+
+def _integrity_check(path: Path, *, timeout: float = 30.0) -> str:
+    conn = _connect_ro(path, timeout=timeout)
+    try:
+        row = conn.execute("PRAGMA integrity_check").fetchone()
+    finally:
+        conn.close()
+    return "" if row is None else str(row[0])
+
+
+def _unlink_sidecars(db_path: Path) -> tuple[Path, ...]:
+    removed: list[Path] = []
+    for sidecar in _sidecars(db_path):
+        try:
+            sidecar.unlink()
+        except FileNotFoundError:
+            continue
+        removed.append(sidecar)
+    return tuple(removed)
+
+
+def _temp_path(parent: Path, final_name: str) -> Path:
+    fd, raw = tempfile.mkstemp(
+        prefix=f".{final_name}.tmp-",
+        suffix=".sqlite",
+        dir=parent,
+    )
+    os.close(fd)
+    path = Path(raw)
+    path.unlink()
+    return path
+
+
+def create_backup(
+    destination: str | os.PathLike[str],
+    *,
+    source: str | os.PathLike[str] | None = None,
+    replace: bool = False,
+    timeout: float = 30.0,
+) -> BackupResult:
+    """Copy a live SQLite database into one integrity-checked file.
+
+    ``VACUUM INTO`` reads a consistent snapshot through a normal SQLite
+    connection, so committed frames still living in the source WAL are included
+    without asking other thread-keeper writers to stop.
+    """
+    src = _expand(source) if source is not None else _default_db_path()
+    dst = _expand(destination)
+    if not src.exists():
+        raise BackupError(f"source database does not exist: {src}")
+    if dst.exists() and not replace:
+        raise BackupError(f"destination exists; pass --replace: {dst}")
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    tmp = _temp_path(dst.parent, dst.name)
+    try:
+        src_conn = _connect_ro(src, timeout=timeout)
+        try:
+            src_conn.execute(f"PRAGMA busy_timeout={int(timeout * 1000)}")
+            src_conn.execute("VACUUM INTO ?", (str(tmp),))
+        finally:
+            src_conn.close()
+        dst_conn = sqlite3.connect(str(tmp), timeout=timeout)
+        try:
+            _single_file_mode(dst_conn)
+            row = dst_conn.execute("PRAGMA integrity_check").fetchone()
+            integrity = "" if row is None else str(row[0])
+            if integrity != "ok":
+                raise BackupError(f"backup integrity_check failed: {integrity}")
+        finally:
+            dst_conn.close()
+
+        os.chmod(tmp, 0o600)
+        os.replace(tmp, dst)
+        _unlink_sidecars(dst)
+        return BackupResult(
+            source=src,
+            destination=dst,
+            integrity=integrity,
+            bytes_written=dst.stat().st_size,
+        )
+    except Exception:
+        try:
+            tmp.unlink()
+        except FileNotFoundError:
+            pass
+        _unlink_sidecars(tmp)
+        raise
+
+
+def restore_backup(
+    source: str | os.PathLike[str],
+    *,
+    destination: str | os.PathLike[str] | None = None,
+    timeout: float = 30.0,
+) -> RestoreResult:
+    """Atomically replace the store with an integrity-checked backup file.
+
+    Callers must stop thread-keeper/CLI processes first. Replacing a SQLite
+    database while another process has it open can leave that process writing to
+    the old unlinked file.
+    """
+    src = _expand(source)
+    dst = _expand(destination) if destination is not None else _default_db_path()
+    if not src.exists():
+        raise BackupError(f"backup file does not exist: {src}")
+    integrity = _integrity_check(src, timeout=timeout)
+    if integrity != "ok":
+        raise BackupError(f"backup integrity_check failed: {integrity}")
+
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    tmp = _temp_path(dst.parent, dst.name)
+    removed: tuple[Path, ...] = ()
+    try:
+        shutil.copyfile(src, tmp)
+        os.chmod(tmp, 0o600)
+        rw = sqlite3.connect(str(tmp), timeout=timeout)
+        try:
+            _single_file_mode(rw)
+            check = rw.execute("PRAGMA integrity_check").fetchone()
+            restored_integrity = "" if check is None else str(check[0])
+            if restored_integrity != "ok":
+                raise BackupError(
+                    f"restored copy integrity_check failed: {restored_integrity}"
+                )
+        finally:
+            rw.close()
+
+        removed = _unlink_sidecars(dst)
+        os.replace(tmp, dst)
+        removed = removed + _unlink_sidecars(dst)
+        final_integrity = _integrity_check(dst, timeout=timeout)
+        if final_integrity != "ok":
+            raise BackupError(
+                f"restored database integrity_check failed: {final_integrity}"
+            )
+        return RestoreResult(
+            source=src,
+            destination=dst,
+            integrity=final_integrity,
+            removed_sidecars=removed,
+        )
+    except Exception:
+        try:
+            tmp.unlink()
+        except FileNotFoundError:
+            pass
+        _unlink_sidecars(tmp)
+        raise
+
+
+def _positive_float(raw: str) -> float:
+    value = float(raw)
+    if value <= 0:
+        raise argparse.ArgumentTypeError("must be > 0")
+    return value
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="tk-backup",
+        description="Create or restore consistent thread-keeper SQLite snapshots.",
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    create = sub.add_parser(
+        "create",
+        help="write a consistent single-file snapshot from the live SQLite store",
+    )
+    create.add_argument("destination", help="backup sqlite file to create")
+    create.add_argument("--db", dest="db", help="source DB path")
+    create.add_argument("--replace", action="store_true", help="replace destination")
+    create.add_argument(
+        "--timeout",
+        type=_positive_float,
+        default=30.0,
+        help="SQLite busy timeout in seconds (default: 30)",
+    )
+
+    restore = sub.add_parser(
+        "restore",
+        help="replace the store with a previously created backup",
+    )
+    restore.add_argument("source", help="backup sqlite file to restore")
+    restore.add_argument("--db", dest="db", help="destination DB path")
+    restore.add_argument(
+        "--timeout",
+        type=_positive_float,
+        default=30.0,
+        help="SQLite busy timeout in seconds (default: 30)",
+    )
+    restore.add_argument(
+        "--yes",
+        action="store_true",
+        help="confirm thread-keeper/CLI processes have been stopped",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    started = time.time()
+    try:
+        if args.command == "create":
+            result = create_backup(
+                args.destination,
+                source=args.db,
+                replace=args.replace,
+                timeout=args.timeout,
+            )
+            elapsed = time.time() - started
+            print(
+                "ok backup "
+                f"source={result.source} dest={result.destination} "
+                f"bytes={result.bytes_written} integrity={result.integrity} "
+                f"elapsed_s={elapsed:.2f}"
+            )
+            return 0
+        if args.command == "restore":
+            if not args.yes:
+                parser.error(
+                    "restore is destructive; stop thread-keeper/CLI processes "
+                    "first, then pass --yes"
+                )
+            result = restore_backup(
+                args.source,
+                destination=args.db,
+                timeout=args.timeout,
+            )
+            elapsed = time.time() - started
+            removed = ",".join(str(p) for p in result.removed_sidecars) or "none"
+            print(
+                "ok restored "
+                f"source={result.source} dest={result.destination} "
+                f"integrity={result.integrity} removed_sidecars={removed} "
+                f"elapsed_s={elapsed:.2f}"
+            )
+            return 0
+    except BackupError as exc:
+        print(f"ERR {exc}", file=sys.stderr)
+        return 1
+    parser.error(f"unknown command: {args.command}")
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Add `tk-backup create` using SQLite `VACUUM INTO` for consistent single-file snapshots of the live WAL store.
- Add `tk-backup restore --yes` to verify a backup, atomically replace the store, and remove stale WAL/SHM sidecars.
- Update README, architecture, roadmap, and changelog storage guidance away from raw live `cp` backups.

## Tests
- `env -u THREADKEEPER_NO_EMBEDDINGS .venv/bin/python -m pytest -q` exited 0.
- `env -u THREADKEEPER_NO_EMBEDDINGS .venv/bin/python -m pytest -o addopts='--strict-markers'` reported 1150 passed, 1 skipped, 95 warnings.

Closes #102