### PR TITLE
fix: repair System Automation layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@ version bumps follow semver per the policy in
   job cards now use a compact hours-based schedule row and a wider adaptive
   grid minimum, preventing labels from collapsing into one-character columns.
   Empty `.env` selections show their concrete inherited value (`On`, `Off`, or
-  the effective hourly cadence) instead of a generic `Default` label.
+  the effective hourly cadence) instead of a generic `Default` label. Boolean
+  settings remain two-state controls; the reset button restores inheritance.
 
 ## v0.16.0 — 2026-07-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ version bumps follow semver per the policy in
 
 ## [Unreleased]
 
+## v0.16.1 — 2026-07-19
+
+### Fixed
+
+- **System Automation cards keep their schedule controls readable.** Mechanical
+  job cards now use a compact hours-based schedule row and a wider adaptive
+  grid minimum, preventing labels from collapsing into one-character columns.
+
 ## v0.16.0 — 2026-07-19
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ version bumps follow semver per the policy in
 - **System Automation cards keep their schedule controls readable.** Mechanical
   job cards now use a compact hours-based schedule row and a wider adaptive
   grid minimum, preventing labels from collapsing into one-character columns.
+  Settings cards expand to use the available tab width instead of leaving a
+  fixed empty column on the right.
   Empty `.env` selections show their concrete inherited value (`On`, `Off`, or
   the effective hourly cadence) instead of a generic `Default` label. Boolean
   settings remain two-state controls; the reset button restores inheritance.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ version bumps follow semver per the policy in
 - **System Automation cards keep their schedule controls readable.** Mechanical
   job cards now use a compact hours-based schedule row and a wider adaptive
   grid minimum, preventing labels from collapsing into one-character columns.
+  Empty `.env` selections show their concrete inherited value (`On`, `Off`, or
+  the effective hourly cadence) instead of a generic `Default` label.
 
 ## v0.16.0 — 2026-07-19
 

