### PR TITLE
fix: make Codex fallback message IDs unique

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ version bumps follow semver per the policy in
 
 ## [Unreleased]
 
+### Fixed
+
+- **Codex transcript ingest keeps timestamp-colliding fallback messages (#97).**
+  Fallback message UUIDs now include the rollout line index, and forced child
+  cid detection happens during the normal JSONL pass instead of opening each
+  Codex rollout twice.
+
 ## v0.15.0 — 2026-07-15
 
 ### Added

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -859,10 +859,10 @@ deduplicated against the issues above):
   instead of copying live `-wal`/`-shm` sidecars, so dirty-WAL source databases
   migrate into a consistent main DB and machine-local `-shm` state is never
   imported.
-- Codex adapter: the fallback message **UUID** has no per-line offset, so
-  timestamp-colliding messages collapse to one uuid and the later ones are
-  deduped away; separately, each rollout file is fully scanned twice per ingest
-  pass (#97).
+- ✅ DONE (#97): Codex adapter fallback message **UUIDs** now include the
+  rollout line index, so timestamp-colliding messages keep distinct dialog
+  rows, and forced child-cid detection happens during the single rollout scan
+  instead of opening each Codex transcript twice per ingest pass.
 - ✅ DONE (#98): The candidate-reviewer's "max 2 new skills per pass" cap is
   enforced server-side in `skill_manage(create)` for autonomous learning-loop
   child origins, not only stated in the reviewer prompt.

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -380,6 +380,76 @@ def test_codex_iter_messages_filters_developer_turns(tmp_path, monkeypatch):
     assert msgs[1].content == "hello"
 
 
+def test_codex_fallback_uuid_uses_line_index_for_same_timestamp(
+    tmp_path, monkeypatch,
+):
+    pkg = _bootstrap(tmp_path, monkeypatch)
+    fp = tmp_path / "rollout-2026-05-14T10-00-00.jsonl"
+    ts = "2026-05-14T10:00:02Z"
+    fp.write_text("\n".join([
+        json.dumps({"timestamp": "2026-05-14T10:00:00Z", "type": "session_meta",
+                    "payload": {"id": "sess-x", "cwd": "/x"}}),
+        json.dumps({"timestamp": ts, "type": "response_item",
+                    "payload": {"type": "message", "role": "user",
+                                "content": [{"type": "input_text",
+                                             "text": "first colliding turn"}]}}),
+        json.dumps({"timestamp": ts, "type": "response_item",
+                    "payload": {"type": "message", "role": "assistant",
+                                "content": [{"type": "output_text",
+                                             "text": "second colliding turn"}]}}),
+    ]) + "\n")
+
+    msgs = list(pkg["codex"].iter_messages(fp))
+
+    assert [m.uuid for m in msgs] == [
+        f"codex:{fp.name}:2:{ts}",
+        f"codex:{fp.name}:3:{ts}",
+    ]
+    assert len({m.uuid for m in msgs}) == 2
+
+
+def test_codex_ingest_keeps_timestamp_colliding_fallback_messages(
+    fresh_mp, tmp_path
+):
+    from threadkeeper import ingest
+    from threadkeeper.adapters.codex import ADAPTER
+
+    ingest.SEMANTIC_AVAILABLE = False
+    conn = fresh_mp["db"].get_db()
+    rollout_dir = tmp_path / "2026" / "05" / "14"
+    rollout_dir.mkdir(parents=True)
+    fp = rollout_dir / "rollout-2026-05-14T10-00-00.jsonl"
+    ts = "2026-05-14T10:00:02Z"
+    fp.write_text("\n".join([
+        json.dumps({"timestamp": "2026-05-14T10:00:00Z", "type": "session_meta",
+                    "payload": {"id": "sess-x", "cwd": "/x"}}),
+        json.dumps({"timestamp": ts, "type": "response_item",
+                    "payload": {"type": "message", "role": "user",
+                                "content": [{"type": "input_text",
+                                             "text": "first colliding payload"}]}}),
+        json.dumps({"timestamp": ts, "type": "response_item",
+                    "payload": {"type": "message", "role": "assistant",
+                                "content": [{"type": "output_text",
+                                             "text": "second colliding payload"}]}}),
+    ]) + "\n")
+
+    added = ingest._ingest_file(conn, fp, max_msgs=100, adapter=ADAPTER)
+    conn.commit()
+
+    assert added == 2
+    rows = conn.execute(
+        "SELECT uuid, content FROM dialog_messages ORDER BY rowid"
+    ).fetchall()
+    assert [row["uuid"] for row in rows] == [
+        f"codex:{fp.name}:2:{ts}",
+        f"codex:{fp.name}:3:{ts}",
+    ]
+    assert [row["content"] for row in rows] == [
+        "first colliding payload",
+        "second colliding payload",
+    ]
+
+
 def test_codex_iter_messages_uses_forced_child_cid_from_spawn_preamble(
     tmp_path, monkeypatch,
 ):
@@ -432,7 +502,19 @@ def test_codex_iter_messages_uses_forced_child_cid_from_spawn_preamble(
         }),
     ]) + "\n")
 
