### PR TITLE
fix: bound destructive curator prompts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ version bumps follow semver per the policy in
 
 ### Fixed
 
+- **Destructive Curator prompts are now bounded (#105).** Curator passes split
+  lessons/skills/concepts inventory into complete batches, report entries /
+  batch counts in `curator_pass`, and cap the dry-run inventory preview with
+  omitted-entry telemetry. Claude `spawn()` also keeps prompt argv under 96 KiB
+  and feeds larger prompts through the owner-only stdin spool to avoid Linux
+  `E2BIG`.
+
 - **Codex transcript ingest keeps timestamp-colliding fallback messages (#97).**
   Fallback message UUIDs now include the rollout line index, and forced child
   cid detection happens during the normal JSONL pass instead of opening each

--- a/README.md
+++ b/README.md
@@ -273,6 +273,11 @@ CLI emits a recognizable usage trailer. Optional daily ceilings
 `THREADKEEPER_SPAWN_COST_BUDGET_USD` admission-deny new children once the
 recorded 24h spend reaches the configured limit; both default to `0`
 (disabled), so existing installs behave the same until a budget is set.
+Claude children keep their positional prompt argv under a conservative
+96 KiB byte ceiling; larger prompts are written to
+`THREADKEEPER_TASK_LOG_DIR/<task>.stdin.txt` with owner-only permissions and
+fed on stdin, so Linux's per-argument `MAX_ARG_STRLEN` limit cannot turn a large
+curator/reviewer prompt into an opaque `E2BIG` spawn failure.
 
 Visible (`visible=True`, Terminal.app) children persist `pid=0`, so the
 daemon resolves their live pid from the `--session-id` it carries in `ps`
@@ -618,10 +623,12 @@ locks.
 #### 5. Autonomous Curator
 
 Every `THREADKEEPER_CURATOR_INTERVAL_S` seconds (default off, 604800
-= 7 days recommended) spawns a slim child that reviews the EXISTING
-`lessons.md` + `lesson_usage` + `skill_usage` inventory and writes
-`~/.threadkeeper/curator/REPORT-<isodate>.md` with KEEP / PATCH /
-CONSOLIDATE / PRUNE recommendations. Pinned and foreground-authored
+= 7 days recommended) reviews the EXISTING `lessons.md` + `lesson_usage` +
+`skill_usage` + concepts inventory through bounded slim-child batches. Each
+child sees a complete slice and writes either
+`~/.threadkeeper/curator/REPORT-<isodate>.md` for a one-batch pass or
+`REPORT-<isodate>-batch-NNN-of-MMM.md` for a multi-batch pass with KEEP /
+PATCH / CONSOLIDATE / PRUNE recommendations. Pinned and foreground-authored
 entries are marked `[PROTECTED]` in the inventory so the curator
 never proposes destructive changes against them, and delete-class tools
 enforce the same boundary server-side. The pass is
@@ -640,7 +647,9 @@ recorded complete/endorsed curator pass, the wake-up records an
 `unchanged_inventory` no-op event and endorses the last report instead of
 asking another child to re-grade the same snapshot. `curator_review_status()`
 shows both the last endorsed `inventory_sha256` and the current inventory hash
-so operators can tell whether the store is quiescent.
+so operators can tell whether the store is quiescent. Spawned pass events record
+`entries`, `batches`, `batch_entries`, and `max_batch_chars`, making partial or
+large reviews visible in the normal `curator_pass` trail.
 
 Curator applies its own PATCH / PRUNE / CONSOLIDATE directly by default (it
 writes the REPORT first, then mutates — `lesson_remove` is in its toolset so it

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -422,9 +422,11 @@ moving the high-water forward; `force=True` bypasses this due gate.
   plus the running validator-task check. Spawn failures release the just-claimed
   rows; parent crashes leave them under the normal stale-claim lease requeue.
 - **curator** — once per `CURATOR_INTERVAL_S` (default 0 = off) audits the
-  existing lessons / skills / concepts inventory through one slim child. Before
-  spawning, it hashes the stable inventory state and compares it to the last
-  recorded complete/endorsed pass; unchanged snapshots record an
+  existing lessons / skills / concepts inventory through bounded slim-child
+  batches. Each batch prompt carries an explicit entry range and per-kind
+  counts; multi-batch runs write `REPORT-<pass>-batch-NNN-of-MMM.md` files.
+  Before spawning, it hashes the stable inventory state and compares it to the
+  last recorded complete/endorsed pass; unchanged snapshots record an
   `unchanged_inventory` no-op event instead of re-deriving the same report.
   The last `curator_pass` timestamp is also an interval high-water, so restarts
   inside the interval return `not_due` before any snapshot or child spawn.
@@ -432,7 +434,9 @@ moving the high-water forward; `force=True` bypasses this due gate.
   `curator.lock` plus the running curator-task check, so multiple foreground
   servers do not re-read and spawn against the same snapshot.
   `curator_review_status()` exposes the last
-  endorsed `inventory_sha256` and the current inventory hash.
+  endorsed `inventory_sha256` and the current inventory hash. Spawned
+  `curator_pass` events record total entries, batch count, compressed
+  `batch_entries`, and max rendered batch chars.
 - **evolve_reviewer** (`evolve_daemon.start_evolve_daemon`) — once per
   `EVOLVE_REVIEW_INTERVAL_S` (default 0 = off) it reviews thread-keeper itself
   for security/privacy risks, memory leaks, runaway daemons, cost waste,
@@ -817,6 +821,11 @@ optional 24h spawned-child token and dollar ceilings when
   (`0600`), matching the stdin prompt spool. The task spool defaults to
   `~/.threadkeeper/tasks` (`0700`) and configured directories are refused when
   symlinked or owned by another user.
+- Claude prompt argv is capped at 96 KiB. If the prompt exceeds that bound,
+  `spawn()` omits the prompt positional argument, writes the prompt to
+  `<task>.stdin.txt` with the same owner-only spool helper, and feeds it through
+  stdin. This avoids Linux's 128 KiB single-argv-string ceiling while keeping
+  the non-Claude stdin adapter path unchanged.
 - Daemon ticks run only in foreground parent processes and update real RSS via
   `ps`; unreadable RSS samples preserve the last-known `rss_kb`, and every open
   row is swept for dead root pids → `ended_at`.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -382,9 +382,17 @@ a dump of what would be archived" this item asked for already exists: set
 `THREADKEEPER_CURATOR_DESTRUCTIVE=0` for advisory REPORT-only.
 
 Open follow-ups (issue-backed): broader recovery/UX paths outside the snapshot
-plus trash safety net (#52); bounding the curator/candidate_reviewer prompt
-argv so the full inventory dump can't hit `E2BIG` — the single-flight half of
-#24 has landed but the argv bound has not (#24). Scope: S–M each.
+plus trash safety net (#52); bounding the candidate_reviewer prompt payload so
+its full queue dump cannot hit `E2BIG` — the Curator side is done in #105.
+Scope: S–M each.
+
+✅ DONE (#105): destructive Curator passes no longer dump the entire
+lessons/skills/concepts inventory into one child prompt. The pass now renders
+bounded inventory batches, records `entries` / `batches` / `batch_entries` /
+`max_batch_chars` in the `curator_pass` event, and keeps the dry-run preview
+char-capped with explicit omitted-entry counts. Claude spawn also has a 96 KiB
+prompt-argv guard that falls back to the private stdin spool instead of risking
+Linux `E2BIG`.
 
 ✅ DONE (#91): lesson-store append/remove/restore mutations now serialize on a
 blocking `lessons.md.lock` flock around the file creation/read/mutate/write
@@ -572,12 +580,12 @@ the three bare-`time.sleep` loops onto it), pruning `_last_notify_at` of
 past-cooldown / dead-pid entries each `_maybe_notify`, and collapsing
 consecutive no-op janitor passes into a single recorded row. Scope: S.
 
-**Daemon robustness under load.** ✅ PARTIAL (#24/#53). Curator single-flight
-has landed, and #53 unified the fcntl single-flight helper across the spawning
-daemon family. The remaining #24 work is bounding the
-`candidate_reviewer`/`curator` queue/inventory prompt payloads so a full dump
-cannot hit `E2BIG` (the class already fixed for `dialectic_validator`).
-Scope: S.
+**Daemon robustness under load.** ✅ PARTIAL (#24/#53/#105). Curator
+single-flight has landed, #53 unified the fcntl single-flight helper across the
+spawning daemon family, and #105 bounds Curator inventory prompts plus the
+Claude prompt argv path. The remaining #24 work is bounding the
+`candidate_reviewer` queue prompt payload so a full dump cannot hit `E2BIG`
+(the class already fixed for `dialectic_validator`). Scope: S.
 
 **Spawn cost accounting.** ✅ DONE (#25, extends #6). The spawn budget now
 tracks more than child RSS: `_spawn_wrap.py` parses JSON or human-readable CLI

--- a/tests/test_curator.py
+++ b/tests/test_curator.py
@@ -16,12 +16,33 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import sys
 import time
 from pathlib import Path
 
 
 _FAKE_CID = "aaaa1111-2222-3333-4444-555566667777"
+
+
+def _write_bulk_lessons(path: Path, count: int) -> None:
+    now = int(time.time()) - 90 * 86400
+    sections = [
+        "# thread-keeper lessons\n\n"
+        "Procedural knowledge accumulated across sessions.\n\n"
+    ]
+    for i in range(count):
+        slug = f"bulk-lesson-{i:04d}"
+        body = "body " + ("x" * 240)
+        sections.append(
+            f"<!-- LESSON:BEGIN slug={slug} ts={now + i} "
+            "source=shadow origin=shadow_review -->\n"
+            f"## {slug}\n"
+            f"> summary {i}\n\n"
+            f"{body}\n"
+            f"<!-- LESSON:END slug={slug} -->\n\n"
+        )
+    path.write_text("".join(sections), encoding="utf-8")
 
 
 def _bootstrap(
@@ -180,6 +201,20 @@ def test_collect_inventory_marks_legacy_and_unknown_skills_protected(
     assert "SKILL unknown-skill [PROTECTED]" in dump
 
 
+def test_collect_inventory_preview_truncates_large_store(tmp_path, monkeypatch):
+    pkg = _bootstrap(tmp_path, monkeypatch)
+    _write_bulk_lessons(pkg["lessons_path"], 1500)
+    conn = pkg["db"].get_db()
+
+    dump, n_lessons, n_skills = pkg["curator"]._collect_inventory(conn)
+
+    assert n_lessons == 1500
+    assert n_skills == 0
+    assert "INVENTORY TRUNCATED" in dump
+    assert "omitted_lessons=" in dump
+    assert "live curator pass reviews complete bounded batches" in dump
+
+
 # ──────────────────────────────────────────────────────────────────────
 # run_curator_pass — dispatch logic
 # ──────────────────────────────────────────────────────────────────────
@@ -266,6 +301,48 @@ def test_run_curator_pass_spawns_when_threshold_met(tmp_path, monkeypatch):
     assert pkg["reports_dir"].is_dir()
     assert "THREADKEEPER_CURATOR_PASS_ID" not in os.environ
     assert "THREADKEEPER_CURATOR_SNAPSHOT_DIR" not in os.environ
+
+
+def test_run_curator_pass_batches_large_inventory_without_oversize_prompt(
+    tmp_path, monkeypatch,
+):
+    pkg = _bootstrap(tmp_path, monkeypatch, min_lessons="2")
+    _write_bulk_lessons(pkg["lessons_path"], 1500)
+
+    import threadkeeper.tools.spawn as spawn_mod
+    captured: list[dict] = []
+
+    def fake_spawn(**kwargs):
+        captured.append(kwargs)
+        return f"ok task=tk_batch_{len(captured)} pid=0"
+
+    monkeypatch.setattr(spawn_mod, "spawn", fake_spawn)
+
+    out = pkg["curator"].run_curator_pass(force=True)
+
+    assert out.startswith("spawned batches="), out
+    assert len(captured) > 1
+    seen: list[str] = []
+    for idx, kw in enumerate(captured, start=1):
+        prompt = kw["prompt"]
+        assert f"CURATOR BATCH {idx}/{len(captured)}" in prompt
+        assert (
+            len(prompt.encode("utf-8"))
+            <= spawn_mod.CLAUDE_PROMPT_ARGV_MAX_BYTES
+        )
+        seen.extend(re.findall(r"- LESSON (bulk-lesson-\d{4})", prompt))
+
+    assert len(seen) == 1500
+    assert len(set(seen)) == 1500
+
+    conn = pkg["db"].get_db()
+    row = conn.execute(
+        "SELECT summary FROM events WHERE kind='curator_pass' "
+        "ORDER BY id DESC LIMIT 1"
+    ).fetchone()
+    assert "entries=1500" in row["summary"]
+    assert f"batches={len(captured)}" in row["summary"]
+    assert "batch_entries=" in row["summary"]
 
 
 def test_run_curator_pass_recent_high_water_is_not_due(

--- a/tests/test_spawn_slim.py
+++ b/tests/test_spawn_slim.py
@@ -206,6 +206,57 @@ def test_headless_log_file_is_owner_only(mp_with_cid, monkeypatch):
     assert mode == 0o600, f"expected 0600, got {oct(mode)}"
 
 
+def test_claude_large_prompt_uses_stdin_file(mp_with_cid, monkeypatch):
+    """Claude's prompt positional arg must stay below Linux MAX_ARG_STRLEN."""
+    pkg = mp_with_cid(_FAKE_CID)
+
+    import threadkeeper.identity as identity
+    import threadkeeper.spawn_config as spawn_config
+    import threadkeeper.tools.spawn as spawn_mod
+
+    monkeypatch.setattr(spawn_mod, "_claude_bin", lambda: "/fake/bin/claude")
+    monkeypatch.setattr(identity, "_active_cli", "claude")
+    monkeypatch.setattr(
+        spawn_config, "resolve_agent", lambda role, active_cli=None: "claude"
+    )
+    monkeypatch.setattr(spawn_config, "resolve_model", lambda cli, role="": "")
+
+    captured: dict[str, object] = {}
+
+    class _FakePopen:
+        def __init__(self, args, **kwargs):
+            captured["args"] = list(args)
+            stdin = kwargs.get("stdin")
+            captured["stdin"] = stdin.read().decode("utf-8")
+            self.pid = 4322
+
+    monkeypatch.setattr(spawn_mod.subprocess, "Popen", _FakePopen)
+
+    long_prompt = "large claude prompt " + (
+        "x" * (spawn_mod.CLAUDE_PROMPT_ARGV_MAX_BYTES + 1)
+    )
+    out = spawn_mod.spawn(
+        prompt=long_prompt,
+        cwd=str(pkg["tmp"]),
+        visible=False,
+        capture_output=False,
+        slim=True,
+    )
+
+    assert out.startswith("ok task="), out
+    args = captured["args"]
+    assert long_prompt not in args
+    assert captured["stdin"] == long_prompt
+    assert all(
+        spawn_mod._utf8_len(str(arg)) <= spawn_mod.CLAUDE_PROMPT_ARGV_MAX_BYTES
+        for arg in args
+    )
+    stdin_files = list(spawn_mod.TASK_LOG_DIR.glob("*.stdin.txt"))
+    assert len(stdin_files) == 1
+    mode = stdin_files[0].stat().st_mode & 0o777
+    assert mode == 0o600, f"expected 0600, got {oct(mode)}"
+
+
 def test_spawn_slim_falls_back_to_full_config_when_unable(tmp_path, monkeypatch):
     """If _build_slim_mcp_config returns None (e.g. write error), spawn()
     must NOT crash — it just runs without slim flags."""

--- a/threadkeeper/curator.py
+++ b/threadkeeper/curator.py
@@ -10,13 +10,13 @@ minutes, the Curator REVIEWS THE STORE every few days:
      records an unchanged/no-op event instead of spawning another child.
   4. Collects inventory: every lesson slug + every recently-touched
      skill + usage telemetry + advisory lesson decay ranking.
-  5. Spawns slim child with CURATOR_PROMPT + inventory dump.
+  5. Spawns one or more slim children with bounded inventory batches.
   6. Child grades each entry, suggests KEEP / PATCH / CONSOLIDATE /
      PRUNE, and writes REPORT-<isodate>.md under CURATOR_REPORTS_DIR.
   7. In destructive mode, parent writes a pre-mutation snapshot before
      spawning the child; child tool calls add tombstones/action telemetry.
-  8. Parent records `curator_pass` event with high-water timestamp and
-     inventory fingerprint.
+  8. Parent records `curator_pass` event with high-water timestamp,
+     inventory fingerprint, and batch coverage.
 
 Design choices:
 
@@ -56,6 +56,7 @@ import re
 import sqlite3
 import threading
 import time
+from dataclasses import dataclass
 
 from .config import (
     CURATOR_INTERVAL_S,
@@ -102,9 +103,9 @@ _CURATABLE_SKILL_ORIGINS = {
 CURATOR_PROMPT_PREFIX = "You are an autonomous CURATOR for thread-keeper"
 
 CURATOR_PROMPT = CURATOR_PROMPT_PREFIX + """'s lessons + skills
-library. You read the inventory below — every lesson slug, every
-recently-touched skill, usage telemetry — and decide what to keep,
-patch, consolidate, or prune.
+library. You read the inventory below — either the whole library or one
+bounded batch of lesson slugs, recently-touched skills, usage telemetry —
+and decide what to keep, patch, consolidate, or prune.
 
 Where the shadow_review observer LOOKS FOR new class-level learning,
 your role is the inverse: review the EXISTING store for quality, dedup,
@@ -229,6 +230,35 @@ CONSTRAINTS:
 INVENTORY
 =========
 """
+
+
+# Bounded curator slices. The spawn layer has its own argv safety net; these
+# limits keep each curator child reviewing a complete, context-sized slice.
+CURATOR_BATCH_MAX_ENTRIES = 200
+CURATOR_BATCH_MAX_CHARS = 55_000
+CURATOR_INVENTORY_PREVIEW_MAX_CHARS = 80_000
+
+
+@dataclass(frozen=True)
+class _InventoryEntry:
+    kind: str
+    key: str
+    text: str
+
+
+@dataclass(frozen=True)
+class _InventoryBatch:
+    index: int
+    total: int
+    start_entry: int
+    end_entry: int
+    total_entries: int
+    text: str
+    entry_count: int
+    lesson_count: int
+    skill_count: int
+    concept_count: int
+    char_count: int
 
 
 # ──────────────────────────────────────────────────────────────────────
@@ -478,6 +508,18 @@ def _format_skill(row: dict) -> str:
     )
 
 
+def _format_stale_lesson_row(row: dict) -> str:
+    age = int(row["age_days"])
+    return (
+        f"- {row['slug']} score={row['decay_score']:.6f} "
+        f"freq={row['access_frequency']:.4f}/d "
+        f"pulls={row['pull_count']} uses={row['use_count']} "
+        f"views={row['view_count']} last_access={age}d_ago "
+        f"tier={row['tier']} pinned={row['pinned']} "
+        f"source={row['source'] or '?'}"
+    )
+
+
 def _collect_stale_lessons(conn: sqlite3.Connection) -> tuple[str, int]:
     """Build the advisory stale-lessons decay section.
 
@@ -497,39 +539,30 @@ def _collect_stale_lessons(conn: sqlite3.Connection) -> tuple[str, int]:
         lines.append("(none)")
         return "\n".join(lines), 0
     for r in rows:
-        age = int(r["age_days"])
-        lines.append(
-            f"- {r['slug']} score={r['decay_score']:.6f} "
-            f"freq={r['access_frequency']:.4f}/d "
-            f"pulls={r['pull_count']} uses={r['use_count']} "
-            f"views={r['view_count']} last_access={age}d_ago "
-            f"tier={r['tier']} pinned={r['pinned']} "
-            f"source={r['source'] or '?'}"
-        )
+        lines.append(_format_stale_lesson_row(r))
     return "\n".join(lines), len(rows)
 
 
-def _collect_inventory(conn: sqlite3.Connection) -> tuple[str, int, int]:
-    """Build the inventory dump the curator child will read.
-
-    Returns (dump_text, lesson_count, skill_count). The dump format is
-    plain text — `_format_lesson` and `_format_skill` produce one line
-    per entry, grouped into LESSONS and SKILLS sections.
-    """
-    # ---- Lessons ----
-    lesson_lines: list[str] = []
-    n_lessons = 0
+def _collect_inventory_entry_groups(
+    conn: sqlite3.Connection,
+) -> tuple[list[_InventoryEntry], list[_InventoryEntry], str, int, int]:
+    """Collect lesson/skill inventory entries without rendering one prompt."""
+    lesson_entries: list[_InventoryEntry] = []
     try:
         usage = lessons.lesson_usage_map(conn)
         for item in lessons.iter_lessons():
-            lesson_lines.append(_format_lesson(item, usage.get(item["slug"])))
-            n_lessons += 1
+            slug = item.get("slug") or ""
+            lesson_entries.append(
+                _InventoryEntry(
+                    "lesson",
+                    slug,
+                    _format_lesson(item, usage.get(slug)),
+                )
+            )
     except Exception:
         logger.debug("curator: iter_lessons failed", exc_info=True)
 
-    # ---- Skills ----
-    skill_lines: list[str] = []
-    n_skills = 0
+    skill_entries: list[_InventoryEntry] = []
     try:
         rows = conn.execute(
             "SELECT name, created_at, created_by_origin, last_used_at, "
@@ -541,20 +574,126 @@ def _collect_inventory(conn: sqlite3.Connection) -> tuple[str, int, int]:
             "                  last_patched_at, created_at) DESC"
         ).fetchall()
         for r in rows:
-            skill_lines.append(_format_skill(dict(r)))
-            n_skills += 1
+            name = r["name"] or ""
+            skill_entries.append(
+                _InventoryEntry("skill", name, _format_skill(dict(r)))
+            )
     except sqlite3.OperationalError:
         logger.debug("curator: skill_usage scan failed", exc_info=True)
 
-    parts: list[str] = []
-    parts.append(f"## LESSONS (n={n_lessons})\n")
-    parts.extend(lesson_lines if lesson_lines else ["(none)"])
     stale_text, _n_stale = _collect_stale_lessons(conn)
+    return (
+        lesson_entries,
+        skill_entries,
+        stale_text,
+        len(lesson_entries),
+        len(skill_entries),
+    )
+
+
+def _append_entries_with_char_cap(
+    parts: list[str],
+    entries: list[_InventoryEntry],
+    *,
+    used_chars: int,
+    max_chars: int,
+) -> tuple[int, int]:
+    dropped = 0
+    for entry in entries:
+        cost = len(entry.text) + 1
+        if used_chars + cost > max_chars:
+            dropped += 1
+            continue
+        parts.append(entry.text)
+        used_chars += cost
+    return used_chars, dropped
+
+
+def _collect_inventory(conn: sqlite3.Connection) -> tuple[str, int, int]:
+    """Build the inventory dump the curator child will read.
+
+    Returns (dump_text, lesson_count, skill_count). The dump format is
+    plain text — `_format_lesson` and `_format_skill` produce one line
+    per entry, grouped into LESSONS and SKILLS sections. This preview is
+    char-capped as a defensive floor; the real curator pass uses complete
+    bounded batches from `_collect_inventory_batches`.
+    """
+    lesson_entries, skill_entries, stale_text, n_lessons, n_skills = (
+        _collect_inventory_entry_groups(conn)
+    )
+
+    parts: list[str] = []
+    used = 0
+    parts.append(f"## LESSONS (n={n_lessons})\n")
+    used += len(parts[-1]) + 1
+    if lesson_entries:
+        used, dropped_lessons = _append_entries_with_char_cap(
+            parts,
+            lesson_entries,
+            used_chars=used,
+            max_chars=CURATOR_INVENTORY_PREVIEW_MAX_CHARS,
+        )
+    else:
+        parts.append("(none)")
+        used += len(parts[-1]) + 1
+        dropped_lessons = 0
     parts.append("\n" + stale_text)
+    used += len(parts[-1]) + 1
     parts.append(f"\n## SKILLS (n={n_skills})\n")
-    parts.extend(skill_lines if skill_lines else ["(none)"])
+    used += len(parts[-1]) + 1
+    if skill_entries:
+        used, dropped_skills = _append_entries_with_char_cap(
+            parts,
+            skill_entries,
+            used_chars=used,
+            max_chars=CURATOR_INVENTORY_PREVIEW_MAX_CHARS,
+        )
+    else:
+        parts.append("(none)")
+        dropped_skills = 0
+
+    dropped_total = dropped_lessons + dropped_skills
+    if dropped_total:
+        parts.append(
+            "\n## INVENTORY TRUNCATED\n"
+            f"omitted_entries={dropped_total} "
+            f"omitted_lessons={dropped_lessons} "
+            f"omitted_skills={dropped_skills} "
+            f"preview_char_cap={CURATOR_INVENTORY_PREVIEW_MAX_CHARS}. "
+            "The live curator pass reviews complete bounded batches."
+        )
 
     return ("\n".join(parts), n_lessons, n_skills)
+
+
+def _collect_concept_entries(conn: sqlite3.Connection) -> tuple[list[_InventoryEntry], int]:
+    try:
+        rows = conn.execute(
+            "SELECT id, description, confidence, registered_at, "
+            "last_evidence_at FROM concepts "
+            "ORDER BY COALESCE(last_evidence_at, registered_at) ASC"
+        ).fetchall()
+    except sqlite3.OperationalError:
+        return [], 0
+    if not rows:
+        return [], 0
+    now_t = int(time.time())
+    entries: list[_InventoryEntry] = []
+    for r in rows:
+        last = r["last_evidence_at"] or r["registered_at"]
+        age_d = max(0, (now_t - last) // 86400)
+        desc = (r["description"] or "").replace("\n", " ")[:200]
+        cid = r["id"] or ""
+        entries.append(
+            _InventoryEntry(
+                "concept",
+                cid,
+                f"- {cid} conf={r['confidence']} "
+                f"last_evidence={age_d}d_ago\n"
+                f"    {desc}",
+            )
+        )
+    return entries, len(rows)
 
 
 def _collect_concepts(conn: sqlite3.Connection) -> tuple[str, int]:
@@ -566,28 +705,159 @@ def _collect_concepts(conn: sqlite3.Connection) -> tuple[str, int]:
     confidence band and days since last corroboration — the two signals
     the curator rubric uses to flag low-confidence/never-corroborated
     concepts as false positives."""
-    try:
-        rows = conn.execute(
-            "SELECT id, description, confidence, registered_at, "
-            "last_evidence_at FROM concepts "
-            "ORDER BY COALESCE(last_evidence_at, registered_at) ASC"
-        ).fetchall()
-    except sqlite3.OperationalError:
+    entries, count = _collect_concept_entries(conn)
+    if not entries:
         return "", 0
-    if not rows:
-        return "", 0
-    now_t = int(time.time())
-    lines = [f"## CONCEPTS (n={len(rows)})\n"]
-    for r in rows:
-        last = r["last_evidence_at"] or r["registered_at"]
-        age_d = max(0, (now_t - last) // 86400)
-        desc = (r["description"] or "").replace("\n", " ")[:200]
-        lines.append(
-            f"- {r['id']} conf={r['confidence']} "
-            f"last_evidence={age_d}d_ago\n"
-            f"    {desc}"
+    lines = [f"## CONCEPTS (n={count})\n"]
+    lines.extend(entry.text for entry in entries)
+    return "\n".join(lines), count
+
+
+def _entry_cost(entry: _InventoryEntry) -> int:
+    return len(entry.text) + 1
+
+
+def _chunk_inventory_entries(
+    entries: list[_InventoryEntry],
+    *,
+    max_entries: int = CURATOR_BATCH_MAX_ENTRIES,
+    max_chars: int = CURATOR_BATCH_MAX_CHARS,
+) -> list[list[_InventoryEntry]]:
+    entry_limit = max(1, int(max_entries))
+    char_limit = max(1_000, int(max_chars))
+    batches: list[list[_InventoryEntry]] = []
+    current: list[_InventoryEntry] = []
+    current_chars = 0
+    for entry in entries:
+        cost = _entry_cost(entry)
+        should_flush = (
+            current
+            and (
+                len(current) >= entry_limit
+                or current_chars + cost > char_limit
+            )
         )
-    return "\n".join(lines), len(rows)
+        if should_flush:
+            batches.append(current)
+            current = []
+            current_chars = 0
+        current.append(entry)
+        current_chars += cost
+    if current:
+        batches.append(current)
+    return batches
+
+
+def _render_batch_inventory(
+    batch_entries: list[_InventoryEntry],
+    *,
+    index: int,
+    total: int,
+    start_entry: int,
+    total_entries: int,
+    stale_text: str,
+    n_lessons: int,
+    n_skills: int,
+    n_concepts: int,
+) -> _InventoryBatch:
+    lesson_entries = [e for e in batch_entries if e.kind == "lesson"]
+    skill_entries = [e for e in batch_entries if e.kind == "skill"]
+    concept_entries = [e for e in batch_entries if e.kind == "concept"]
+    end_entry = start_entry + len(batch_entries) - 1
+    parts = [
+        f"## CURATOR BATCH {index}/{total}",
+        (
+            f"Coverage: entries {start_entry}-{end_entry} of "
+            f"{total_entries}; batch_entries={len(batch_entries)} "
+            f"lessons={len(lesson_entries)}/{n_lessons} "
+            f"skills={len(skill_entries)}/{n_skills} "
+            f"concepts={len(concept_entries)}/{n_concepts}."
+        ),
+        (
+            "Review ONLY the entries in this batch. Other curator children "
+            "receive the remaining bounded slices for the same inventory "
+            "fingerprint, so do not infer that omitted entries are absent."
+        ),
+        (
+            "For CONSOLIDATE, only merge entries whose full lines appear in "
+            "this batch; otherwise recommend a future cross-batch review."
+        ),
+        f"\n## LESSONS (n={len(lesson_entries)})\n",
+    ]
+    parts.extend(entry.text for entry in lesson_entries)
+    if not lesson_entries:
+        parts.append("(none)")
+    if lesson_entries:
+        parts.append("\n" + stale_text)
+    parts.append(f"\n## SKILLS (n={len(skill_entries)})\n")
+    parts.extend(entry.text for entry in skill_entries)
+    if not skill_entries:
+        parts.append("(none)")
+    parts.append(f"\n## CONCEPTS (n={len(concept_entries)})\n")
+    parts.extend(entry.text for entry in concept_entries)
+    if not concept_entries:
+        parts.append("(none)")
+    text = "\n".join(parts)
+    return _InventoryBatch(
+        index=index,
+        total=total,
+        start_entry=start_entry,
+        end_entry=end_entry,
+        total_entries=total_entries,
+        text=text,
+        entry_count=len(batch_entries),
+        lesson_count=len(lesson_entries),
+        skill_count=len(skill_entries),
+        concept_count=len(concept_entries),
+        char_count=len(text),
+    )
+
+
+def _collect_inventory_batches(
+    conn: sqlite3.Connection,
+) -> tuple[list[_InventoryBatch], int, int, int]:
+    lesson_entries, skill_entries, stale_text, n_lessons, n_skills = (
+        _collect_inventory_entry_groups(conn)
+    )
+    concept_entries, n_concepts = _collect_concept_entries(conn)
+    entries = lesson_entries + skill_entries + concept_entries
+    chunks = _chunk_inventory_entries(entries)
+    total = len(chunks)
+    batches: list[_InventoryBatch] = []
+    cursor = 1
+    for idx, chunk in enumerate(chunks, start=1):
+        batch = _render_batch_inventory(
+            chunk,
+            index=idx,
+            total=total,
+            start_entry=cursor,
+            total_entries=len(entries),
+            stale_text=stale_text,
+            n_lessons=n_lessons,
+            n_skills=n_skills,
+            n_concepts=n_concepts,
+        )
+        batches.append(batch)
+        cursor += len(chunk)
+    return batches, n_lessons, n_skills, n_concepts
+
+
+def _summarize_batch_entries(batches: list[_InventoryBatch]) -> str:
+    counts = [b.entry_count for b in batches]
+    if not counts:
+        return "0"
+    runs: list[str] = []
+    current = counts[0]
+    run_len = 1
+    for value in counts[1:]:
+        if value == current:
+            run_len += 1
+            continue
+        runs.append(f"{current}x{run_len}" if run_len > 1 else str(current))
+        current = value
+        run_len = 1
+    runs.append(f"{current}x{run_len}" if run_len > 1 else str(current))
+    return "+".join(runs)
 
 
 # ──────────────────────────────────────────────────────────────────────
@@ -657,7 +927,7 @@ def run_curator_pass(force: bool = False, *, scheduled: bool = False) -> str:
       - 'curator_running n=…' — a curator child is already running; skip
       - 'below_threshold' — fewer than CURATOR_MIN_LESSONS lessons; skip
       - 'unchanged_inventory' — latest complete inventory already reviewed
-      - 'spawned task_id=…' — curator child launched
+      - 'spawned task_id=…' or 'spawned batches=…' — child launches
       - 'spawn_error: …'  — spawn() rejected
     """
     if CURATOR_INTERVAL_S <= 0 and not force:
@@ -717,14 +987,13 @@ def run_curator_pass(force: bool = False, *, scheduled: bool = False) -> str:
                 f"fingerprint={fingerprint[:12]}{ts_part}"
             )
 
-        inventory, _n_lessons, _n_skills = _collect_inventory(conn)
-
         # Concepts enrich the review but do NOT lower the lesson threshold —
         # a curator pass is only worth a child spawn when there's a real
-        # lesson/skill inventory to audit; concepts ride along.
-        concepts_text, _n_concepts = _collect_concepts(conn)
-        if concepts_text:
-            inventory = inventory + "\n\n" + concepts_text
+        # lesson/skill inventory to audit; concepts ride along in the bounded
+        # batches.
+        batches, _n_lessons, _n_skills, _n_concepts = (
+            _collect_inventory_batches(conn)
+        )
 
         # Ensure reports dir exists before the child tries to Write into it.
         CURATOR_REPORTS_DIR.mkdir(parents=True, exist_ok=True)
@@ -807,33 +1076,52 @@ def run_curator_pass(force: bool = False, *, scheduled: bool = False) -> str:
                 "Read,Write"
             )
 
-        full_prompt = (
-            CURATOR_PROMPT.replace("{DESTRUCTIVE_CLAUSE}", destructive_clause)
-            + inventory
-            + "\n\n"
-            + f"REPORT_PATH = {CURATOR_REPORTS_DIR}/REPORT-"
-            f"{pass_id}.md\n"
-            + "Write the REPORT.md to that exact path."
-        )
-
         from .tools.spawn import spawn  # type: ignore
         old_pass = os.environ.get(PASS_ID_ENV)
         old_snap = os.environ.get(SNAPSHOT_DIR_ENV)
         if CURATOR_DESTRUCTIVE:
             os.environ[PASS_ID_ENV] = pass_id
             os.environ[SNAPSHOT_DIR_ENV] = str(snapshot_dir)
+        results: list[str] = []
         try:
             try:
-                result = spawn(
-                    prompt=full_prompt,
-                    visible=False,
-                    capture_output=True,
-                    permission_mode="auto",
-                    role="curator",
-                    write_origin="curator",
-                    slim=True,
-                    extra_allowed_tools=allowed_tools,
-                )
+                for batch in batches:
+                    if len(batches) == 1:
+                        report_name = f"REPORT-{pass_id}.md"
+                    else:
+                        report_name = (
+                            f"REPORT-{pass_id}-batch-"
+                            f"{batch.index:03d}-of-{batch.total:03d}.md"
+                        )
+                    full_prompt = (
+                        CURATOR_PROMPT.replace(
+                            "{DESTRUCTIVE_CLAUSE}",
+                            destructive_clause,
+                        )
+                        + batch.text
+                        + "\n\n"
+                        + f"REPORT_PATH = {CURATOR_REPORTS_DIR}/{report_name}\n"
+                        + "Write the REPORT.md to that exact path."
+                    )
+                    result = spawn(
+                        prompt=full_prompt,
+                        visible=False,
+                        capture_output=True,
+                        permission_mode="auto",
+                        role="curator",
+                        write_origin="curator",
+                        slim=True,
+                        extra_allowed_tools=allowed_tools,
+                    )
+                    result_s = str(result)
+                    if result_s.startswith("ERR "):
+                        out = (
+                            f"spawn_error batch={batch.index}/{batch.total}: "
+                            f"{result_s}"
+                        )
+                        _record_curator_pass(conn, now, out)
+                        return out
+                    results.append(result_s)
             finally:
                 if old_pass is None:
                     os.environ.pop(PASS_ID_ENV, None)
@@ -847,15 +1135,24 @@ def run_curator_pass(force: bool = False, *, scheduled: bool = False) -> str:
             _record_curator_pass(conn, now, f"spawn_error: {e}")
             return f"spawn_error: {e}"
 
+        batch_entries = _summarize_batch_entries(batches)
+        max_batch_chars = max((b.char_count for b in batches), default=0)
+        total_entries = sum(b.entry_count for b in batches)
         _record_curator_pass(
             conn, now,
             f"spawned {INVENTORY_FINGERPRINT_KEY}={fingerprint} "
-            f"lessons={n_lessons} skills={n_skills} "
-            f"concepts={n_concepts} "
+            f"entries={total_entries} batches={len(batches)} "
+            f"batch_entries={batch_entries} max_batch_chars={max_batch_chars} "
+            f"lessons={n_lessons} skills={n_skills} concepts={n_concepts} "
             f"snapshot={pass_id if snapshot_dir else '-'} "
-            f":: {str(result)[:140]}",
+            f":: {' | '.join(results)[:140]}",
         )
-        return str(result)
+        if len(results) == 1:
+            return results[0]
+        return (
+            f"spawned batches={len(results)} batch_entries={batch_entries} "
+            f":: {' | '.join(results)[:180]}"
+        )
 
 
 def _serve_loop() -> None:

--- a/threadkeeper/tools/curator.py
+++ b/threadkeeper/tools/curator.py
@@ -5,9 +5,9 @@ mutates skill_usage state). These tools are about the *LLM-driven*
 audit pass:
 
   curator_review(force=False, dry_run=False)
-    Trigger one curator pass NOW. Spawns a slim child with the inventory
-    of every lesson + skill, child writes a REPORT.md with KEEP / PATCH
-    / CONSOLIDATE / PRUNE recommendations.
+    Trigger one curator pass NOW. Spawns bounded slim-child batches over
+    the lesson + skill + concept inventory; each child writes a REPORT.md
+    with KEEP / PATCH / CONSOLIDATE / PRUNE recommendations.
 
   curator_review_status()
     Diagnostic: env config, last cursor, last 5 passes, latest REPORT
@@ -49,9 +49,9 @@ def curator_review(force: bool = False, dry_run: bool = False) -> str:
     Use for one-shot triage or testing the prompt.
 
     `dry_run=True` short-circuits before the spawn — returns the
-    inventory that WOULD be passed plus n_lessons/n_skills. No spawn,
-    no cursor advance. Use to inspect what the curator child would see
-    before paying for the spawn.
+    capped inventory preview plus n_lessons/n_skills. No spawn, no cursor
+    advance. Use to inspect the inventory shape before paying for the
+    batched spawn.
     """
     conn = get_db()
     _ensure_session(conn)

--- a/threadkeeper/tools/spawn.py
+++ b/threadkeeper/tools/spawn.py
@@ -51,6 +51,15 @@ _BYPASS_ALLOWED_PAIRS = {
 }
 _BYPASS_ENV_OVERRIDE = "THREADKEEPER_ALLOW_BYPASS_PERMISSIONS_SPAWN"
 
+# Linux caps one execve argv string at MAX_ARG_STRLEN (128 KiB), even when the
+# total ARG_MAX budget is larger. Keep Claude's positional prompt well below
+# that and feed larger prompts through the existing owner-only stdin spool.
+CLAUDE_PROMPT_ARGV_MAX_BYTES = 96 * 1024
+
+
+def _utf8_len(text: str) -> int:
+    return len(text.encode("utf-8"))
+
 
 def _permission_mode_is_bypass(permission_mode: str) -> bool:
     return (permission_mode or "").strip().lower() == "bypasspermissions"
@@ -628,8 +637,13 @@ def _spawn_impl(prompt: str, cwd: str = "", append_system: str = "",
         if not cmd:
             return f"ERR spawn_failed cli={chosen_cli} reason=binary_not_found"
     else:
-        cmd = [
-            bin_, "-p", prompt,
+        stdin_text = None
+        cmd = [bin_, "-p"]
+        if _utf8_len(prompt) > CLAUDE_PROMPT_ARGV_MAX_BYTES:
+            stdin_text = prompt
+        else:
+            cmd.append(prompt)
+        cmd += [
             "--session-id", child_cid,
             "--append-system-prompt", sys_extra,
         ]


### PR DESCRIPTION
## Summary
- split destructive Curator inventory review into bounded child batches with entry coverage telemetry
- cap the dry-run inventory preview with omitted-entry counts
- keep Claude prompt argv under 96 KiB by falling back to the owner-only stdin spool

## Tests
- env -u THREADKEEPER_NO_EMBEDDINGS .venv/bin/python -m pytest -q

Closes #105