--- a/apps/macos-agent-status/ThreadKeeperAgentStatus.swift
+++ b/apps/macos-agent-status/ThreadKeeperAgentStatus.swift
@@ -3088,8 +3088,7 @@ struct EnvSettingRow: View {
     private var control: some View {
         switch definition.kind {
         case .toggle:
-            Picker("", selection: envStore.binding(for: definition.key)) {
-                Text(inheritedDefaultLabel(for: definition)).tag("")
+            Picker("", selection: effectiveToggleSelection) {
                 Text("On").tag("true")
                 Text("Off").tag("false")
             }
@@ -3121,6 +3120,18 @@ struct EnvSettingRow: View {
         }
     }
 
+    private var effectiveToggleSelection: Binding<String> {
+        Binding(
+            get: {
+                let explicit = envStore.values[definition.key] ?? ""
+                return normalizedToggleValue(explicit)
+                    ?? normalizedToggleValue(definition.defaultValue)
+                    ?? "false"
+            },
+            set: { envStore.setValue($0, for: definition.key) }
+        )
+    }
+
     private func choicesIncludingCurrent(_ choices: [ChoiceOption]) -> [ChoiceOption] {
         guard let current = envStore.values[definition.key],
               !current.isEmpty,
@@ -3131,6 +3142,14 @@ struct EnvSettingRow: View {
             ? "From .env · \(hourChoiceLabel(current))"
             : "From .env · \(current)"
         return choices + [ChoiceOption(current, label: label)]
+    }
+}
+
+private func normalizedToggleValue(_ raw: String) -> String? {
+    switch raw.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
+    case "1", "true", "yes", "on": return "true"
+    case "0", "false", "no", "off": return "false"
+    default: return nil
     }
 }
 

--- a/apps/macos-agent-status/ThreadKeeperAgentStatus.swift
+++ b/apps/macos-agent-status/ThreadKeeperAgentStatus.swift
@@ -2238,10 +2238,10 @@ struct EnvSettingsView: View {
     @ObservedObject var envStore: EnvSettingsStore
     @State private var selectedSection: EnvSettingsSection? = .cliAgents
     private let agentColumns = [
-        GridItem(.adaptive(minimum: 340, maximum: 520), spacing: 14, alignment: .top)
+        GridItem(.adaptive(minimum: 340, maximum: .infinity), spacing: 14, alignment: .top)
     ]
     private let automationColumns = [
-        GridItem(.adaptive(minimum: 340, maximum: 520), spacing: 14, alignment: .top)
+        GridItem(.adaptive(minimum: 340, maximum: .infinity), spacing: 14, alignment: .top)
     ]
 
     var body: some View {

--- a/apps/macos-agent-status/ThreadKeeperAgentStatus.swift
+++ b/apps/macos-agent-status/ThreadKeeperAgentStatus.swift
@@ -2221,7 +2221,7 @@ struct EnvSettingsView: View {
         GridItem(.adaptive(minimum: 340, maximum: 520), spacing: 14, alignment: .top)
     ]
     private let automationColumns = [
-        GridItem(.adaptive(minimum: 300, maximum: 460), spacing: 14, alignment: .top)
+        GridItem(.adaptive(minimum: 340, maximum: 520), spacing: 14, alignment: .top)
     ]
 
     var body: some View {
@@ -2849,11 +2849,64 @@ struct AutomationJobCard: View {
                 StatusBadge(text: "Mechanical", color: .secondary)
             }
             if let definition = envStore.definition(for: job.intervalKey) {
-                EnvSettingRow(definition: definition, envStore: envStore, showKey: false)
+                Divider()
+                AutomationScheduleRow(definition: definition, envStore: envStore)
                 ScheduleHint(value: envStore.values[job.intervalKey] ?? "")
             }
         }
         .settingsCardSurface()
+    }
+}
+
+struct AutomationScheduleRow: View {
+    let definition: EnvSettingDefinition
+    @ObservedObject var envStore: EnvSettingsStore
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Text("Schedule (hours)")
+                .font(.system(size: 11, weight: .semibold))
+                .lineLimit(1)
+                .layoutPriority(1)
+            Spacer(minLength: 8)
+            Picker("Schedule (hours)", selection: envStore.binding(for: definition.key)) {
+                Text("Default").tag("")
+                ForEach(choicesIncludingCurrent, id: \.value) { choice in
+                    Text(choice.label).tag(choice.value)
+                }
+            }
+            .labelsHidden()
+            .pickerStyle(.menu)
+            .frame(minWidth: 135, idealWidth: 170, maxWidth: 190)
+            Button {
+                envStore.setValue("", for: definition.key)
+            } label: {
+                Image(systemName: "xmark.circle.fill")
+                    .foregroundStyle(.tertiary)
+            }
+            .buttonStyle(.plain)
+            .disabled((envStore.values[definition.key] ?? "").isEmpty)
+            .accessibilityLabel("Use default for \(jobLabel)")
+            .help("Use default")
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private var choicesIncludingCurrent: [ChoiceOption] {
+        guard case .choice(let choices) = definition.kind,
+              let current = envStore.values[definition.key],
+              !current.isEmpty,
+              !choices.contains(where: { $0.value == current }) else {
+            if case .choice(let choices) = definition.kind { return choices }
+            return []
+        }
+        return choices + [
+            ChoiceOption(current, label: "From .env · \(hourChoiceLabel(current))")
+        ]
+    }
+
+    private var jobLabel: String {
+        definition.title.replacingOccurrences(of: " schedule (hours)", with: "")
     }
 }
 

--- a/apps/macos-agent-status/ThreadKeeperAgentStatus.swift
+++ b/apps/macos-agent-status/ThreadKeeperAgentStatus.swift
@@ -339,6 +339,23 @@ private let hourScheduleChoices = [
     ChoiceOption("2592000", label: "720 h · 30 days"),
 ]
 
+private let scheduleDefaultValues: [String: String] = [
+    "THREADKEEPER_INGEST_INTERVAL_S": "3",
+    "THREADKEEPER_RETENTION_INTERVAL_S": "0",
+    "THREADKEEPER_AUTO_UPDATE_INTERVAL_S": "86400",
+    "THREADKEEPER_SKILL_UPDATE_INTERVAL_S": "302400",
+    "THREADKEEPER_SHADOW_REVIEW_INTERVAL_S": "0",
+    "THREADKEEPER_CURATOR_INTERVAL_S": "259200",
+    "THREADKEEPER_EXTRACT_INTERVAL_S": "0",
+    "THREADKEEPER_CANDIDATE_REVIEW_INTERVAL_S": "0",
+    "THREADKEEPER_PROBE_INTERVAL_S": "0",
+    "THREADKEEPER_EVOLVE_REVIEW_INTERVAL_S": "0",
+    "THREADKEEPER_EVOLVE_APPLY_INTERVAL_S": "0",
+    "THREADKEEPER_THREAD_JANITOR_INTERVAL_S": "0",
+    "THREADKEEPER_DIALECTIC_MINE_INTERVAL_S": "0",
+    "THREADKEEPER_DIALECTIC_VALIDATE_INTERVAL_S": "0",
+]
+
 private let memoryLimitChoices = choiceOptions([
     "0", "256", "512", "768", "1024", "1536", "2048", "3072",
     "4096", "6144", "8192", "12288",
@@ -423,7 +440,7 @@ private let baseEnvSettingDefinitions: [EnvSettingDefinition] = [
         key: "THREADKEEPER_CURATOR_INTERVAL_S",
         title: "Curator interval",
         detail: "Audits and consolidates materialized lessons.",
-        defaultValue: "0",
+        defaultValue: "259200",
         kind: .choice(hourScheduleChoices)
     ),
     EnvSettingDefinition(
@@ -596,13 +613,16 @@ final class EnvSettingsStore: ObservableObject {
         var definitions = baseEnvSettingDefinitions
         let clis = catalog?.clis ?? []
         let choices = cliChoices
+        let activeCLI = catalog?.activeCLI
+            ?? clis.first(where: \.installed)?.id
+            ?? "claude"
         if !choices.isEmpty {
             definitions.append(EnvSettingDefinition(
                 group: "CLI Agents",
                 key: "THREADKEEPER_SPAWN__DEFAULT",
                 title: "Default CLI",
                 detail: "Inherited by every Learning Loop agent without an override.",
-                defaultValue: "",
+                defaultValue: activeCLI,
                 kind: .choice(choices)
             ))
         }
@@ -615,7 +635,7 @@ final class EnvSettingsStore: ObservableObject {
                 key: modelKey,
                 title: "\(cli.name) default model",
                 detail: "CLI default when an agent has no model override.",
-                defaultValue: "CLI default",
+                defaultValue: "CLI managed",
                 kind: .model(choiceOptions(
                     cli.models,
                     preserving: [values[modelKey] ?? ""]
@@ -631,7 +651,7 @@ final class EnvSettingsStore: ObservableObject {
                     key: effortKey,
                     title: "\(cli.name) default effort",
                     detail: "CLI effort inherited by agents without an override.",
-                    defaultValue: "CLI default",
+                    defaultValue: "CLI managed",
                     kind: .choice(choiceOptions(
                         efforts,
                         preserving: [values[effortKey] ?? ""]
@@ -646,7 +666,7 @@ final class EnvSettingsStore: ObservableObject {
                 key: "THREADKEEPER_SPAWN__LOOP__\(token)",
                 title: "\(role.name) CLI",
                 detail: "Default inherits the global CLI.",
-                defaultValue: "Inherited",
+                defaultValue: role.cli.isEmpty ? activeCLI : role.cli,
                 kind: .choice(choices)
             ))
             let roleCLI = draftCLI(for: role)
@@ -657,7 +677,7 @@ final class EnvSettingsStore: ObservableObject {
                 key: roleModelKey,
                 title: "\(role.name) model",
                 detail: "Default inherits the selected CLI model.",
-                defaultValue: "Inherited",
+                defaultValue: role.model.isEmpty ? "CLI managed" : role.model,
                 kind: .model(choiceOptions(
                     models,
                     preserving: [values[roleModelKey] ?? ""]
@@ -690,7 +710,7 @@ final class EnvSettingsStore: ObservableObject {
                 key: effortKey,
                 title: "\(role.name) effort",
                 detail: "Default inherits the selected CLI effort.",
-                defaultValue: "Inherited",
+                defaultValue: role.effort.isEmpty ? "CLI managed" : role.effort,
                 kind: effortKind
             ))
             if !role.intervalKey.isEmpty {
@@ -699,7 +719,7 @@ final class EnvSettingsStore: ObservableObject {
                     key: role.intervalKey,
                     title: "\(role.name) schedule (hours)",
                     detail: "Choose the cadence in hours; Off disables this schedule.",
-                    defaultValue: "0",
+                    defaultValue: scheduleDefaultValues[role.intervalKey] ?? "0",
                     kind: .choice(hourScheduleChoices)
                 ))
             }
@@ -710,7 +730,7 @@ final class EnvSettingsStore: ObservableObject {
                 key: job.intervalKey,
                 title: "\(job.name) schedule (hours)",
                 detail: "Choose the cadence in hours; Off disables this job.",
-                defaultValue: "0",
+                defaultValue: scheduleDefaultValues[job.intervalKey] ?? "0",
                 kind: .choice(hourScheduleChoices)
             ))
         }
@@ -2746,7 +2766,10 @@ struct LearningAgentCard: View {
             if !role.intervalKey.isEmpty,
                let schedule = envStore.definition(for: role.intervalKey) {
                 EnvSettingRow(definition: schedule, envStore: envStore, showKey: false)
-                ScheduleHint(value: envStore.values[role.intervalKey] ?? "")
+                ScheduleHint(
+                    value: envStore.values[role.intervalKey] ?? "",
+                    defaultValue: schedule.defaultValue
+                )
             } else {
                 Label("Runs on demand; no autonomous schedule.", systemImage: "hand.tap")
                     .font(.system(size: 11))
@@ -2851,7 +2874,10 @@ struct AutomationJobCard: View {
             if let definition = envStore.definition(for: job.intervalKey) {
                 Divider()
                 AutomationScheduleRow(definition: definition, envStore: envStore)
-                ScheduleHint(value: envStore.values[job.intervalKey] ?? "")
+                ScheduleHint(
+                    value: envStore.values[job.intervalKey] ?? "",
+                    defaultValue: definition.defaultValue
+                )
             }
         }
         .settingsCardSurface()
@@ -2870,7 +2896,7 @@ struct AutomationScheduleRow: View {
                 .layoutPriority(1)
             Spacer(minLength: 8)
             Picker("Schedule (hours)", selection: envStore.binding(for: definition.key)) {
-                Text("Default").tag("")
+                Text(inheritedDefaultLabel(for: definition)).tag("")
                 ForEach(choicesIncludingCurrent, id: \.value) { choice in
                     Text(choice.label).tag(choice.value)
                 }
@@ -2886,8 +2912,10 @@ struct AutomationScheduleRow: View {
             }
             .buttonStyle(.plain)
             .disabled((envStore.values[definition.key] ?? "").isEmpty)
-            .accessibilityLabel("Use default for \(jobLabel)")
-            .help("Use default")
+            .accessibilityLabel(
+                "Use inherited \(concreteDefaultLabel(for: definition)) for \(jobLabel)"
+            )
+            .help("Use inherited value: \(concreteDefaultLabel(for: definition))")
         }
         .frame(maxWidth: .infinity, alignment: .leading)
     }
@@ -2929,13 +2957,19 @@ struct ImpactLine: View {
 
 struct ScheduleHint: View {
     let value: String
+    let defaultValue: String
 
     var body: some View {
-        Label(humanSchedule(value), systemImage: "clock")
+        let explicit = !value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        let effectiveValue = explicit ? value : defaultValue
+        let label = explicit
+            ? humanSchedule(effectiveValue)
+            : "\(humanSchedule(effectiveValue)) · inherited"
+        Label(label, systemImage: "clock")
             .font(.system(size: 10, weight: .medium))
             .foregroundStyle(.secondary)
             .padding(.leading, 10)
-            .accessibilityLabel("Schedule: \(humanSchedule(value))")
+            .accessibilityLabel("Schedule: \(label)")
     }
 }
 
@@ -3041,8 +3075,10 @@ struct EnvSettingRow: View {
             }
             .buttonStyle(.plain)
             .disabled((envStore.values[definition.key] ?? "").isEmpty)
-            .accessibilityLabel("Use default for \(definition.title)")
-            .help("Use default")
+            .accessibilityLabel(
+                "Use inherited \(concreteDefaultLabel(for: definition)) for \(definition.title)"
+            )
+            .help("Use inherited value: \(concreteDefaultLabel(for: definition))")
         }
         .padding(.horizontal, 10)
         .padding(.vertical, 9)
@@ -3053,7 +3089,7 @@ struct EnvSettingRow: View {
         switch definition.kind {
         case .toggle:
             Picker("", selection: envStore.binding(for: definition.key)) {
-                Text("Default").tag("")
+                Text(inheritedDefaultLabel(for: definition)).tag("")
                 Text("On").tag("true")
                 Text("Off").tag("false")
             }
@@ -3061,7 +3097,7 @@ struct EnvSettingRow: View {
             .pickerStyle(.segmented)
         case .choice(let choices):
             Picker("", selection: envStore.binding(for: definition.key)) {
-                Text("Default").tag("")
+                Text(inheritedDefaultLabel(for: definition)).tag("")
                 ForEach(choicesIncludingCurrent(choices), id: \.value) { choice in
                     Text(choice.label).tag(choice.value)
                 }
@@ -3071,7 +3107,7 @@ struct EnvSettingRow: View {
         case .model(let choices):
             VStack(alignment: .trailing, spacing: 4) {
                 Picker("", selection: envStore.binding(for: definition.key)) {
-                    Text("CLI default").tag("")
+                    Text(inheritedDefaultLabel(for: definition)).tag("")
                     ForEach(choicesIncludingCurrent(choices), id: \.value) { choice in
                         Text(choice.label).tag(choice.value)
                     }
@@ -3096,6 +3132,30 @@ struct EnvSettingRow: View {
             : "From .env · \(current)"
         return choices + [ChoiceOption(current, label: label)]
     }
+}
+
+private func concreteDefaultLabel(for definition: EnvSettingDefinition) -> String {
+    let raw = definition.defaultValue.trimmingCharacters(in: .whitespacesAndNewlines)
+    switch definition.kind {
+    case .toggle:
+        if raw.lowercased() == "true" { return "On" }
+        if raw.lowercased() == "false" { return "Off" }
+        return raw.isEmpty ? "Off" : raw
+    case .choice(let choices):
+        if let option = choices.first(where: { $0.value == raw }) {
+            return option.label
+        }
+        if definition.key.hasSuffix("_S") {
+            return hourChoiceLabel(raw)
+        }
+        return raw.isEmpty ? "Inherited" : raw
+    case .model:
+        return raw.isEmpty ? "CLI managed" : raw
+    }
+}
+
+private func inheritedDefaultLabel(for definition: EnvSettingDefinition) -> String {
+    "\(concreteDefaultLabel(for: definition)) · inherited"
 }
 
 private func formattedHours(_ hours: Double) -> String {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "threadkeeper"
-version = "0.16.0"
+version = "0.16.1"
 description = "Multi-agent shared brain across Claude Code/Desktop, Codex, Antigravity CLI, Copilot, and VS Code. Cross-session memory, self-improving skill loops, inter-agent signaling — one local MCP server."
 requires-python = ">=3.11"
 authors = [{ name = "thread-keeper contributors" }]

--- a/server.json
+++ b/server.json
@@ -7,12 +7,12 @@
     "url": "https://github.com/po4erk91/thread-keeper",
     "source": "github"
   },
-  "version": "0.16.0",
+  "version": "0.16.1",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "threadkeeper",
-      "version": "0.16.0",
+      "version": "0.16.1",
       "transport": {
         "type": "stdio"
       }

--- a/tests/test_menubar_app.py
+++ b/tests/test_menubar_app.py
@@ -147,7 +147,8 @@ def test_menubar_env_settings_window_edits_env_and_presets():
     assert "AutomationJobCard" in swift
     assert "AutomationScheduleRow" in swift
     assert 'Text("Schedule (hours)")' in swift
-    assert "GridItem(.adaptive(minimum: 340, maximum: 520)" in swift
+    assert swift.count("GridItem(.adaptive(minimum: 340, maximum: .infinity)") == 2
+    assert "GridItem(.adaptive(minimum: 340, maximum: 520)" not in swift
     assert 'Text("Default")' not in swift
     assert 'Text("CLI default")' not in swift
     assert "inheritedDefaultLabel(for: definition)" in swift

--- a/tests/test_menubar_app.py
+++ b/tests/test_menubar_app.py
@@ -148,6 +148,13 @@ def test_menubar_env_settings_window_edits_env_and_presets():
     assert "AutomationScheduleRow" in swift
     assert 'Text("Schedule (hours)")' in swift
     assert "GridItem(.adaptive(minimum: 340, maximum: 520)" in swift
+    assert 'Text("Default")' not in swift
+    assert 'Text("CLI default")' not in swift
+    assert "inheritedDefaultLabel(for: definition)" in swift
+    assert '"THREADKEEPER_INGEST_INTERVAL_S": "3"' in swift
+    assert '"THREADKEEPER_CURATOR_INTERVAL_S": "259200"' in swift
+    assert '"THREADKEEPER_SKILL_UPDATE_INTERVAL_S": "302400"' in swift
+    assert '"\\(humanSchedule(effectiveValue)) · inherited"' in swift
     automation_card = swift[
         swift.index("struct AutomationJobCard"):
         swift.index("struct AutomationScheduleRow")
@@ -186,7 +193,7 @@ def test_menubar_env_settings_window_edits_env_and_presets():
     assert 'CommandGroup(replacing: .appSettings)' in swift
     assert '.accessibilityLabel("Settings presets")' in swift
     assert '.accessibilityLabel("Refresh CLI models and capabilities")' in swift
-    assert '.accessibilityLabel("Use default for \\(definition.title)")' in swift
+    assert '"Use inherited \\(concreteDefaultLabel(for: definition)) for \\(definition.title)"' in swift
     assert 'Label("Save Changes", systemImage: "square.and.arrow.down")' in swift
     assert 'Label("Save & Restart", systemImage: "arrow.clockwise")' in swift
     assert 'process.arguments = ["-TERM", "-f", "threadkeeper.server"]' in swift

--- a/tests/test_menubar_app.py
+++ b/tests/test_menubar_app.py
@@ -151,6 +151,14 @@ def test_menubar_env_settings_window_edits_env_and_presets():
     assert 'Text("Default")' not in swift
     assert 'Text("CLI default")' not in swift
     assert "inheritedDefaultLabel(for: definition)" in swift
+    control_start = swift.index("    private var control: some View")
+    toggle_start = swift.index("case .toggle:", control_start)
+    toggle_end = swift.index("case .choice", toggle_start)
+    toggle_control = swift[toggle_start:toggle_end]
+    assert "selection: effectiveToggleSelection" in toggle_control
+    assert 'Text("On").tag("true")' in toggle_control
+    assert 'Text("Off").tag("false")' in toggle_control
+    assert '.tag("")' not in toggle_control
     assert '"THREADKEEPER_INGEST_INTERVAL_S": "3"' in swift
     assert '"THREADKEEPER_CURATOR_INTERVAL_S": "259200"' in swift
     assert '"THREADKEEPER_SKILL_UPDATE_INTERVAL_S": "302400"' in swift

--- a/tests/test_menubar_app.py
+++ b/tests/test_menubar_app.py
@@ -145,6 +145,14 @@ def test_menubar_env_settings_window_edits_env_and_presets():
     assert "THREADKEEPER_SPAWN__EFFORT__\\(token)" in swift
     assert "LearningAgentCard" in swift
     assert "AutomationJobCard" in swift
+    assert "AutomationScheduleRow" in swift
+    assert 'Text("Schedule (hours)")' in swift
+    assert "GridItem(.adaptive(minimum: 340, maximum: 520)" in swift
+    automation_card = swift[
+        swift.index("struct AutomationJobCard"):
+        swift.index("struct AutomationScheduleRow")
+    ]
+    assert "EnvSettingRow(" not in automation_card
     assert "ImpactBadge" in swift
     assert "ScheduleHint" in swift
     assert "hourScheduleChoices" in swift

--- a/threadkeeper/assets/macos-agent-status/ThreadKeeperAgentStatus.swift
+++ b/threadkeeper/assets/macos-agent-status/ThreadKeeperAgentStatus.swift
@@ -3088,8 +3088,7 @@ struct EnvSettingRow: View {
     private var control: some View {
         switch definition.kind {
         case .toggle:
-            Picker("", selection: envStore.binding(for: definition.key)) {
-                Text(inheritedDefaultLabel(for: definition)).tag("")
+            Picker("", selection: effectiveToggleSelection) {
                 Text("On").tag("true")
                 Text("Off").tag("false")
             }
@@ -3121,6 +3120,18 @@ struct EnvSettingRow: View {
         }
     }
 
+    private var effectiveToggleSelection: Binding<String> {
+        Binding(
+            get: {
+                let explicit = envStore.values[definition.key] ?? ""
+                return normalizedToggleValue(explicit)
+                    ?? normalizedToggleValue(definition.defaultValue)
+                    ?? "false"
+            },
+            set: { envStore.setValue($0, for: definition.key) }
+        )
+    }
+
     private func choicesIncludingCurrent(_ choices: [ChoiceOption]) -> [ChoiceOption] {
         guard let current = envStore.values[definition.key],
               !current.isEmpty,
@@ -3131,6 +3142,14 @@ struct EnvSettingRow: View {
             ? "From .env · \(hourChoiceLabel(current))"
             : "From .env · \(current)"
         return choices + [ChoiceOption(current, label: label)]
+    }
+}
+
+private func normalizedToggleValue(_ raw: String) -> String? {
+    switch raw.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
+    case "1", "true", "yes", "on": return "true"
+    case "0", "false", "no", "off": return "false"
+    default: return nil
     }
 }
 

--- a/threadkeeper/assets/macos-agent-status/ThreadKeeperAgentStatus.swift
+++ b/threadkeeper/assets/macos-agent-status/ThreadKeeperAgentStatus.swift
@@ -2238,10 +2238,10 @@ struct EnvSettingsView: View {
     @ObservedObject var envStore: EnvSettingsStore
     @State private var selectedSection: EnvSettingsSection? = .cliAgents
     private let agentColumns = [
-        GridItem(.adaptive(minimum: 340, maximum: 520), spacing: 14, alignment: .top)
+        GridItem(.adaptive(minimum: 340, maximum: .infinity), spacing: 14, alignment: .top)
     ]
     private let automationColumns = [
-        GridItem(.adaptive(minimum: 340, maximum: 520), spacing: 14, alignment: .top)
+        GridItem(.adaptive(minimum: 340, maximum: .infinity), spacing: 14, alignment: .top)
     ]
 
     var body: some View {

--- a/threadkeeper/assets/macos-agent-status/ThreadKeeperAgentStatus.swift
+++ b/threadkeeper/assets/macos-agent-status/ThreadKeeperAgentStatus.swift
@@ -2221,7 +2221,7 @@ struct EnvSettingsView: View {
         GridItem(.adaptive(minimum: 340, maximum: 520), spacing: 14, alignment: .top)
     ]
     private let automationColumns = [
-        GridItem(.adaptive(minimum: 300, maximum: 460), spacing: 14, alignment: .top)
+        GridItem(.adaptive(minimum: 340, maximum: 520), spacing: 14, alignment: .top)
     ]
 
     var body: some View {
@@ -2849,11 +2849,64 @@ struct AutomationJobCard: View {
                 StatusBadge(text: "Mechanical", color: .secondary)
             }
             if let definition = envStore.definition(for: job.intervalKey) {
-                EnvSettingRow(definition: definition, envStore: envStore, showKey: false)
+                Divider()
+                AutomationScheduleRow(definition: definition, envStore: envStore)
                 ScheduleHint(value: envStore.values[job.intervalKey] ?? "")
             }
         }
         .settingsCardSurface()
+    }
+}
+
+struct AutomationScheduleRow: View {
+    let definition: EnvSettingDefinition
+    @ObservedObject var envStore: EnvSettingsStore
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Text("Schedule (hours)")
+                .font(.system(size: 11, weight: .semibold))
+                .lineLimit(1)
+                .layoutPriority(1)
+            Spacer(minLength: 8)
+            Picker("Schedule (hours)", selection: envStore.binding(for: definition.key)) {
+                Text("Default").tag("")
+                ForEach(choicesIncludingCurrent, id: \.value) { choice in
+                    Text(choice.label).tag(choice.value)
+                }
+            }
+            .labelsHidden()
+            .pickerStyle(.menu)
+            .frame(minWidth: 135, idealWidth: 170, maxWidth: 190)
+            Button {
+                envStore.setValue("", for: definition.key)
+            } label: {
+                Image(systemName: "xmark.circle.fill")
+                    .foregroundStyle(.tertiary)
+            }
+            .buttonStyle(.plain)
+            .disabled((envStore.values[definition.key] ?? "").isEmpty)
+            .accessibilityLabel("Use default for \(jobLabel)")
+            .help("Use default")
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private var choicesIncludingCurrent: [ChoiceOption] {
+        guard case .choice(let choices) = definition.kind,
+              let current = envStore.values[definition.key],
+              !current.isEmpty,
+              !choices.contains(where: { $0.value == current }) else {
+            if case .choice(let choices) = definition.kind { return choices }
+            return []
+        }
+        return choices + [
+            ChoiceOption(current, label: "From .env · \(hourChoiceLabel(current))")
+        ]
+    }
+
+    private var jobLabel: String {
+        definition.title.replacingOccurrences(of: " schedule (hours)", with: "")
     }
 }
 

--- a/threadkeeper/assets/macos-agent-status/ThreadKeeperAgentStatus.swift
+++ b/threadkeeper/assets/macos-agent-status/ThreadKeeperAgentStatus.swift
@@ -339,6 +339,23 @@ private let hourScheduleChoices = [
     ChoiceOption("2592000", label: "720 h · 30 days"),
 ]
 
+private let scheduleDefaultValues: [String: String] = [
+    "THREADKEEPER_INGEST_INTERVAL_S": "3",
+    "THREADKEEPER_RETENTION_INTERVAL_S": "0",
+    "THREADKEEPER_AUTO_UPDATE_INTERVAL_S": "86400",
+    "THREADKEEPER_SKILL_UPDATE_INTERVAL_S": "302400",
+    "THREADKEEPER_SHADOW_REVIEW_INTERVAL_S": "0",
+    "THREADKEEPER_CURATOR_INTERVAL_S": "259200",
+    "THREADKEEPER_EXTRACT_INTERVAL_S": "0",
+    "THREADKEEPER_CANDIDATE_REVIEW_INTERVAL_S": "0",
+    "THREADKEEPER_PROBE_INTERVAL_S": "0",
+    "THREADKEEPER_EVOLVE_REVIEW_INTERVAL_S": "0",
+    "THREADKEEPER_EVOLVE_APPLY_INTERVAL_S": "0",
+    "THREADKEEPER_THREAD_JANITOR_INTERVAL_S": "0",
+    "THREADKEEPER_DIALECTIC_MINE_INTERVAL_S": "0",
+    "THREADKEEPER_DIALECTIC_VALIDATE_INTERVAL_S": "0",
+]
+
 private let memoryLimitChoices = choiceOptions([
     "0", "256", "512", "768", "1024", "1536", "2048", "3072",
     "4096", "6144", "8192", "12288",
@@ -423,7 +440,7 @@ private let baseEnvSettingDefinitions: [EnvSettingDefinition] = [
         key: "THREADKEEPER_CURATOR_INTERVAL_S",
         title: "Curator interval",
         detail: "Audits and consolidates materialized lessons.",
-        defaultValue: "0",
+        defaultValue: "259200",
         kind: .choice(hourScheduleChoices)
     ),
     EnvSettingDefinition(
@@ -596,13 +613,16 @@ final class EnvSettingsStore: ObservableObject {
         var definitions = baseEnvSettingDefinitions
         let clis = catalog?.clis ?? []
         let choices = cliChoices
+        let activeCLI = catalog?.activeCLI
+            ?? clis.first(where: \.installed)?.id
+            ?? "claude"
         if !choices.isEmpty {
             definitions.append(EnvSettingDefinition(
                 group: "CLI Agents",
                 key: "THREADKEEPER_SPAWN__DEFAULT",
                 title: "Default CLI",
                 detail: "Inherited by every Learning Loop agent without an override.",
-                defaultValue: "",
+                defaultValue: activeCLI,
                 kind: .choice(choices)
             ))
         }
@@ -615,7 +635,7 @@ final class EnvSettingsStore: ObservableObject {
                 key: modelKey,
                 title: "\(cli.name) default model",
                 detail: "CLI default when an agent has no model override.",
-                defaultValue: "CLI default",
+                defaultValue: "CLI managed",
                 kind: .model(choiceOptions(
                     cli.models,
                     preserving: [values[modelKey] ?? ""]
@@ -631,7 +651,7 @@ final class EnvSettingsStore: ObservableObject {
                     key: effortKey,
                     title: "\(cli.name) default effort",
                     detail: "CLI effort inherited by agents without an override.",
-                    defaultValue: "CLI default",
+                    defaultValue: "CLI managed",
                     kind: .choice(choiceOptions(
                         efforts,
                         preserving: [values[effortKey] ?? ""]
@@ -646,7 +666,7 @@ final class EnvSettingsStore: ObservableObject {
                 key: "THREADKEEPER_SPAWN__LOOP__\(token)",
                 title: "\(role.name) CLI",
                 detail: "Default inherits the global CLI.",
-                defaultValue: "Inherited",
+                defaultValue: role.cli.isEmpty ? activeCLI : role.cli,
                 kind: .choice(choices)
             ))
             let roleCLI = draftCLI(for: role)
@@ -657,7 +677,7 @@ final class EnvSettingsStore: ObservableObject {
                 key: roleModelKey,
                 title: "\(role.name) model",
                 detail: "Default inherits the selected CLI model.",
-                defaultValue: "Inherited",
+                defaultValue: role.model.isEmpty ? "CLI managed" : role.model,
                 kind: .model(choiceOptions(
                     models,
                     preserving: [values[roleModelKey] ?? ""]
@@ -690,7 +710,7 @@ final class EnvSettingsStore: ObservableObject {
                 key: effortKey,
                 title: "\(role.name) effort",
                 detail: "Default inherits the selected CLI effort.",
-                defaultValue: "Inherited",
+                defaultValue: role.effort.isEmpty ? "CLI managed" : role.effort,
                 kind: effortKind
             ))
             if !role.intervalKey.isEmpty {
@@ -699,7 +719,7 @@ final class EnvSettingsStore: ObservableObject {
                     key: role.intervalKey,
                     title: "\(role.name) schedule (hours)",
                     detail: "Choose the cadence in hours; Off disables this schedule.",
-                    defaultValue: "0",
+                    defaultValue: scheduleDefaultValues[role.intervalKey] ?? "0",
                     kind: .choice(hourScheduleChoices)
                 ))
             }
@@ -710,7 +730,7 @@ final class EnvSettingsStore: ObservableObject {
                 key: job.intervalKey,
                 title: "\(job.name) schedule (hours)",
                 detail: "Choose the cadence in hours; Off disables this job.",
-                defaultValue: "0",
+                defaultValue: scheduleDefaultValues[job.intervalKey] ?? "0",
                 kind: .choice(hourScheduleChoices)
             ))
         }
@@ -2746,7 +2766,10 @@ struct LearningAgentCard: View {
             if !role.intervalKey.isEmpty,
                let schedule = envStore.definition(for: role.intervalKey) {
                 EnvSettingRow(definition: schedule, envStore: envStore, showKey: false)
-                ScheduleHint(value: envStore.values[role.intervalKey] ?? "")
+                ScheduleHint(
+                    value: envStore.values[role.intervalKey] ?? "",
+                    defaultValue: schedule.defaultValue
+                )
             } else {
                 Label("Runs on demand; no autonomous schedule.", systemImage: "hand.tap")
                     .font(.system(size: 11))
@@ -2851,7 +2874,10 @@ struct AutomationJobCard: View {
             if let definition = envStore.definition(for: job.intervalKey) {
                 Divider()
                 AutomationScheduleRow(definition: definition, envStore: envStore)
-                ScheduleHint(value: envStore.values[job.intervalKey] ?? "")
+                ScheduleHint(
+                    value: envStore.values[job.intervalKey] ?? "",
+                    defaultValue: definition.defaultValue
+                )
             }
         }
         .settingsCardSurface()
@@ -2870,7 +2896,7 @@ struct AutomationScheduleRow: View {
                 .layoutPriority(1)
             Spacer(minLength: 8)
             Picker("Schedule (hours)", selection: envStore.binding(for: definition.key)) {
-                Text("Default").tag("")
+                Text(inheritedDefaultLabel(for: definition)).tag("")
                 ForEach(choicesIncludingCurrent, id: \.value) { choice in
                     Text(choice.label).tag(choice.value)
                 }
@@ -2886,8 +2912,10 @@ struct AutomationScheduleRow: View {
             }
             .buttonStyle(.plain)
             .disabled((envStore.values[definition.key] ?? "").isEmpty)
-            .accessibilityLabel("Use default for \(jobLabel)")
-            .help("Use default")
+            .accessibilityLabel(
+                "Use inherited \(concreteDefaultLabel(for: definition)) for \(jobLabel)"
+            )
+            .help("Use inherited value: \(concreteDefaultLabel(for: definition))")
         }
         .frame(maxWidth: .infinity, alignment: .leading)
     }
@@ -2929,13 +2957,19 @@ struct ImpactLine: View {
 
 struct ScheduleHint: View {
     let value: String
+    let defaultValue: String
 
     var body: some View {
-        Label(humanSchedule(value), systemImage: "clock")
+        let explicit = !value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        let effectiveValue = explicit ? value : defaultValue
+        let label = explicit
+            ? humanSchedule(effectiveValue)
+            : "\(humanSchedule(effectiveValue)) · inherited"
+        Label(label, systemImage: "clock")
             .font(.system(size: 10, weight: .medium))
             .foregroundStyle(.secondary)
             .padding(.leading, 10)
-            .accessibilityLabel("Schedule: \(humanSchedule(value))")
+            .accessibilityLabel("Schedule: \(label)")
     }
 }
 
@@ -3041,8 +3075,10 @@ struct EnvSettingRow: View {
             }
             .buttonStyle(.plain)
             .disabled((envStore.values[definition.key] ?? "").isEmpty)
-            .accessibilityLabel("Use default for \(definition.title)")
-            .help("Use default")
+            .accessibilityLabel(
+                "Use inherited \(concreteDefaultLabel(for: definition)) for \(definition.title)"
+            )
+            .help("Use inherited value: \(concreteDefaultLabel(for: definition))")
         }
         .padding(.horizontal, 10)
         .padding(.vertical, 9)
@@ -3053,7 +3089,7 @@ struct EnvSettingRow: View {
         switch definition.kind {
         case .toggle:
             Picker("", selection: envStore.binding(for: definition.key)) {
-                Text("Default").tag("")
+                Text(inheritedDefaultLabel(for: definition)).tag("")
                 Text("On").tag("true")
                 Text("Off").tag("false")
             }
@@ -3061,7 +3097,7 @@ struct EnvSettingRow: View {
             .pickerStyle(.segmented)
         case .choice(let choices):
             Picker("", selection: envStore.binding(for: definition.key)) {
-                Text("Default").tag("")
+                Text(inheritedDefaultLabel(for: definition)).tag("")
                 ForEach(choicesIncludingCurrent(choices), id: \.value) { choice in
                     Text(choice.label).tag(choice.value)
                 }
@@ -3071,7 +3107,7 @@ struct EnvSettingRow: View {
         case .model(let choices):
             VStack(alignment: .trailing, spacing: 4) {
                 Picker("", selection: envStore.binding(for: definition.key)) {
-                    Text("CLI default").tag("")
+                    Text(inheritedDefaultLabel(for: definition)).tag("")
                     ForEach(choicesIncludingCurrent(choices), id: \.value) { choice in
                         Text(choice.label).tag(choice.value)
                     }
@@ -3096,6 +3132,30 @@ struct EnvSettingRow: View {
             : "From .env · \(current)"
         return choices + [ChoiceOption(current, label: label)]
     }
+}
+
+private func concreteDefaultLabel(for definition: EnvSettingDefinition) -> String {
+    let raw = definition.defaultValue.trimmingCharacters(in: .whitespacesAndNewlines)
+    switch definition.kind {
+    case .toggle:
+        if raw.lowercased() == "true" { return "On" }
+        if raw.lowercased() == "false" { return "Off" }
+        return raw.isEmpty ? "Off" : raw
+    case .choice(let choices):
+        if let option = choices.first(where: { $0.value == raw }) {
+            return option.label
+        }
+        if definition.key.hasSuffix("_S") {
+            return hourChoiceLabel(raw)
+        }
+        return raw.isEmpty ? "Inherited" : raw
+    case .model:
+        return raw.isEmpty ? "CLI managed" : raw
+    }
+}
+
+private func inheritedDefaultLabel(for definition: EnvSettingDefinition) -> String {
+    "\(concreteDefaultLabel(for: definition)) · inherited"
 }
 
 private func formattedHours(_ hours: Double) -> String {


### PR DESCRIPTION
## Summary

- replace the generic fixed-width settings row inside mechanical-job cards with a compact `Schedule (hours)` row
- keep the hours dropdown, `.env` fallback value, reset-to-default action, and accessibility label
- increase the adaptive automation-card minimum width from 300 to 340 points
- bump release metadata and changelog to `0.16.1`

## Root cause

The generic row reserved 190 points for its picker plus reset controls inside cards that could shrink to 300 points. The remaining label column collapsed to a few characters, producing one-character-per-line schedule titles.

## Impact

System Automation cards remain readable at the minimum settings-window size while preserving the dropdown-only schedule workflow.

## Validation

- `tests/test_menubar_app.py`: 12 passed
- real Swift settings harness compiled successfully
- production menu-bar app rebuilt, installed, and relaunched as one process
- embedded and development Swift sources are byte-identical
- release versions agree at `0.16.1` in `pyproject.toml` and both `server.json` fields
- `git diff --check`
