### PR TITLE
fix: recover stale evolve merges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -390,6 +390,15 @@ version bumps follow semver per the policy in
   `origin/main` / configured base ref, and refuse to overlap reviewer/applier
   git writers in the shared checkout.
 
+- **Evolve managed-checkout stale-merge recovery.** An interrupted PR-conflict
+  repair can no longer leave every later backlog item permanently blocked by
+  `skipped_dirty_worktree` after that PR was merged elsewhere. For the default
+  auto-managed checkout only, the parent now verifies the exact applier branch
+  is `MERGED` on GitHub, archives its tracked diff under
+  `~/.threadkeeper/evolve-recovery/`, and restores the fresh configured origin
+  base before dispatch continues. Live writers, explicit checkouts, and
+  uncertain/open PR states remain fail-closed.
+
 - **Task retention and spool GC (#42).** `consolidate()` now reports and
   applies retention for ended `tasks` rows using
   `THREADKEEPER_TASK_RETENTION_DAYS` (30d default) and

--- a/README.md
+++ b/README.md
@@ -788,7 +788,16 @@ base branch and create feature branches from `origin/main` (or the configured
 `THREADKEEPER_EVOLVE_REPO_BRANCH`), not from whatever `HEAD` the daemon happens
 to have checked out. A shared git-writer running-task check prevents the
 privileged reviewer audit and code/PR applier from overlapping in the same
-checkout.
+checkout. If a killed conflict-repair child leaves an unresolved merge in the
+default auto-managed checkout, the next code-applying pass can recover it — but
+only when the current branch is `roadmap/…`/`evolve/…` and GitHub confirms that
+exact PR is already merged. Before returning the managed tree to fresh
+`origin/<THREADKEEPER_EVOLVE_REPO_BRANCH>`, thread-keeper archives the tracked
+diff under
+`~/.threadkeeper/evolve-recovery/stale-merge-pr-*.patch` and records
+`recovered_stale_merge` telemetry. Open, closed-unmerged, missing, or
+unreadable PR state remains fail-closed. An explicit
+`THREADKEEPER_EVOLVE_REPO_ROOT` is never auto-reset.
 
 **Skip-label gate.** Autonomous issue pickup refuses issues with labels listed
 in `THREADKEEPER_EVOLVE_APPLY_SKIP_LABELS` (default

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -589,7 +589,16 @@ moving the high-water forward; `force=True` bypasses this due gate.
   base ref (`origin/main` by default, or `origin/<EVOLVE_REPO_BRANCH>`) instead
   of arbitrary current `HEAD`; reviewer roadmap-doc prompts additionally reuse
   the daily `docs/roadmap-audit-YYYY-MM-DD` branch or an existing open
-  roadmap-doc PR branch so repeated audits do not collide.
+  roadmap-doc PR branch so repeated audits do not collide. The running-writer
+  check precedes dirty-state recovery so active child WIP is never discarded.
+  For the default auto-managed checkout only, an in-progress merge on an
+  applier-owned branch is treated as recoverable when GitHub proves the exact
+  PR is already merged. The parent fetches the configured base, archives the
+  tracked diff as an owner-only (`0600`)
+  `DB_PATH.parent/evolve-recovery/stale-merge-pr-*.patch`, then
+  hard-resets the disposable checkout and switches it to fresh `origin/main`
+  (or the configured base). Unknown/open/closed-unmerged PR state and explicit
+  operator checkouts remain fail-closed with `skipped_dirty_worktree`.
 - **curator → evolve bridge** — the Curator's lessons/skills audit remains
   snapshot-first and report-first: destructive mode writes a recoverable
   snapshot before spawning the child, then the child writes its REPORT before

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -81,6 +81,12 @@ remains a live question.
   overlapping reviewer/applier git writers in the shared checkout, and prompts
   children to fetch and branch from `origin/main` / `origin/<EVOLVE_REPO_BRANCH>`
   instead of arbitrary current `HEAD`.
+- Evolve managed-checkout stale-merge recovery: a killed conflict-repair child
+  no longer blocks the entire backlog after its PR was merged elsewhere. The
+  parent first excludes live git writers, requires the default managed checkout
+  plus an applier-owned branch and an exact GitHub `MERGED` state, archives the
+  tracked diff under `evolve-recovery/`, and returns the checkout to the fetched
+  base. Explicit operator checkouts and uncertain PR states remain fail-closed.
 - Evolve reviewer roadmap-doc PR dedup (#54): before spawning the privileged
   audit child, the parent checks open PRs for automation-owned changes touching
   `docs/ROADMAP.md`; the prompt tells the reviewer to append/skip when one

--- a/tests/test_evolve_applier.py
+++ b/tests/test_evolve_applier.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import json
 import logging
+import subprocess
 import sys
 import time
 from pathlib import Path
@@ -923,7 +924,8 @@ def test_fetch_open_prs_reads_mergeability_fields(tmp_path, monkeypatch):
 
     assert err == ""
     assert [int(pr["number"]) for pr in prs] == [22]
-    joined = " ".join(calls[0])
+    gh_call = next(cmd for cmd in calls if cmd[:3] == ["gh", "pr", "list"])
+    joined = " ".join(gh_call)
     assert "mergeStateStatus" in joined
     assert "mergeable" in joined
     assert "isCrossRepository" in joined
@@ -1026,6 +1028,9 @@ def test_apply_roadmap_issue_skips_dirty_worktree_and_records_event(
         lambda conn: [],
     )
     monkeypatch.setattr(
+        pkg["ea"], "_managed_repo_auto_recovery_allowed", lambda repo: False,
+    )
+    monkeypatch.setattr(
         pkg["ea"], "_fetch_open_issues",
         lambda repo_root=None: ([_issue(6, "Telemetry dashboard")], ""),
     )
@@ -1051,6 +1056,228 @@ def test_apply_roadmap_issue_skips_dirty_worktree_and_records_event(
     ).fetchone()
     assert row["target"] == "roadmap_issue"
     assert row["summary"] == "skipped_dirty_worktree mode=git"
+
+
+def test_managed_checkout_recovers_stale_merge_after_pr_merged(
+    tmp_path, monkeypatch,
+):
+    """A killed repair child must not leave the whole backlog blocked forever.
+
+    Recovery is restricted to the auto-managed checkout and archives the
+    tracked merge diff before returning the tree to the fresh configured base.
+    """
+    pkg = _bootstrap(tmp_path, monkeypatch, pin_repo=False)
+    conn = pkg["db"].get_db()
+    monkeypatch.setattr(
+        pkg["ea"], "_git_worktree_precondition",
+        pkg["orig"]["_git_worktree_precondition"],
+    )
+    repo = pkg["ea"]._managed_repo_dir()
+    remote = tmp_path / "remote.git"
+
+    def git(*args, check=True):
+        proc = subprocess.run(
+            ["git", "-C", str(repo), *args],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        if check and proc.returncode != 0:
+            raise AssertionError(proc.stderr or proc.stdout)
+        return proc
+
+    repo.mkdir(parents=True)
+    subprocess.run(
+        ["git", "init", "--bare", str(remote)],
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+    git("init", "-b", "main")
+    git("config", "user.email", "test@example.com")
+    git("config", "user.name", "Test")
+    (repo / "shared.txt").write_text("base\n", encoding="utf-8")
+    git("add", "shared.txt")
+    git("commit", "-m", "base")
+    git("remote", "add", "origin", str(remote))
+    git("push", "-u", "origin", "main")
+
+    branch = "roadmap/issue-7-stale-repair"
+    git("checkout", "-b", branch)
+    (repo / "shared.txt").write_text("issue\n", encoding="utf-8")
+    git("commit", "-am", "issue")
+    git("push", "-u", "origin", branch)
+    git("checkout", "main")
+    (repo / "shared.txt").write_text("main\n", encoding="utf-8")
+    git("commit", "-am", "main change")
+    git("push", "origin", "main")
+    git("checkout", branch)
+    conflicted = git("merge", "origin/main", check=False)
+    assert conflicted.returncode != 0
+    assert git("rev-parse", "-q", "--verify", "MERGE_HEAD").returncode == 0
+
+    monkeypatch.setattr(
+        pkg["ea"], "_prs_for_head_branch",
+        lambda head, repo_root=None: ([{
+            "number": 7,
+            "state": "MERGED",
+            "mergedAt": "2026-07-12T10:28:56Z",
+            "headRefName": branch,
+            "url": "https://github.com/o/r/pull/7",
+        }], ""),
+    )
+    monkeypatch.setattr(
+        pkg["ea"], "_running_git_writer_children", lambda _conn: [],
+    )
+
+    out = pkg["ea"]._git_worktree_precondition(
+        conn, repo, "roadmap_issue"
+    )
+
+    assert out == ""
+    assert git("branch", "--show-current").stdout.strip() == "main"
+    assert git("status", "--porcelain", "--untracked-files=no").stdout == ""
+    assert git(
+        "rev-parse", "-q", "--verify", "MERGE_HEAD", check=False
+    ).returncode == 1
+    backups = list(
+        (tmp_path / "evolve-recovery").glob("stale-merge-pr-7-*.patch")
+    )
+    assert len(backups) == 1
+    assert "diff --git" in backups[0].read_text(encoding="utf-8")
+    assert backups[0].stat().st_mode & 0o777 == 0o600
+    row = conn.execute(
+        "SELECT target, summary FROM events WHERE kind=? ORDER BY id DESC",
+        (pkg["ea"].EVOLVE_GIT_SAFETY_KIND,),
+    ).fetchone()
+    assert row["target"] == "roadmap_issue"
+    assert "recovered_stale_merge pr=#7" in row["summary"]
+    assert backups[0].name in row["summary"]
+
+
+def test_explicit_checkout_never_auto_recovers_dirty_merge(
+    tmp_path, monkeypatch,
+):
+    pkg = _bootstrap(tmp_path, monkeypatch)
+    conn = pkg["db"].get_db()
+    monkeypatch.setattr(
+        pkg["ea"], "_git_worktree_precondition",
+        pkg["orig"]["_git_worktree_precondition"],
+    )
+    monkeypatch.setattr(pkg["ea"], "EVOLVE_REPO_ROOT", "/operator/repo")
+    monkeypatch.setattr(
+        pkg["ea"], "_tracked_worktree_status",
+        lambda repo_root: ("UU CHANGELOG.md", ""),
+    )
+    monkeypatch.setattr(
+        pkg["ea"], "_running_git_writer_children", lambda _conn: [],
+    )
+
+    out = pkg["ea"]._git_worktree_precondition(
+        conn, Path("/operator/repo"), "roadmap_issue"
+    )
+
+    assert out == "skipped_dirty_worktree mode=git"
+
+
+def test_managed_checkout_keeps_open_pr_merge_fail_closed(
+    tmp_path, monkeypatch,
+):
+    pkg = _bootstrap(tmp_path, monkeypatch)
+    branch = "roadmap/issue-7-still-open"
+    monkeypatch.setattr(
+        pkg["ea"], "_managed_repo_auto_recovery_allowed", lambda repo: True,
+    )
+    monkeypatch.setattr(pkg["ea"], "_merge_in_progress", lambda repo: (True, ""))
+    monkeypatch.setattr(pkg["ea"], "_current_branch", lambda repo: (branch, ""))
+    monkeypatch.setattr(
+        pkg["ea"], "_prs_for_head_branch",
+        lambda head, repo_root=None: ([{
+            "number": 7,
+            "state": "OPEN",
+            "mergedAt": None,
+            "headRefName": branch,
+        }], ""),
+    )
+    monkeypatch.setattr(
+        pkg["ea"], "_archive_stale_merge_diff",
+        lambda *args: (_ for _ in ()).throw(
+            AssertionError("open PR state must never be reset")
+        ),
+    )
+
+    recovered, reason = pkg["ea"]._recover_stale_managed_merge(
+        tmp_path / "repo"
+    )
+
+    assert recovered is False
+    assert reason == "stale_merge_pr_not_merged=#7:OPEN"
+
+
+def test_prs_for_head_branch_filters_cross_repository_matches(
+    tmp_path, monkeypatch,
+):
+    pkg = _bootstrap(tmp_path, monkeypatch)
+    branch = "roadmap/issue-7-stale-repair"
+
+    class _Proc:
+        returncode = 0
+        stderr = ""
+        stdout = json.dumps([
+            {
+                "number": 70,
+                "state": "MERGED",
+                "mergedAt": "2026-07-12T10:28:56Z",
+                "headRefName": branch,
+                "isCrossRepository": True,
+            },
+            {
+                "number": 7,
+                "state": "MERGED",
+                "mergedAt": "2026-07-12T10:28:56Z",
+                "headRefName": branch,
+                "isCrossRepository": False,
+            },
+        ])
+
+    seen = {}
+
+    def run_gh(cmd, **kwargs):
+        seen["cmd"] = cmd
+        return _Proc()
+
+    monkeypatch.setattr(pkg["ea"], "_run_gh", run_gh)
+
+    prs, err = pkg["ea"]._prs_for_head_branch(branch, tmp_path)
+
+    assert err == ""
+    assert [pr["number"] for pr in prs] == [7]
+    assert seen["cmd"][seen["cmd"].index("--state") + 1] == "all"
+    assert seen["cmd"][seen["cmd"].index("--head") + 1] == branch
+
+
+def test_live_git_writer_wins_before_dirty_recovery(tmp_path, monkeypatch):
+    pkg = _bootstrap(tmp_path, monkeypatch)
+    conn = pkg["db"].get_db()
+    monkeypatch.setattr(
+        pkg["ea"], "_git_worktree_precondition",
+        pkg["orig"]["_git_worktree_precondition"],
+    )
+    monkeypatch.setattr(
+        pkg["ea"], "_running_git_writer_children", lambda _conn: ["tk_live"],
+    )
+    monkeypatch.setattr(
+        pkg["ea"], "_tracked_worktree_status",
+        lambda repo_root: (_ for _ in ()).throw(
+            AssertionError("must not inspect/recover a live writer's WIP")
+        ),
+    )
+
+    out = pkg["ea"]._git_worktree_precondition(
+        conn, tmp_path / "repo", "roadmap_issue"
+    )
+
+    assert out == "evolve_git_writer_running n=1"
 
 
 def test_apply_roadmap_issue_blocks_during_reviewer_audit_git_writer(
@@ -2320,3 +2547,25 @@ def test_evolve_apply_status_surfaces_conflicted_prs(tmp_path, monkeypatch):
     assert "conflicted_prs=1" in out
     assert "conflicted PRs (next first):" in out
     assert "#44  roadmap/issue-44-conflict-aaaaaa" in out
+
+
+def test_evolve_apply_status_surfaces_stale_merge_recovery(
+    tmp_path, monkeypatch,
+):
+    pkg = _bootstrap(tmp_path, monkeypatch, interval="604800")
+    conn = pkg["db"].get_db()
+    conn.execute(
+        "INSERT INTO events (session_id, kind, target, summary, created_at) "
+        "VALUES (?, 'evolve_git_safety', 'roadmap_issue', ?, ?)",
+        (
+            "s_test",
+            "recovered_stale_merge pr=#7 branch=roadmap/issue-7 "
+            "backup=stale-merge-pr-7.patch",
+            int(time.time()),
+        ),
+    )
+    conn.commit()
+
+    out = _tool(pkg, "evolve_apply_status")()
+
+    assert "evolve_git_safety: recovered_stale_merge pr=#7" in out

--- a/tests/test_evolve_daemon.py
+++ b/tests/test_evolve_daemon.py
@@ -419,6 +419,9 @@ def test_run_evolve_pass_audit_skips_dirty_worktree_and_records_event(
         pkg["ea"], "_running_git_writer_children",
         lambda conn: [],
     )
+    monkeypatch.setattr(
+        pkg["ea"], "_managed_repo_auto_recovery_allowed", lambda repo: False,
+    )
 
     def _boom(**kw):
         raise AssertionError("must not spawn reviewer audit from dirty checkout")

--- a/threadkeeper/evolve_applier.py
+++ b/threadkeeper/evolve_applier.py
@@ -37,7 +37,11 @@ work applied without a real PR URL; the conflict-repair path is the only
 autoland exception and may merge an already-open same-repo applier PR after
 resolving conflicts and passing tests. Before any git-writing child is spawned,
 the parent refuses dirty tracked files and refuses to overlap reviewer/applier
-git writers in the shared checkout.
+git writers in the shared checkout. A stale interrupted merge in the dedicated
+managed checkout is recovered only after GitHub proves its applier PR is
+already merged; the tracked diff is archived before the checkout returns to
+the fresh configured origin base. Explicit operator checkouts are never
+auto-reset.
 """
 
 from __future__ import annotations
@@ -203,6 +207,7 @@ PR_METADATA_DATA_TAG = "github_pr_metadata_data"
 APPLIER_BRANCH_PREFIXES = ("roadmap/", "evolve/")
 CONFLICTING_PR_MERGE_STATES = {"DIRTY"}
 CONFLICTING_PR_MERGEABLE_STATES = {"CONFLICTING"}
+STALE_MERGE_BACKUP_MAX_BYTES = 10 * 1024 * 1024
 
 
 def _fence_untrusted_data(tag: str, text: str, limit: int = 20000) -> str:
@@ -606,6 +611,236 @@ def _tracked_worktree_status(repo_root: Path) -> tuple[str, str]:
     return (proc.stdout or "").strip(), ""
 
 
+def _managed_repo_auto_recovery_allowed(repo_root: Path) -> bool:
+    """True only for thread-keeper's disposable, auto-managed checkout.
+
+    An explicit ``THREADKEEPER_EVOLVE_REPO_ROOT`` may contain operator work,
+    even when it happens to point under the thread-keeper state directory. It
+    must retain the normal fail-closed dirty-worktree behavior.
+    """
+    if (EVOLVE_REPO_ROOT or "").strip() or not EVOLVE_AUTO_CLONE:
+        return False
+    try:
+        return repo_root.expanduser().resolve() == _managed_repo_dir().resolve()
+    except OSError:
+        return False
+
+
+def _merge_in_progress(repo_root: Path) -> tuple[bool, str]:
+    """Return whether ``repo_root`` has an unresolved/in-progress merge."""
+    try:
+        proc = subprocess.run(
+            ["git", "-C", str(repo_root), "rev-parse", "-q", "--verify",
+             "MERGE_HEAD"],
+            text=True,
+            capture_output=True,
+            timeout=10,
+            check=False,
+        )
+    except FileNotFoundError:
+        return False, "git_not_found"
+    except subprocess.TimeoutExpired:
+        return False, "git_merge_probe_timeout"
+    except OSError as e:
+        return False, f"git_merge_probe_error: {e}"
+    if proc.returncode == 0:
+        return True, ""
+    if proc.returncode == 1 and not (proc.stderr or proc.stdout or "").strip():
+        return False, ""
+    return False, _short(
+        proc.stderr or proc.stdout or f"exit={proc.returncode}"
+    )
+
+
+def _current_branch(repo_root: Path) -> tuple[str, str]:
+    try:
+        proc = subprocess.run(
+            ["git", "-C", str(repo_root), "branch", "--show-current"],
+            text=True,
+            capture_output=True,
+            timeout=10,
+            check=False,
+        )
+    except FileNotFoundError:
+        return "", "git_not_found"
+    except subprocess.TimeoutExpired:
+        return "", "git_branch_timeout"
+    except OSError as e:
+        return "", f"git_branch_error: {e}"
+    if proc.returncode != 0:
+        return "", _short(
+            proc.stderr or proc.stdout or f"exit={proc.returncode}"
+        )
+    return (proc.stdout or "").strip(), ""
+
+
+def _prs_for_head_branch(
+    branch: str,
+    repo_root: Optional[Path] = None,
+) -> tuple[list[dict], str]:
+    """All same-repository PR states for one exact head branch."""
+    repo = str(repo_root or _repo_root())
+    cmd = [
+        "gh", "pr", "list",
+        "--state", "all",
+        "--head", branch,
+        "--json", "number,state,mergedAt,headRefName,url,isCrossRepository",
+        "--limit", "10",
+    ]
+    try:
+        proc = _run_gh(cmd, cwd=repo, timeout=30)
+    except FileNotFoundError:
+        return [], "gh_not_found"
+    except subprocess.TimeoutExpired:
+        return [], "gh_pr_list_timeout"
+    except OSError as e:
+        return [], f"gh_pr_list_error: {e}"
+    if proc.returncode != 0:
+        err = (proc.stderr or proc.stdout or "").strip().splitlines()
+        msg = err[-1] if err else f"exit={proc.returncode}"
+        return [], f"gh_pr_list_failed: {msg[:180]}"
+    try:
+        data = json.loads(proc.stdout or "[]")
+    except json.JSONDecodeError as e:
+        return [], f"gh_pr_list_bad_json: {e}"
+    if not isinstance(data, list):
+        return [], "gh_pr_list_bad_shape"
+    return [
+        item for item in data
+        if isinstance(item, dict)
+        and str(item.get("headRefName") or "") == branch
+        and not bool(item.get("isCrossRepository"))
+    ], ""
+
+
+def _archive_stale_merge_diff(
+    repo_root: Path,
+    pr_number: int,
+) -> tuple[Optional[Path], str]:
+    """Persist the tracked stale-merge diff before resetting managed state."""
+    try:
+        proc = subprocess.run(
+            ["git", "-C", str(repo_root), "diff", "--binary", "HEAD", "--"],
+            text=True,
+            capture_output=True,
+            timeout=30,
+            check=False,
+        )
+    except FileNotFoundError:
+        return None, "git_not_found"
+    except subprocess.TimeoutExpired:
+        return None, "git_diff_timeout"
+    except OSError as e:
+        return None, f"git_diff_error: {e}"
+    if proc.returncode != 0:
+        return None, _short(
+            proc.stderr or proc.stdout or f"exit={proc.returncode}"
+        )
+    diff = proc.stdout or ""
+    if len(diff.encode("utf-8")) > STALE_MERGE_BACKUP_MAX_BYTES:
+        return None, "stale_merge_diff_too_large"
+    backup_dir = DB_PATH.parent / "evolve-recovery"
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S%fZ")
+    path = backup_dir / f"stale-merge-pr-{int(pr_number)}-{stamp}.patch"
+    tmp = path.with_suffix(".patch.tmp")
+    try:
+        backup_dir.mkdir(parents=True, exist_ok=True)
+        backup_dir.chmod(0o700)
+        tmp.write_text(diff, encoding="utf-8")
+        tmp.chmod(0o600)
+        tmp.replace(path)
+    except OSError as e:
+        try:
+            tmp.unlink(missing_ok=True)
+        except OSError:
+            pass
+        return None, f"stale_merge_backup_write_failed: {e}"
+    return path, ""
+
+
+def _recover_stale_managed_merge(
+    repo_root: Path,
+) -> tuple[bool, str]:
+    """Recover an orphaned merge only when its applier PR is already merged.
+
+    The managed checkout is shared across passes, so a killed conflict-repair
+    child can otherwise block every future backlog item. This recovery is
+    intentionally narrow: managed checkout, merge in progress, applier-owned
+    branch, exact GitHub PR proven merged, archived tracked diff. Any uncertain
+    state remains fail-closed for a human.
+    """
+    if not _managed_repo_auto_recovery_allowed(repo_root):
+        return False, ""
+    merging, merge_err = _merge_in_progress(repo_root)
+    if merge_err:
+        return False, f"stale_merge_probe_failed={_short(merge_err)}"
+    if not merging:
+        return False, ""
+    branch, branch_err = _current_branch(repo_root)
+    if branch_err:
+        return False, f"stale_merge_branch_failed={_short(branch_err)}"
+    if not branch.startswith(APPLIER_BRANCH_PREFIXES):
+        return False, f"stale_merge_non_applier_branch={_short(branch or '?')}"
+    prs, pr_err = _prs_for_head_branch(branch, repo_root)
+    if pr_err:
+        return False, f"stale_merge_pr_fetch_failed={_short(pr_err)}"
+    if not prs:
+        return False, "stale_merge_pr_not_found"
+    merged = next(
+        (
+            pr for pr in prs
+            if str(pr.get("state") or "").upper() == "MERGED"
+            or bool(pr.get("mergedAt"))
+        ),
+        None,
+    )
+    if merged is None:
+        state = str(prs[0].get("state") or "UNKNOWN").upper()
+        return False, (
+            f"stale_merge_pr_not_merged=#{int(prs[0].get('number') or 0)}"
+            f":{state}"
+        )
+    pr_number = int(merged.get("number") or 0)
+    if pr_number <= 0:
+        return False, "stale_merge_pr_number_invalid"
+
+    fetch_err = _run(
+        ["git", "fetch", "origin", _base_branch_name()],
+        timeout=60,
+        cwd=repo_root,
+    )
+    if fetch_err:
+        return False, f"stale_merge_fetch_failed={_short(fetch_err)}"
+    backup, backup_err = _archive_stale_merge_diff(repo_root, pr_number)
+    if backup_err or backup is None:
+        return False, f"stale_merge_backup_failed={_short(backup_err)}"
+
+    reset_err = _run(
+        ["git", "reset", "--hard", "HEAD"], timeout=30, cwd=repo_root
+    )
+    if reset_err:
+        return False, f"stale_merge_reset_failed={_short(reset_err)}"
+    checkout_err = _run(
+        [
+            "git", "checkout", "-f", "-B", _base_branch_name(),
+            _base_ref(),
+        ],
+        timeout=30,
+        cwd=repo_root,
+    )
+    if checkout_err:
+        return False, f"stale_merge_checkout_failed={_short(checkout_err)}"
+    dirty, status_err = _tracked_worktree_status(repo_root)
+    if status_err:
+        return False, f"stale_merge_recheck_failed={_short(status_err)}"
+    if dirty:
+        return False, "stale_merge_recovery_left_dirty"
+    return True, (
+        f"recovered_stale_merge pr=#{pr_number} branch={_short(branch, 80)} "
+        f"backup={backup.name}"
+    )
+
+
 def _record_git_safety_event(
     conn: sqlite3.Connection,
     actor: str,
@@ -671,18 +906,33 @@ def _git_worktree_precondition(
     Untracked scratch files intentionally do not block, matching auto_update's
     `git status --porcelain --untracked-files=no` safety contract.
     """
+    # Check durable/live writer state before inspecting dirty files: a current
+    # child owns its WIP and must never be mistaken for an orphan eligible for
+    # managed-checkout recovery.
+    running = _running_git_writer_children(conn)
+    if running:
+        outcome = f"evolve_git_writer_running n={len(running)}"
+        _record_git_safety_event(conn, actor, outcome)
+        return outcome
     dirty, err = _tracked_worktree_status(repo_root)
     if err:
         outcome = f"ERR git_status_failed mode=git err={err}"
         _record_git_safety_event(conn, actor, outcome)
         return outcome
     if dirty:
+        recovered, recovery = _recover_stale_managed_merge(repo_root)
+        if recovered:
+            _record_git_safety_event(conn, actor, recovery)
+            dirty, err = _tracked_worktree_status(repo_root)
+            if err:
+                outcome = f"ERR git_status_failed mode=git err={err}"
+                _record_git_safety_event(conn, actor, outcome)
+                return outcome
+            if not dirty:
+                return ""
         outcome = "skipped_dirty_worktree mode=git"
-        _record_git_safety_event(conn, actor, outcome)
-        return outcome
-    running = _running_git_writer_children(conn)
-    if running:
-        outcome = f"evolve_git_writer_running n={len(running)}"
+        if recovery:
+            outcome += f" reason={_short(recovery)}"
         _record_git_safety_event(conn, actor, outcome)
         return outcome
     return ""

--- a/threadkeeper/tools/evolve_applier.py
+++ b/threadkeeper/tools/evolve_applier.py
@@ -28,7 +28,7 @@
 
   evolve_apply_status()
     Diagnostic: interval knob, promoted+unapplied queue, running applier, and
-    the last few apply passes.
+    the last few apply/recovery passes.
 """
 
 from __future__ import annotations
@@ -172,7 +172,7 @@ def evolve_mark_curator_report_applied(report_path: str, summary: str) -> str:
 @read_tool()
 def evolve_apply_status() -> str:
     """Show evolve-applier config + curator/evolve queues + running applier
-    + the last 5 apply passes."""
+    + the last 5 apply/recovery passes."""
     conn = get_db()
     _ensure_session(conn)
     reports = _pending_curator_reports(conn)
@@ -253,6 +253,8 @@ def evolve_apply_status() -> str:
             "WHERE kind IN ('evolve_apply_pass', 'curator_report_applied', "
             "'evolve_applied', 'roadmap_issue_applied', "
             "'roadmap_issue_requeued', 'roadmap_issue_dead_letter') "
+            "OR (kind='evolve_git_safety' "
+            "AND summary LIKE 'recovered_stale_merge%') "
             "ORDER BY created_at DESC, id DESC LIMIT 5"
         ).fetchall()
     except Exception:


### PR DESCRIPTION
## Summary
- recover an interrupted merge only in the auto-managed evolve checkout after GitHub proves the exact same-repository applier PR is merged
- archive the tracked diff with owner-only permissions before restoring the configured origin base
- keep live writers, explicit checkouts, open/unknown PRs, and oversized/unarchivable diffs fail-closed
- surface successful recovery in evolve apply status and document the behavior

## Validation
- targeted evolve applier and evolve daemon suites passed
- full suite passed in four alphabetical chunks; the single invocation was externally terminated at 30 minutes while still running
- live managed checkout restored to clean origin/main
- forced live queue pass spawned roadmap issue 100 instead of skipped_dirty_worktree