### PR TITLE
fix: enforce protected memory deletes server-side

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,14 @@ version bumps follow semver per the policy in
 
 ### Fixed
 
+- **Protected memory is enforced server-side (#100).** New lesson sections now
+  stamp `origin=<THREADKEEPER_WRITE_ORIGIN>` separately from the free-text
+  `source`, and `lesson_remove` keys its refusal on that origin. Foreground,
+  legacy, empty, or unknown-origin lessons fail closed unless a foreground
+  writer explicitly passes `force=True`; curator/spawned force is ignored.
+  `skill_manage(action='delete')` now mirrors the same guard for foreground or
+  unknown `created_by_origin`, while pinned skills remain undeletable. Curator
+  inventory marks those entries `[PROTECTED]` using the same predicates.
 - **All background daemon starters now honor `BACKGROUND_DAEMONS_ALLOWED`.**
   `search_proxy`, `skill_watcher`, `spawn_budget`, and the background ingester
   started unconditionally, ignoring the spawned-child / `DISABLE_BG_DAEMONS`
@@ -981,8 +989,8 @@ version bumps follow semver per the policy in
   lessons (previously it could only delete skills and rewrite same-slug
   lessons, so lesson-level PRUNE/CONSOLIDATE recommendations were never
   applied). `[PROTECTED]` (foreground/user/pinned/validated) entries are never
-  mutated, and `lesson_remove` is always called without `force`, so it refuses
-  user/foreground-authored lessons by design.
+  mutated; as of #100, lesson and skill delete paths also enforce protected
+  provenance server-side.
 - **Destructive curator deletes now have a recovery path (#41).**
   `lesson_remove` captures the exact removed lesson section plus its usage row
   under `<db dir>/curator/trash/` before rewriting `lessons.md`, and

--- a/README.md
+++ b/README.md
@@ -623,7 +623,8 @@ Every `THREADKEEPER_CURATOR_INTERVAL_S` seconds (default off, 604800
 `~/.threadkeeper/curator/REPORT-<isodate>.md` with KEEP / PATCH /
 CONSOLIDATE / PRUNE recommendations. Pinned and foreground-authored
 entries are marked `[PROTECTED]` in the inventory so the curator
-never proposes destructive changes against them. The pass is
+never proposes destructive changes against them, and delete-class tools
+enforce the same boundary server-side. The pass is
 single-flight across processes — a non-blocking `fcntl.flock` pidfile
 (`<db dir>/curator.lock`) plus a running-children check serialize it, so
 multiple MCP server instances can't run overlapping (now destructive) passes
@@ -645,9 +646,13 @@ Curator applies its own PATCH / PRUNE / CONSOLIDATE directly by default (it
 writes the REPORT first, then mutates — `lesson_remove` is in its toolset so it
 can actually prune and consolidate duplicate lessons). Set
 `THREADKEEPER_CURATOR_DESTRUCTIVE=0` for advisory REPORT-only. It never touches
-`[PROTECTED]` / foreground / user / pinned / validated entries, and
-`lesson_remove` is always called without `force` (so user/foreground lessons are
-refused by design). Before a destructive child is spawned, thread-keeper writes
+`[PROTECTED]` / foreground / user / pinned / validated entries. Lessons are
+stamped with an explicit `origin=<THREADKEEPER_WRITE_ORIGIN>` marker when
+appended; missing, legacy, or unknown lesson provenance is protected by
+default. `lesson_remove` and `skill_manage(action='delete')` refuse protected
+foreground/unknown-origin entries unless `force=True` is called from a
+foreground writer; curator/spawned children cannot elevate themselves with
+`force`. Before a destructive child is spawned, thread-keeper writes
 a recoverable snapshot under
 `<reports_dir>/snapshots/<pass-id>/` (default
 `~/.threadkeeper/curator/snapshots/<pass-id>/`). The snapshot contains
@@ -685,7 +690,9 @@ ranked `STALE LESSONS (dry-run decay ranking)` section computed as
 `access_frequency × exp(-days_since_access / tau)`, filtered to unprotected
 lessons with no recent access and low pull-count. That decay list is advisory
 only; it never becomes an automatic `lesson_remove` path by itself, and pinned
-or validated lessons are excluded.
+or validated lessons are excluded. A lesson is unprotected only when its
+explicit `origin` marker is a known loop origin; foreground, legacy, empty, and
+unknown-origin lessons fail closed.
 
 The curator also audits the `concepts` store (abstract regularities triangulated
 across paraphrase runs). Concepts are no longer write-only: `register_concept`
@@ -984,7 +991,7 @@ The most-used env knobs (full list in `threadkeeper/config.py`):
 | `THREADKEEPER_LEARNING_LOOP_SKILL_CREATE_LIMIT` | 2 | max new skills one autonomous learning-loop child (`candidate_review`, `shadow_review`, or `background_review`) may create in its session; foreground creation is unaffected |
 | `THREADKEEPER_CURATOR_INTERVAL_S` | 0 (off) | curator daemon tick (s), restart-throttled by the last `curator_pass`; 604800 = 7d recommended |
 | `THREADKEEPER_CURATOR_MIN_LESSONS` | 3 | min lessons before curator engages |
-| `THREADKEEPER_CURATOR_DESTRUCTIVE` | `1` (on) | curator child writes its REPORT then applies its own PATCH/PRUNE/CONSOLIDATE directly (incl. `lesson_remove` for prune/consolidate); set `0` for advisory REPORT-only. `[PROTECTED]` entries never mutated |
+| `THREADKEEPER_CURATOR_DESTRUCTIVE` | `1` (on) | curator child writes its REPORT then applies its own PATCH/PRUNE/CONSOLIDATE directly (incl. `lesson_remove` for prune/consolidate); set `0` for advisory REPORT-only. `[PROTECTED]` entries are refused server-side |
 | `THREADKEEPER_CURATOR_SNAPSHOT_RETENTION` | 10 | number of destructive curator pre-mutation snapshots to retain under `<reports_dir>/snapshots`; current pass is always retained |
 | `THREADKEEPER_CURATOR_TRASH_TTL_DAYS` | 30 | days to retain recovery artifacts under `<db dir>/curator/trash` for `lesson_remove` and `skill_manage(action='delete')`; expired artifacts are swept on new trash writes |
 | `THREADKEEPER_PROBE_INTERVAL_S` | 0 (off) | probe daemon tick (s); 1800 = 30 min recommended so finished probe answers are graded promptly |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -981,9 +981,13 @@ Optional subfolders: `references/`, `templates/`, `scripts/`, `assets/`.
   restore trash artifacts with `lesson_restore(slug=...)` or
   `skill_manage(action='restore', name=...)`. Trash is bounded by
   `THREADKEEPER_CURATOR_TRASH_TTL_DAYS` (default 30); expired artifacts are
-  swept on new trash writes. Protected refusal behavior is unchanged:
-  user/foreground lessons still require `force`, and pinned skills still refuse
-  deletion. `mp_dashboard()` renders destructive action counts by window.
+  swept on new trash writes. Protected refusal is server-side: lesson sections
+  carry an explicit `origin=<THREADKEEPER_WRITE_ORIGIN>` marker, and
+  foreground, legacy, empty, or unknown-origin lessons require a foreground
+  `force=True`; non-foreground force is ignored. Skill deletion similarly
+  refuses foreground or unknown `created_by_origin` without foreground force,
+  while pinned skills always refuse deletion. `mp_dashboard()` renders
+  destructive action counts by window.
   The lesson file itself is a separate serialization boundary:
   `append_lesson`, `lesson_remove`, and `lesson_restore` hold a blocking
   `fcntl.flock` on `lessons.md.lock` across file creation/read/mutate/write, so
@@ -991,8 +995,11 @@ Optional subfolders: `references/`, `templates/`, `scripts/`, `assets/`.
   store instead of relying on per-daemon dispatch locks.
 
 - **skill_manage write_origin** — `THREADKEEPER_WRITE_ORIGIN`
-  (`foreground` default | `background_review` | `shadow_review`) is written to
-  `sessions.write_origin` and proxied into `skill_usage.created_by_origin`.
+  (`foreground` default | `background_review` | `shadow_review` | loop-specific
+  origins such as `curator` / `evolve_apply`) is written to
+  `sessions.write_origin`, proxied into `skill_usage.created_by_origin`, and
+  stamped into new lesson sections as `origin=<...>` for server-side protected
+  memory checks.
 
 - **curator_run(stale_after_days, archive_after_days, dry_run=True)** —
   background cleanup of stale agent-created skills. Never touches
@@ -1568,12 +1575,12 @@ unsupported CLI overrides still fall through to the next priority, and
 | `THREADKEEPER_CANDIDATE_REVIEW_MIN` | 3 | min pending candidates before reviewer engages |
 | `THREADKEEPER_CURATOR_INTERVAL_S` | 0 | curator daemon tick, restart-throttled by the last `curator_pass`; 604800 = 7d recommended |
 | `THREADKEEPER_CURATOR_MIN_LESSONS` | 3 | min lessons before curator engages |
-| `THREADKEEPER_CURATOR_DESTRUCTIVE` | `1` | curator child writes its REPORT then applies PATCH/PRUNE/CONSOLIDATE directly; set `0` for advisory-only |
+| `THREADKEEPER_CURATOR_DESTRUCTIVE` | `1` | curator child writes its REPORT then applies PATCH/PRUNE/CONSOLIDATE directly; set `0` for advisory-only; protected entries are refused server-side |
 | `THREADKEEPER_CURATOR_TRASH_TTL_DAYS` | 30 | days to retain `lesson_remove` / `skill_manage(delete)` recovery artifacts under `<db dir>/curator/trash` |
 | `THREADKEEPER_PROBE_INTERVAL_S` | 0 | probe daemon tick; 1800 = 30 min recommended for prompt answer grading |
 | `THREADKEEPER_PROBE_COOLDOWN_S` | 604800 | per-category objective probe cooldown; 86400 = 1d recommended for active reliability tracking |
 | `THREADKEEPER_NO_EMBEDDINGS` | off | force-disable st model (slim children) |
-| `THREADKEEPER_WRITE_ORIGIN` | foreground | provenance tag for curator |
+| `THREADKEEPER_WRITE_ORIGIN` | foreground | provenance tag for sessions, skill rows, and lesson protected-memory markers |
 | `THREADKEEPER_SPAWNED_CHILD` | off | spawn-internal marker; disables autonomous child daemons |
 | `THREADKEEPER_FORCE_CID` | — | test-only / spawn-injected cid override |
 | `THREADKEEPER_SELF_CID_TTL_S` | 5 | mtime-fallback cache TTL |

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -360,10 +360,12 @@ heuristic. `curator_run` now spawns a slim child that grades every lesson +
 recently-active skill (and any concepts) against an explicit rubric
 (KEEP / PATCH / CONSOLIDATE / PRUNE), writes an auditable
 `REPORT-<isodate>.md`, and — **destructive-by-default** — applies its own
-PATCH/PRUNE/CONSOLIDATE directly via `lesson_append` / `lesson_remove`
-(always without `force`, so user/foreground lessons are refused) /
-`skill_manage`. `[PROTECTED]` (pinned / foreground / user) entries are never
-mutated, and the pass is single-flight across processes (a non-blocking
+PATCH/PRUNE/CONSOLIDATE directly via `lesson_append` / `lesson_remove` /
+`skill_manage`. `[PROTECTED]` entries are refused server-side:
+`lesson_append` stamps `origin=<THREADKEEPER_WRITE_ORIGIN>` into each lesson
+section, legacy/unknown-origin lessons fail closed, skill deletion refuses
+foreground/unknown provenance, and non-foreground children cannot escalate with
+`force`. The pass is single-flight across processes (a non-blocking
 `fcntl.flock` pidfile plus a running-children check). The "dry-run mode with
 a dump of what would be archived" this item asked for already exists: set
 `THREADKEEPER_CURATOR_DESTRUCTIVE=0` for advisory REPORT-only.
@@ -393,6 +395,13 @@ high-water before spawning. A recent `curator_pass` or
 `candidate_review_pass` makes fresh MCP-server restarts and non-forced direct
 checks return `not_due` without launching another destructive/expensive child;
 `force=True` still bypasses the interval.
+
+✅ DONE (#100): protected memory is enforced server-side, not only in curator
+prompt text. New lesson sections carry `origin=<THREADKEEPER_WRITE_ORIGIN>`;
+`lesson_remove` keys protection on that origin and treats missing/legacy/unknown
+provenance as protected; `skill_manage(action='delete')` refuses foreground or
+unknown-origin skills; and `force=True` is effective only for foreground
+writers, so curator/spawned children cannot hard-delete protected memory.
 
 Lesson-store decay/eviction scoring is also in place (#27): `lesson_list` /
 `lesson_get` update `lesson_usage` counters, and curator dry runs include a

--- a/tests/test_curator.py
+++ b/tests/test_curator.py
@@ -105,15 +105,17 @@ def test_collect_inventory_empty(tmp_path, monkeypatch):
 
 def test_collect_inventory_counts_lessons_and_skills(tmp_path, monkeypatch):
     pkg = _bootstrap(tmp_path, monkeypatch)
+    monkeypatch.setattr(pkg["lessons"], "WRITE_ORIGIN", "shadow_review")
     pkg["lessons"].append_lesson(
         title="reset wifi proxy before WDA start",
         body="Always read networksetup; if 127.0.0.1, reset.",
         source="shadow",
     )
+    monkeypatch.setattr(pkg["lessons"], "WRITE_ORIGIN", "foreground")
     pkg["lessons"].append_lesson(
         title="testID drift detection",
         body="Before chasing logic, check fixture testIDs.",
-        source="foreground",
+        source="T123",
     )
     conn = pkg["db"].get_db()
     now = int(time.time())
@@ -146,6 +148,36 @@ def test_collect_inventory_counts_lessons_and_skills(tmp_path, monkeypatch):
     assert "SKILL auto-created-skill [PROTECTED]" not in dump
     assert "SKILL auto-created-skill" in dump
     assert "STALE LESSONS (dry-run decay ranking)" in dump
+
+
+def test_collect_inventory_marks_legacy_and_unknown_skills_protected(
+    tmp_path, monkeypatch,
+):
+    pkg = _bootstrap(tmp_path, monkeypatch)
+    pkg["lessons_path"].write_text(
+        "# thread-keeper lessons\n\n"
+        "<!-- LESSON:BEGIN slug=legacy-empty ts=123 source= -->\n"
+        "## legacy-empty\n\n"
+        "old body\n"
+        "<!-- LESSON:END slug=legacy-empty -->\n",
+        encoding="utf-8",
+    )
+    conn = pkg["db"].get_db()
+    now = int(time.time())
+    conn.execute(
+        "INSERT INTO skill_usage "
+        "(name, created_at, created_by_origin, state) "
+        "VALUES ('unknown-skill', ?, '', 'active')",
+        (now,),
+    )
+    conn.commit()
+
+    dump, n_lessons, n_skills = pkg["curator"]._collect_inventory(conn)
+
+    assert n_lessons == 1
+    assert n_skills == 1
+    assert "legacy-empty [PROTECTED]" in dump
+    assert "SKILL unknown-skill [PROTECTED]" in dump
 
 
 # ──────────────────────────────────────────────────────────────────────
@@ -565,6 +597,7 @@ def test_curator_dry_run_ranks_stale_lessons_by_decay_score(
     now = 1_800_000_000
     old = now - 90 * 86400
     monkeypatch.setattr(pkg["lessons"].time, "time", lambda: old)
+    monkeypatch.setattr(pkg["lessons"], "WRITE_ORIGIN", "shadow_review")
     for title in [
         "never pulled",
         "one old pull",

--- a/tests/test_lessons.py
+++ b/tests/test_lessons.py
@@ -55,7 +55,7 @@ def _lessons_rmw_worker(
         raise
 
 
-def _bootstrap(tmp_path, monkeypatch):
+def _bootstrap(tmp_path, monkeypatch, write_origin="foreground"):
     env = {
         "THREADKEEPER_DB": str(tmp_path / "db.sqlite"),
         "CLAUDE_PROJECTS_DIR": str(tmp_path / "fake_claude_projects"),
@@ -65,7 +65,7 @@ def _bootstrap(tmp_path, monkeypatch):
         "THREADKEEPER_SPAWN_BUDGET_POLL_S": "0",
         "THREADKEEPER_SEARCH_PROXY_POLL_S": "0",
         "THREADKEEPER_SHADOW_REVIEW_INTERVAL_S": "0",
-        "THREADKEEPER_WRITE_ORIGIN": "foreground",
+        "THREADKEEPER_WRITE_ORIGIN": write_origin,
         "THREADKEEPER_LESSONS": str(tmp_path / "lessons.md"),
         "THREADKEEPER_TASK_LOG_DIR": str(tmp_path / "tasks"),
     }
@@ -102,6 +102,7 @@ def test_append_creates_file_with_header(tmp_path, monkeypatch):
     assert "## always-paginate" in body
     assert "Use offset+limit" in body
     assert "source=Tabc" in body
+    assert "origin=foreground" in body
 
 
 def test_slugify_handles_messy_titles(tmp_path, monkeypatch):
@@ -260,7 +261,7 @@ def test_foreground_lesson_append_allows_near_duplicate_slug(
 def test_shadow_lesson_append_semantic_duplicate_patches_incumbent(
     tmp_path, monkeypatch,
 ):
-    pkg = _bootstrap(tmp_path, monkeypatch)
+    pkg = _bootstrap(tmp_path, monkeypatch, write_origin="shadow_review")
     la = _tool(pkg, "lesson_append")
 
     import threadkeeper.embeddings as embeddings
@@ -409,7 +410,7 @@ def test_mcp_lesson_get_returns_body(tmp_path, monkeypatch):
 def test_rank_stale_lessons_scores_and_skips_protected(
     tmp_path, monkeypatch,
 ):
-    pkg = _bootstrap(tmp_path, monkeypatch)
+    pkg = _bootstrap(tmp_path, monkeypatch, write_origin="shadow_review")
     now = 1_800_000_000
     old = now - 90 * 86400
     monkeypatch.setattr(pkg["lessons"].time, "time", lambda: old)
@@ -452,7 +453,7 @@ def test_rank_stale_lessons_scores_and_skips_protected(
 
 
 def test_mcp_lesson_remove_deletes_nonprotected_section(tmp_path, monkeypatch):
-    pkg = _bootstrap(tmp_path, monkeypatch)
+    pkg = _bootstrap(tmp_path, monkeypatch, write_origin="shadow_review")
     la = _tool(pkg, "lesson_append")
     lr = _tool(pkg, "lesson_remove")
     lg = _tool(pkg, "lesson_get")
@@ -477,7 +478,7 @@ def test_mcp_lesson_remove_deletes_nonprotected_section(tmp_path, monkeypatch):
 
 
 def test_mcp_lesson_restore_recreates_original_bytes(tmp_path, monkeypatch):
-    pkg = _bootstrap(tmp_path, monkeypatch)
+    pkg = _bootstrap(tmp_path, monkeypatch, write_origin="shadow_review")
     la = _tool(pkg, "lesson_append")
     lr = _tool(pkg, "lesson_remove")
     restore = _tool(pkg, "lesson_restore")
@@ -510,7 +511,7 @@ def test_mcp_lesson_remove_refuses_protected_without_force(
     pkg = _bootstrap(tmp_path, monkeypatch)
     la = _tool(pkg, "lesson_append")
     lr = _tool(pkg, "lesson_remove")
-    la(title="human policy", body="keep this", source="foreground")
+    la(title="human policy", body="keep this", source="T123")
 
     out = lr(slug="human-policy")
 
@@ -518,6 +519,49 @@ def test_mcp_lesson_remove_refuses_protected_without_force(
     assert "human-policy" in pkg["path"].read_text()
     assert not (tmp_path / "curator" / "trash").exists()
     assert lr(slug="human-policy", force=True) == "ok removed=human-policy"
+
+
+def test_mcp_lesson_remove_refuses_legacy_empty_source_without_force(
+    tmp_path, monkeypatch,
+):
+    pkg = _bootstrap(tmp_path, monkeypatch)
+    pkg["path"].write_text(
+        "# thread-keeper lessons\n\n"
+        "<!-- LESSON:BEGIN slug=legacy-empty ts=123 source= -->\n"
+        "## legacy-empty\n\n"
+        "old body\n"
+        "<!-- LESSON:END slug=legacy-empty -->\n",
+        encoding="utf-8",
+    )
+    lr = _tool(pkg, "lesson_remove")
+
+    out = lr(slug="legacy-empty")
+
+    assert out.startswith("ERR protected_lesson")
+    assert "reason=unknown_origin" in out
+    assert "legacy-empty" in pkg["path"].read_text()
+
+
+def test_curator_origin_cannot_force_remove_foreground_lesson(
+    tmp_path, monkeypatch,
+):
+    pkg = _bootstrap(tmp_path, monkeypatch, write_origin="curator")
+    pkg["path"].write_text(
+        "# thread-keeper lessons\n\n"
+        "<!-- LESSON:BEGIN slug=human-owned ts=123 source=T123 "
+        "origin=foreground -->\n"
+        "## human-owned\n\n"
+        "keep this\n"
+        "<!-- LESSON:END slug=human-owned -->\n",
+        encoding="utf-8",
+    )
+    lr = _tool(pkg, "lesson_remove")
+
+    out = lr(slug="human-owned", force=True)
+
+    assert out.startswith("ERR protected_lesson")
+    assert "force_ignored_origin=curator" in out
+    assert "human-owned" in pkg["path"].read_text()
 
 
 def test_curator_trash_sweep_removes_expired_artifacts(tmp_path, monkeypatch):

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -16,8 +16,7 @@ import pytest
 _FAKE_CID = "cccccccc-dddd-eeee-ffff-000011112222"
 
 
-@pytest.fixture()
-def skills_pkg(tmp_path, monkeypatch):
+def _bootstrap_skills(tmp_path, monkeypatch, write_origin="foreground"):
     """Like mp_with_cid but also points CLAUDE_SKILLS_DIR at a sandbox AND
     pins WRITE_ORIGIN='foreground' for predictable provenance assertions."""
     import importlib
@@ -51,7 +50,7 @@ def skills_pkg(tmp_path, monkeypatch):
         "THREADKEEPER_CLIENT": "pytest",
         "THREADKEEPER_FORCE_CID": _FAKE_CID,
         "CLAUDE_SKILLS_DIR": str(skills_root),
-        "THREADKEEPER_WRITE_ORIGIN": "foreground",
+        "THREADKEEPER_WRITE_ORIGIN": write_origin,
     }
     for k, v in env.items():
         monkeypatch.setenv(k, v)
@@ -70,6 +69,11 @@ def skills_pkg(tmp_path, monkeypatch):
         "skills_root": skills_root,
         "tmp": tmp_path,
     }
+
+
+@pytest.fixture()
+def skills_pkg(tmp_path, monkeypatch):
+    return _bootstrap_skills(tmp_path, monkeypatch)
 
 
 def _tool(pkg, name):
@@ -176,6 +180,15 @@ def _seed_skill(pkg, name="seed-skill"):
     return pkg["skills_root"] / name / "SKILL.md"
 
 
+def _set_skill_origin(pkg, name, origin):
+    conn = pkg["db"].get_db()
+    conn.execute(
+        "UPDATE skill_usage SET created_by_origin=? WHERE name=?",
+        (origin, name),
+    )
+    conn.commit()
+
+
 def test_patch_find_and_replace(skills_pkg):
     md = _seed_skill(skills_pkg)
     sm = _tool(skills_pkg, "skill_manage")
@@ -222,6 +235,7 @@ def test_patch_validates_after_replacement(skills_pkg):
 
 def test_delete_removes_skill_dir_and_usage_row(skills_pkg):
     _seed_skill(skills_pkg, name="goner")
+    _set_skill_origin(skills_pkg, "goner", "background_review")
     sm = _tool(skills_pkg, "skill_manage")
     sdir = skills_pkg["skills_root"] / "goner"
     assert sdir.exists()
@@ -241,6 +255,7 @@ def test_delete_restore_recreates_skill_tree_and_usage_row(skills_pkg):
     sm = _tool(skills_pkg, "skill_manage")
     rec = _tool(skills_pkg, "skill_record")
     _seed_skill(skills_pkg, name="recover-me")
+    _set_skill_origin(skills_pkg, "recover-me", "background_review")
     assert sm(
         action="write_file",
         name="recover-me",
@@ -278,6 +293,51 @@ def test_delete_refuses_pinned(skills_pkg):
     result = sm(action="delete", name="pinned-one")
     assert result.startswith("ERR pinned=")
     assert not (skills_pkg["tmp"] / "curator" / "trash").exists()
+
+
+def test_delete_refuses_foreground_without_force(skills_pkg):
+    _seed_skill(skills_pkg, name="user-owned")
+    sm = _tool(skills_pkg, "skill_manage")
+
+    result = sm(action="delete", name="user-owned")
+
+    assert result.startswith("ERR protected_skill")
+    assert "reason=foreground" in result
+    assert (skills_pkg["skills_root"] / "user-owned").exists()
+    assert not (skills_pkg["tmp"] / "curator" / "trash").exists()
+    assert sm(action="delete", name="user-owned", force=True) == "ok"
+
+
+def test_delete_refuses_unknown_origin_without_force(skills_pkg):
+    _seed_skill(skills_pkg, name="unknown-origin")
+    conn = skills_pkg["db"].get_db()
+    conn.execute("DELETE FROM skill_usage WHERE name='unknown-origin'")
+    conn.commit()
+    sm = _tool(skills_pkg, "skill_manage")
+
+    result = sm(action="delete", name="unknown-origin")
+
+    assert result.startswith("ERR protected_skill")
+    assert "reason=unknown_origin" in result
+    assert (skills_pkg["skills_root"] / "unknown-origin").exists()
+    assert sm(action="delete", name="unknown-origin", force=True) == "ok"
+
+
+@pytest.mark.parametrize("write_origin", ["curator", "spawned"])
+def test_loop_origin_cannot_force_delete_foreground_skill(
+    tmp_path, monkeypatch, write_origin,
+):
+    pkg = _bootstrap_skills(tmp_path, monkeypatch, write_origin=write_origin)
+    _seed_skill(pkg, name="human-skill")
+    _set_skill_origin(pkg, "human-skill", "foreground")
+    sm = _tool(pkg, "skill_manage")
+
+    result = sm(action="delete", name="human-skill", force=True)
+
+    assert result.startswith("ERR protected_skill")
+    assert f"force_ignored_origin={write_origin}" in result
+    assert (pkg["skills_root"] / "human-skill").exists()
+    assert not (pkg["tmp"] / "curator" / "trash").exists()
 
 
 # ──────────────────────────────────────────────────────────────────────
@@ -718,6 +778,7 @@ def test_skill_manage_delete_removes_mirrors(skills_pkg, monkeypatch):
     sm = _tool(skills_pkg, "skill_manage")
     sm(action="create", name="will-be-deleted",
        description="Use for the test.", content="# body")
+    _set_skill_origin(skills_pkg, "will-be-deleted", "background_review")
     assert (mirror_dir / "will-be-deleted" / "SKILL.md").exists()
     assert sm(action="delete", name="will-be-deleted") == "ok"
     assert not (mirror_dir / "will-be-deleted").exists()

--- a/threadkeeper/curator.py
+++ b/threadkeeper/curator.py
@@ -22,9 +22,9 @@ Design choices:
 
   • **Class-first / rubric-based output** — child uses an explicit
     decision matrix (see CURATOR_PROMPT) rather than free-form grading.
-  • **Defense-in-depth** — pinned lessons/skills and foreground-origin
-    entries are listed in the inventory as PROTECTED so the child knows
-    not to touch them.
+  • **Defense-in-depth** — protected lessons/skills are listed in the
+    inventory as PROTECTED and delete-class MCP tools refuse them
+    server-side unless a foreground writer explicitly forces the action.
   • **Scoped toolset** — child gets only lesson_*/skill_*/concept_*/
     Read/Write. No shell, no web, no spawn. Curator can't sprawl into
     anything else.
@@ -35,8 +35,9 @@ Design choices:
     CONSOLIDATE directly via lesson_append / lesson_remove / skill_manage, and
     its CONSOLIDATE_CONCEPT / PRUNE_CONCEPT recommendations via concept_manage.
     Set THREADKEEPER_CURATOR_DESTRUCTIVE=0 to revert to advisory REPORT-only.
-    [PROTECTED] entries are never mutated, and lesson_remove is always
-    called without force so it refuses user/foreground lessons by design.
+    [PROTECTED] entries are never mutated; lesson_remove and
+    skill_manage(action='delete') enforce that server-side, and
+    non-foreground children cannot elevate themselves with force.
     Concepts are all system-generated, so concept_manage needs no such
     guard — every concept is curatable.
 
@@ -80,6 +81,19 @@ INVENTORY_FINGERPRINT_KEY = "inventory_sha256"
 _INVENTORY_FINGERPRINT_RE = re.compile(
     rf"\b{INVENTORY_FINGERPRINT_KEY}=([0-9a-f]{{64}})\b"
 )
+
+_CURATABLE_SKILL_ORIGINS = {
+    "background_review",
+    "candidate_review",
+    "curator",
+    "evolve",
+    "evolve_apply",
+    "panel_vote",
+    "probe",
+    "shadow",
+    "shadow_review",
+    "spawned",
+}
 
 
 # Stable leading substring used to find running curator children in the tasks
@@ -292,6 +306,7 @@ def _curator_inventory_snapshot(conn: sqlite3.Connection) -> dict:
                 "body": item.get("body") or "",
                 "ts": _stable_int(item.get("ts")),
                 "source": item.get("source") or "",
+                "origin": item.get("origin") or "",
                 "usage": {
                     "created_at": _stable_int(u.get("created_at")),
                     "source": u.get("source") or "",
@@ -436,10 +451,15 @@ def _format_lesson(item: dict, usage: dict | None = None) -> str:
 
 def _format_skill(row: dict) -> str:
     """One inventory line per recently-touched skill row from
-    skill_usage. Foreground-origin and pinned skills are PROTECTED."""
+    skill_usage. Foreground/unknown-origin and pinned skills are PROTECTED."""
     origin = row.get("created_by_origin") or "?"
     protected = ""
-    if row.get("pinned") or origin == "foreground":
+    if (
+        row.get("pinned")
+        or origin == "foreground"
+        or origin == "?"
+        or origin not in _CURATABLE_SKILL_ORIGINS
+    ):
         protected = " [PROTECTED]"
     now = int(time.time())
     last_active = max(
@@ -746,10 +766,11 @@ def run_curator_pass(force: bool = False, *, scheduled: bool = False) -> str:
                 "false-positive concept; concept_manage(action='set_confidence', "
                 "concept_id=<id>, confidence='low|medium|high') applies a "
                 "confidence review.\n"
-                "NEVER pass force=True to lesson_remove — it refuses "
-                "source=foreground/user lessons by design and that refusal is "
-                "your safety net. NEVER touch any entry marked [PROTECTED], even "
-                "in destructive mode. Apply changes ONLY after the REPORT.md is "
+                "NEVER pass force=True to lesson_remove or skill_manage — "
+                "protected foreground/legacy/unknown entries are refused "
+                "server-side, and non-foreground force is ignored. NEVER touch "
+                "any entry marked [PROTECTED], even in destructive mode. Apply "
+                "changes ONLY after the REPORT.md is "
                 "written (audit trail first, mutation second). A recovery "
                 f"snapshot for this pass already exists at {snapshot_dir}."
             )

--- a/threadkeeper/lessons.py
+++ b/threadkeeper/lessons.py
@@ -11,7 +11,7 @@ Format on disk:
     Procedural knowledge accumulated across sessions. Auto-managed by
     the learning loop — do not edit by hand; new entries are appended.
 
-    <!-- LESSON:BEGIN slug=<slug> ts=<unix> source=<thread_id|shadow> -->
+    <!-- LESSON:BEGIN slug=<slug> ts=<unix> source=<thread_id|shadow> origin=<write_origin> -->
     ## <slug>
     > <one-line summary>
 
@@ -36,6 +36,8 @@ import time
 from pathlib import Path
 from typing import Iterator, Optional
 
+from .config import WRITE_ORIGIN
+
 
 _LESSONS_PATH = Path(
     os.environ.get("THREADKEEPER_LESSONS", "~/.threadkeeper/lessons.md")
@@ -52,6 +54,20 @@ learning loop — do not edit by hand; new entries are appended.
 
 
 _SLUG_RE = re.compile(r"[^a-z0-9-]+")
+
+FOREGROUND_LESSON_ORIGINS = {"foreground", "user"}
+CURATABLE_LESSON_ORIGINS = {
+    "background_review",
+    "candidate_review",
+    "curator",
+    "evolve",
+    "evolve_apply",
+    "panel_vote",
+    "probe",
+    "shadow",
+    "shadow_review",
+    "spawned",
+}
 
 
 def _slugify(title: str) -> str:
@@ -70,13 +86,22 @@ def _ensure_file(path: Path) -> None:
     path.write_text(_HEADER)
 
 
+def _normalize_origin(origin: str | None) -> str:
+    return (origin or "").strip().lower()
+
+
+def _current_origin() -> str:
+    return _normalize_origin(WRITE_ORIGIN) or "unknown"
+
+
 def _format_section(slug: str, summary: str, body: str,
-                    source: str, ts: int) -> str:
+                    source: str, ts: int, origin: str) -> str:
     """One LESSON-BEGIN…LESSON-END block with the sentinel markers."""
     summary_line = f"> {summary.strip()}" if summary.strip() else ""
     body_text = body.strip()
     return (
-        f"<!-- LESSON:BEGIN slug={slug} ts={ts} source={source} -->\n"
+        f"<!-- LESSON:BEGIN slug={slug} ts={ts} source={source} "
+        f"origin={origin} -->\n"
         f"## {slug}\n"
         + (f"{summary_line}\n\n" if summary_line else "\n")
         + body_text + "\n"
@@ -141,12 +166,15 @@ def append_lesson(
     `title` becomes the section header (sluggified for the sentinel).
     `body` is markdown; `summary` is a one-liner shown right after the
     header. `source` is a free-text provenance tag — typically a thread
-    id ("Tabc123") or "shadow" for shadow_review writes.
+    id ("Tabc123") or "shadow" for shadow_review writes. `origin` is
+    stamped from THREADKEEPER_WRITE_ORIGIN and is the protection boundary.
     """
     fp = path or _LESSONS_PATH
     slug = _slugify(title)
     ts = int(time.time())
-    new_section = _format_section(slug, summary, body, source or "", ts)
+    new_section = _format_section(
+        slug, summary, body, source or "", ts, _current_origin(),
+    )
 
     with _lessons_file_lock(fp):
         _ensure_file(fp)
@@ -213,6 +241,7 @@ def lesson_section(slug: str, path: Optional[Path] = None) -> Optional[dict]:
     begin_line = body_existing[start:marker_end].split("\n", 1)[0]
     ts_match = re.search(r"ts=(\d+)", begin_line)
     source_match = re.search(r"source=([^\s>]+)", begin_line)
+    origin_match = re.search(r"origin=([^\s>]+)", begin_line)
     return {
         "slug": slug,
         "section": body_existing[start:end],
@@ -220,6 +249,7 @@ def lesson_section(slug: str, path: Optional[Path] = None) -> Optional[dict]:
         "end": end,
         "ts": int(ts_match.group(1)) if ts_match else 0,
         "source": source_match.group(1) if source_match else "",
+        "origin": origin_match.group(1) if origin_match else "",
         "file_body": body_existing,
     }
 
@@ -248,7 +278,7 @@ def restore_lesson_section(
 
 def iter_lessons(path: Optional[Path] = None) -> Iterator[dict]:
     """Yield every lesson section as a dict with keys:
-       slug, body (raw markdown between BEGIN/END), ts, source.
+       slug, body (raw markdown between BEGIN/END), ts, source, origin.
 
     Order is file-order (chronological if writes are append-only)."""
     fp = path or _LESSONS_PATH
@@ -262,11 +292,13 @@ def iter_lessons(path: Optional[Path] = None) -> Iterator[dict]:
         begin_line = body[m.start():m.start() + 200].split("\n", 1)[0]
         ts_match = re.search(r"ts=(\d+)", begin_line)
         source_match = re.search(r"source=([^\s>]+)", begin_line)
+        origin_match = re.search(r"origin=([^\s>]+)", begin_line)
         yield {
             "slug": slug,
             "body": block_body,
             "ts": int(ts_match.group(1)) if ts_match else 0,
             "source": source_match.group(1) if source_match else "",
+            "origin": origin_match.group(1) if origin_match else "",
         }
 
 
@@ -352,15 +384,26 @@ def lesson_usage_map(conn: sqlite3.Connection) -> dict[str, dict]:
 
 
 def lesson_protection(item: dict, usage: Optional[dict] = None) -> tuple[bool, str]:
-    """Return (protected, reason) for curator decay handling."""
+    """Return (protected, reason) for curator decay/destructive handling.
+
+    The explicit lesson ``origin`` marker is the trust boundary. Missing or
+    unknown origins are protected so legacy lessons fail closed.
+    """
     usage = usage or {}
-    source = (usage.get("source") or item.get("source") or "").strip().lower()
-    if source in {"foreground", "user"}:
-        return True, source
     if int(usage.get("pinned") or 0):
         return True, "pinned"
     if (usage.get("tier") or "hypothesis") == "validated":
         return True, "validated"
+    origin = _normalize_origin(usage.get("origin") or item.get("origin"))
+    if origin in FOREGROUND_LESSON_ORIGINS:
+        return True, origin
+    if not origin:
+        source = (usage.get("source") or item.get("source") or "").strip().lower()
+        if source in FOREGROUND_LESSON_ORIGINS:
+            return True, source
+        return True, "unknown_origin"
+    if origin not in CURATABLE_LESSON_ORIGINS:
+        return True, f"unknown_origin:{origin}"
     return False, ""
 
 
@@ -398,6 +441,7 @@ def lesson_retention_score(
     return {
         "slug": item.get("slug") or usage.get("slug") or "",
         "source": usage.get("source") or item.get("source") or "",
+        "origin": usage.get("origin") or item.get("origin") or "",
         "created_at": created,
         "lesson_ts": lesson_ts,
         "last_used_at": last_used or None,

--- a/threadkeeper/tools/lessons.py
+++ b/threadkeeper/tools/lessons.py
@@ -12,8 +12,9 @@
     Return the full body of a single lesson by slug.
 
   lesson_remove(slug, force=False)
-    Remove one lesson section by slug. Refuses foreground/user lessons unless
-    force=True, so autonomous cleanup cannot delete protected memory.
+    Remove one lesson section by slug. Refuses protected lessons unless
+    force=True from a foreground writer, so autonomous cleanup cannot delete
+    protected memory.
 
   lesson_restore(slug)
     Restore the latest trashed section for a removed lesson slug.
@@ -47,6 +48,7 @@ from ..lessons import (
     lesson_section,
     count_lessons,
     get_path,
+    lesson_protection,
     record_lesson_access,
     remove_lesson,
     restore_lesson_section,
@@ -321,13 +323,13 @@ def lesson_append(
         if semantic_duplicate:
             item, semantic_score = semantic_duplicate
             slug = item["slug"]
-            source_existing = (item.get("source") or "").strip().lower()
             if semantic_score >= LESSON_SEMANTIC_DUPLICATE_THRESHOLD:
-                if source_existing in {"foreground", "user"}:
+                protected, reason = lesson_protection(item)
+                if protected:
                     return (
                         f"ERR likely_duplicate_lesson slug={slug} "
                         f"score={semantic_score:.2f}; incumbent is protected "
-                        f"source={source_existing}; surface to curator or "
+                        f"reason={reason}; surface to curator or "
                         "patch existing memory explicitly"
                     )
                 merged_summary, merged_body, changed = _merge_duplicate_lesson_body(
@@ -461,9 +463,9 @@ def lesson_get(slug: str) -> str:
 def lesson_remove(slug: str, force: bool = False) -> str:
     """Remove one materialized lesson section by slug.
 
-    Refuses `source=foreground` / `source=user` lessons unless `force=True`.
-    Curator/evolve cleanup should never pass force; it exists only for an
-    explicit human-initiated correction.
+    Refuses protected lessons unless `force=True` is called from a foreground
+    writer. Curator/evolve cleanup may pass force accidentally or maliciously;
+    non-foreground force is ignored.
     """
     conn = get_db()
     _ensure_session(conn)
@@ -477,18 +479,28 @@ def lesson_remove(slug: str, force: bool = False) -> str:
             break
     if not found:
         return f"ERR not_found slug={slug}"
+    usage_row = _row_to_dict(
+        conn.execute("SELECT * FROM lesson_usage WHERE slug=?", (slug,)).fetchone()
+    )
+    protected, reason = lesson_protection(found, usage_row)
+    effective_force = bool(force and WRITE_ORIGIN == "foreground")
+    if protected and not effective_force:
+        force_note = (
+            f" force_ignored_origin={WRITE_ORIGIN}"
+            if force and WRITE_ORIGIN != "foreground" else ""
+        )
+        return (
+            f"ERR protected_lesson slug={slug} reason={reason or 'protected'}"
+            f"{force_note}"
+        )
     source = (found.get("source") or "").strip().lower()
-    if source in {"foreground", "user"} and not force:
-        return f"ERR protected_lesson slug={slug} source={source}"
+    origin = (found.get("origin") or "").strip().lower()
     snapshot = lesson_section(slug)
     if not snapshot:
         return f"ERR remove_failed slug={slug}"
     post_remove = (
         snapshot["file_body"][:snapshot["start"]]
         + snapshot["file_body"][snapshot["end"]:]
-    )
-    usage_row = _row_to_dict(
-        conn.execute("SELECT * FROM lesson_usage WHERE slug=?", (slug,)).fetchone()
     )
     try:
         artifact = capture_removed_lesson(
@@ -523,7 +535,7 @@ def lesson_remove(slug: str, force: bool = False) -> str:
         (
             identity._session_id or "",
             slug,
-            f"source={source or '?'} trash={artifact.name}"
+            f"source={source or '?'} origin={origin or '?'} trash={artifact.name}"
             + (f" tombstone={tombstone}" if tombstone else ""),
         ),
     )

--- a/threadkeeper/tools/skills.py
+++ b/threadkeeper/tools/skills.py
@@ -413,6 +413,18 @@ def _recompute_skill_tier(conn: sqlite3.Connection, name: str,
 # TARGET loop-authored skills without touching foreground ones.
 # ──────────────────────────────────────────────────────────────────────
 FOREGROUND_ORIGIN = "foreground"
+CURATABLE_SKILL_ORIGINS = {
+    "background_review",
+    "candidate_review",
+    "curator",
+    "evolve",
+    "evolve_apply",
+    "panel_vote",
+    "probe",
+    "shadow",
+    "shadow_review",
+    "spawned",
+}
 SKILL_CREATE_LIMITED_ORIGINS = {
     "background_review",
     "candidate_review",
@@ -635,7 +647,8 @@ def skill_manage(action: str,
                  old_string: str = "",
                  new_string: str = "",
                  sub_path: str = "",
-                 description: str = "") -> str:
+                 description: str = "",
+                 force: bool = False) -> str:
     """Create, edit, patch, or delete skills under the primary skills root.
 
     Atomic primary write with frontmatter validation before disk hits, then
@@ -657,7 +670,8 @@ def skill_manage(action: str,
       remove_file — remove a support file under one of the allowed subdirs.
                     Requires `name`, `sub_path`.
       delete      — remove a skill entirely. Pinned skills (in skill_usage)
-                    are refused.
+                    are refused. Foreground/unknown-origin skills require
+                    force from a foreground writer.
       restore     — restore the latest trashed copy for `name`.
     """
     action = action.strip()
@@ -677,7 +691,7 @@ def skill_manage(action: str,
     if action == "delete":
         if err := _validate_name(name):
             return f"ERR {err}"
-        return _action_delete(name)
+        return _action_delete(name, force=force)
     if action == "restore":
         return _action_restore(name)
     return (
@@ -865,20 +879,38 @@ def _action_remove_file(name: str, sub_path: str) -> str:
     return "ok"
 
 
-def _action_delete(name: str) -> str:
+def _action_delete(name: str, *, force: bool = False) -> str:
     conn = get_db()
     _ensure_session(conn)
     row = conn.execute(
         "SELECT * FROM skill_usage WHERE name=?", (name,)
     ).fetchone()
+    sdir = _skill_dir(name)
+    if not sdir.exists():
+        return f"ERR skill_not_found={name}"
     if row and row["pinned"]:
         return (
             f"ERR pinned={name} (unpin via UPDATE skill_usage SET pinned=0 "
             "first)"
         )
-    sdir = _skill_dir(name)
-    if not sdir.exists():
-        return f"ERR skill_not_found={name}"
+    origin = ((row["created_by_origin"] if row else "") or "").strip().lower()
+    protected_reason = ""
+    if origin == FOREGROUND_ORIGIN:
+        protected_reason = origin
+    elif not origin:
+        protected_reason = "unknown_origin"
+    elif origin not in CURATABLE_SKILL_ORIGINS:
+        protected_reason = f"unknown_origin:{origin}"
+    effective_force = bool(force and WRITE_ORIGIN == FOREGROUND_ORIGIN)
+    if protected_reason and not effective_force:
+        force_note = (
+            f" force_ignored_origin={WRITE_ORIGIN}"
+            if force and WRITE_ORIGIN != FOREGROUND_ORIGIN else ""
+        )
+        return (
+            f"ERR protected_skill name={name} reason={protected_reason}"
+            f"{force_note}"
+        )
     tombstone = ""
     if WRITE_ORIGIN == "curator":
         tombstone = capture_skill_tombstone("skill_deleted", name, sdir)


### PR DESCRIPTION
## Summary
- stamp lesson sections with write-origin provenance and fail closed for legacy/unknown lessons
- enforce server-side protected delete guards for lesson_remove and skill_manage(delete), with force effective only from foreground writers
- update curator inventory markers, docs, roadmap, changelog, and focused tests

## Tests
- env -u THREADKEEPER_NO_EMBEDDINGS .venv/bin/python -m pytest -q (exited 0)

Closes #100