+    opened = 0
+    original_open = Path.open
+
+    def _counting_open(self, *args, **kwargs):
+        nonlocal opened
+        if self == fp:
+            opened += 1
+        return original_open(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "open", _counting_open)
     msgs = list(pkg["codex"].iter_messages(fp))
+
+    assert opened == 1
     assert [m.uuid for m in msgs] == ["u-agents", "u-spawn", "a-1"]
     assert {m.session_id for m in msgs} == {forced_cid}
 

--- a/threadkeeper/adapters/codex.py
+++ b/threadkeeper/adapters/codex.py
@@ -316,42 +316,13 @@ class CodexAdapter(CLIAdapter):
             return []
         return list(self.sessions_dir.glob("**/rollout-*.jsonl"))
 
-    def _forced_session_id(self, fp: Path) -> str:
-        """Return THREADKEEPER_FORCE_CID encoded in our spawn preamble.
-
-        Codex records its own rollout UUID in session_meta.payload.id even
-        when the child process has THREADKEEPER_FORCE_CID. For thread-keeper
-        provenance we want every message from that spawned transcript grouped
-        under the forced child cid, matching tasks.spawned_cid and Claude's
-        --session-id behavior.
-        """
-        try:
-            with fp.open("r", encoding="utf-8", errors="replace") as f:
-                for line in f:
-                    if "You were spawned in the background" not in line:
-                        continue
-                    try:
-                        env = json.loads(line)
-                    except json.JSONDecodeError:
-                        continue
-                    payload = env.get("payload") or {}
-                    if not isinstance(payload, dict):
-                        continue
-                    if payload.get("type") != "message":
-                        continue
-                    cid = _forced_cid_from_text(_extract_text(payload))
-                    if cid:
-                        return cid
-        except OSError:
-            return ""
-        return ""
-
     def iter_messages(self, fp: Path) -> Iterator[NormalizedMessage]:
         sess_id = ""
-        forced_session_id = self._forced_session_id(fp)
+        forced_session_id = ""
+        pending: list[NormalizedMessage] = []
         try:
             with fp.open("r", encoding="utf-8", errors="replace") as f:
-                for line in f:
+                for idx, line in enumerate(f, start=1):
                     line = line.strip()
                     if not line:
                         continue
@@ -363,6 +334,9 @@ class CodexAdapter(CLIAdapter):
                     payload = env.get("payload") or {}
                     if typ == "session_meta" and isinstance(payload, dict):
                         sess_id = payload.get("id") or sess_id
+                        if sess_id and not forced_session_id:
+                            for msg in pending:
+                                msg.session_id = sess_id
                         continue
                     if typ != "response_item":
                         continue
@@ -378,10 +352,20 @@ class CodexAdapter(CLIAdapter):
                     if role not in ("user", "assistant"):
                         continue
                     text = _extract_text(payload)
+                    cid = _forced_cid_from_text(text)
+                    if cid and not forced_session_id:
+                        forced_session_id = cid
+                        for msg in pending:
+                            msg.session_id = forced_session_id
+                            yield msg
+                        pending.clear()
                     # Stable per-line id: use payload.id when present,
-                    # else fall back to timestamp+offset.
-                    uuid = payload.get("id") or f"codex:{fp.name}:{env.get('timestamp', '')}"
-                    yield NormalizedMessage(
+                    # else fall back to timestamp plus line index.
+                    uuid = (
+                        payload.get("id")
+                        or f"codex:{fp.name}:{idx}:{env.get('timestamp', '')}"
+                    )
+                    msg = NormalizedMessage(
                         uuid=uuid,
                         session_id=forced_session_id or sess_id,
                         role=role,
@@ -390,6 +374,12 @@ class CodexAdapter(CLIAdapter):
                         created_at=_ts(env.get("timestamp", "")),
                         raw=payload,
                     )
+                    if forced_session_id:
+                        yield msg
+                    else:
+                        pending.append(msg)
+                for msg in pending:
+                    yield msg
         except OSError:
             return
 


### PR DESCRIPTION
## Summary
- add the rollout line index to Codex fallback message UUIDs
- detect forced child cids during the normal Codex JSONL scan instead of opening rollouts twice
- add regressions for duplicate timestamps, ingest dedup, and single-scan behavior

## Tests
- env -u THREADKEEPER_NO_EMBEDDINGS .venv/bin/python -m pytest -q
- env -u THREADKEEPER_NO_EMBEDDINGS .venv/bin/python -m pytest -q -o addopts=--strict-markers (1260 passed, 1 skipped)

Closes #97