### PR TITLE
fix: stop learning-loop data loss at cursors, thresholds, and VACUUM

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -105,6 +105,7 @@
 # THREADKEEPER_SHADOW_REVIEW_INTERVAL_S=0
 # THREADKEEPER_SHADOW_REVIEW_WINDOW_S=900
 # THREADKEEPER_SHADOW_REVIEW_MIN_CHARS=500
+# THREADKEEPER_SHADOW_REVIEW_FLUSH_AGE_S=21600  # review an under-min-chars window anyway once its oldest message is this old; 0 = accumulate until min_chars
 THREADKEEPER_CURATOR_INTERVAL_S=259200         # 3-day deep audit; set 0 to disable
 # THREADKEEPER_CURATOR_MIN_LESSONS=3
 # THREADKEEPER_CURATOR_REPORTS_DIR=             # default: <db dir>/curator
@@ -115,6 +116,7 @@ THREADKEEPER_CURATOR_INTERVAL_S=259200         # 3-day deep audit; set 0 to disa
 # THREADKEEPER_EXTRACT_WINDOW_MIN=30
 # THREADKEEPER_CANDIDATE_REVIEW_INTERVAL_S=0   # restart-throttled by last candidate_review_pass; force=True bypasses
 # THREADKEEPER_CANDIDATE_REVIEW_MIN=3
+# THREADKEEPER_CANDIDATE_REVIEW_FLUSH_AGE_S=259200  # review an undersized queue anyway once its oldest candidate is this old; 0 = threshold only
 # THREADKEEPER_LEARNING_LOOP_SKILL_CREATE_LIMIT=2  # max new skills per autonomous review child; foreground unaffected
 # THREADKEEPER_PROBE_INTERVAL_S=0             # 1800 = 30 min active reliability tracking
 # THREADKEEPER_PROBE_COOLDOWN_S=604800       # 86400 = 1d active per-category cooldown
@@ -133,6 +135,7 @@ THREADKEEPER_CURATOR_INTERVAL_S=259200         # 3-day deep audit; set 0 to disa
 # THREADKEEPER_DIALECTIC_MINE_INTERVAL_S=0
 # THREADKEEPER_DIALECTIC_VALIDATE_INTERVAL_S=0
 # THREADKEEPER_DIALECTIC_VALIDATE_MIN=5
+# THREADKEEPER_DIALECTIC_VALIDATE_FLUSH_AGE_S=259200  # validate an undersized buffer anyway once its oldest eligible row is this old; 0 = threshold only
 # THREADKEEPER_DIALECTIC_VALIDATE_BATCH_SIZE=50
 # THREADKEEPER_DIALECTIC_MAX_NEW_CLAIMS=3
 # THREADKEEPER_DIALECTIC_OBS_MAX_REQUEUES=3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,39 @@ version bumps follow semver per the policy in
   echoed into child logs. Enumerated/bulleted lines, tool-name mentions, and
   placeholder fragments are now excluded, while genuine `MATERIALIZED:`
   verdicts and prose results still surface.
+- **VACUUM can no longer corrupt the rowid cursors or FTS indexes.**
+  `dialog_messages` and `notes` have TEXT primary keys, so their implicit
+  rowids may be renumbered by a VACUUM once deletions left gaps — silently
+  breaking the shadow/miner/extract ingest cursors and the external-content
+  `dialog_fts`/`notes_fts` mappings if dialog retention was ever enabled.
+  Both VACUUM paths (retention threshold and the manual `db_compact` tool)
+  now rebase the rowid cursors to created_at form first (translated back to
+  rowids on the next read) and rebuild both FTS indexes afterwards
+  (`db_compact` previously rebuilt only `dialog_fts` and never protected the
+  cursors).
+- **Shadow review no longer drops sparse dialog.** A below-`MIN_CHARS`
+  window used to advance the cursor, permanently skipping quiet-day dialog
+  one under-sized 15-minute slice at a time. `too_short` now keeps the
+  cursor so the window accumulates across ticks (edge-triggered telemetry —
+  no per-tick event flood) and is reviewed anyway once its oldest message
+  ages past `THREADKEEPER_SHADOW_REVIEW_FLUSH_AGE_S` (default 6h,
+  0 = accumulate until the char threshold).
+- **Extract daemon moved to the ingest-order rowid cursor (issue #69).**
+  The wall-clock created_at cursor silently skipped late-ingested dialog —
+  post-downtime backfills, freshly installed adapters, resumed sessions —
+  whose timestamps predated the sliding window. The daemon now scans
+  `rowid > cursor` like shadow_review and dialectic_miner: nothing falls
+  between ticks, a capped batch drains on the next pass, and legacy
+  created_at watermarks translate once on first read. The manual
+  `extract_recent()` tool keeps its wall-clock window contract.
+- **Review thresholds gained an age-flush so weak signal streams are not
+  starved.** A lone strong observation/candidate below
+  `DIALECTIC_VALIDATE_MIN` / `CANDIDATE_REVIEW_MIN` used to wait until the
+  30-day stale window terminally dropped it unreviewed. Undersized queues
+  are now processed anyway once their oldest entry ages past
+  `THREADKEEPER_DIALECTIC_VALIDATE_FLUSH_AGE_S` /
+  `THREADKEEPER_CANDIDATE_REVIEW_FLUSH_AGE_S` (default 3 days, 0 =
+  threshold only).
 
 ## v0.16.2 — 2026-07-19
 

--- a/README.md
+++ b/README.md
@@ -571,9 +571,12 @@ shadow_review (autonomous child lineage excluded) plus message-level noise
 filter (compaction summaries, SKILL.md
 injections, subagent role prompts, test-runner log dumps). The manual
 `extract_recent()` tool uses the configured sliding window directly; the daemon
-also keeps an `extract_pass` cursor and extends a pass back to the previous
-successful tick when `THREADKEEPER_EXTRACT_INTERVAL_S` is longer than
-`THREADKEEPER_EXTRACT_WINDOW_MIN`, so no dialog falls between ticks.
+scans by an ingest-order rowid cursor (`extract_pass`, same scheme as
+shadow_review and dialectic_miner), so no dialog falls between ticks, a capped
+batch drains on the next pass, and a late/out-of-order ingested message (old
+created_at, fresh rowid — a post-downtime backfill or freshly-installed
+adapter) is harvested exactly once instead of falling below a wall-clock
+cutoff.
 
 Where shadow extracts CLASS-LEVEL durable rules, extract harvests
 PER-INCIDENT decision-shaped utterances. Heuristic, not LLM —
@@ -1015,9 +1018,10 @@ The most-used env knobs (full list in `threadkeeper/config.py`):
 | `THREADKEEPER_SHADOW_REVIEW_INTERVAL_S` | 0 (off) | shadow daemon tick (s) |
 | `THREADKEEPER_SHADOW_REVIEW_WINDOW_S` | 900 | sliding window for shadow scan (s) |
 | `THREADKEEPER_EXTRACT_INTERVAL_S` | 0 (off) | extract daemon tick (s); 600 = 10 min recommended; if this exceeds the base window, the daemon extends from the previous successful `extract_pass` cursor so ticks do not leave gaps |
-| `THREADKEEPER_EXTRACT_WINDOW_MIN` | 30 | base sliding dialog window per extract pass (min); daemon runs may scan farther back only to cover an interval/window gap |
+| `THREADKEEPER_EXTRACT_WINDOW_MIN` | 30 | base sliding dialog window per manual extract pass (min); the daemon's first-ever pass also seeds its rowid cursor from this lookback |
 | `THREADKEEPER_CANDIDATE_REVIEW_INTERVAL_S` | 0 (off) | candidate-reviewer daemon tick (s), restart-throttled by the last `candidate_review_pass`; 3600 = 1h recommended |
 | `THREADKEEPER_CANDIDATE_REVIEW_MIN` | 3 | min pending candidates before reviewer engages |
+| `THREADKEEPER_CANDIDATE_REVIEW_FLUSH_AGE_S` | 259200 | age-flush: an undersized pending queue is still reviewed once its oldest candidate is this old (0 = threshold only) |
 | `THREADKEEPER_LEARNING_LOOP_SKILL_CREATE_LIMIT` | 2 | max new skills one autonomous learning-loop child (`candidate_review`, `shadow_review`, or `background_review`) may create in its session; foreground creation is unaffected |
 | `THREADKEEPER_CURATOR_INTERVAL_S` | 259200 | deep curator audit every three days; set `0` to disable |
 | `THREADKEEPER_CURATOR_MANAGE_FOREGROUND_SKILLS` | 0 | allow snapshot-scoped Curator repair/merge/delete of foreground skills; pinned/untracked skills remain protected |
@@ -1058,6 +1062,7 @@ The most-used env knobs (full list in `threadkeeper/config.py`):
 | `THREADKEEPER_DIALECTIC_MINE_INTERVAL_S` | 0 (off) | dialectic_miner daemon tick (s); 0 disables mechanical observation capture |
 | `THREADKEEPER_DIALECTIC_VALIDATE_INTERVAL_S` | 0 (off) | dialectic_validator daemon tick (s); 0 disables LLM-driven claim synthesis |
 | `THREADKEEPER_DIALECTIC_VALIDATE_MIN` | 5 | min buffered observations before validator engages |
+| `THREADKEEPER_DIALECTIC_VALIDATE_FLUSH_AGE_S` | 259200 | age-flush: an undersized observation buffer is still validated once its oldest eligible row is this old (0 = threshold only) |
 | `THREADKEEPER_DIALECTIC_VALIDATE_BATCH_SIZE` | 50 | max observations sent to one validator child; prevents oversized prompts and drains large queues incrementally |
 | `THREADKEEPER_EVOLVE_REVIEW_INTERVAL_S` | 0 (off) | evolve-reviewer daemon tick (s); audits thread-keeper for safety/leaks/optimization/new ideas, updates roadmap/issues, and includes legacy evolve suggestions as input. Runs as two alternating phases — read-only web research, then a privileged web-free audit that consumes the fenced research digest (#79) — so a full cycle spans two ticks |
 | `THREADKEEPER_EVOLVE_APPLY_INTERVAL_S` | 0 (off) | evolve-applier daemon tick (s); implements one open GitHub issue at a time, then falls back to Curator reports and promoted legacy evolve suggestions. Empty checks are throttled between intervals; actionable work and manual apply tools still dispatch |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -309,7 +309,13 @@ All daemon threads are cheap (ticks 0.5–30 s), no-op when env-knobs disable th
 - **retention** — ticks every `RETENTION_INTERVAL_S` (default 0/off). When
   enabled, prunes opted-in aged `dialog_messages`/`tasks`/`signals`/`events`/
   `probe_results`, keeps dialog FTS/vec mirrors consistent, and can run
-  `VACUUM` plus `PRAGMA wal_checkpoint(TRUNCATE)`.
+  `VACUUM` plus `PRAGMA wal_checkpoint(TRUNCATE)`. The VACUUM follows the
+  implicit-rowid safety protocol (dialog_messages/notes have TEXT primary
+  keys, so VACUUM may renumber their rowids once deletions left gaps): the
+  shadow/miner/extract rowid cursors are first rebased to created_at form
+  (translated back to rowids on next read), then after the VACUUM the
+  external-content `dialog_fts`/`notes_fts` indexes are rebuilt. The manual
+  `db_compact` tool runs the same protocol.
 - **search_proxy** — serves `search_via_parent` from slim children via
   signals (see below).
 - **spawn_budget** — in foreground parent processes only, once per
@@ -940,7 +946,12 @@ every SHADOW_REVIEW_INTERVAL_S (default 0=off, typical prod 900s):
 2. _collect_window(): pull dialog_messages WHERE rowid > cursor (first-ever pass
    seeds the floor from now-WINDOW_S) — ALL sessions, not just our own — then
    apply the shared harvest lineage exclusion from `threadkeeper.harvest`.
-3. if n_chars < MIN_CHARS (default 500): write a 'too_short'/'no_window' event, exit.
+3. if n_chars < MIN_CHARS (default 500): KEEP the cursor and exit ('too_short',
+   edge-triggered event) so sparse dialog ACCUMULATES across ticks instead of
+   being dropped one under-sized window at a time; once the window's oldest
+   message ages past SHADOW_REVIEW_FLUSH_AGE_S (default 6h, 0 = never) the
+   accumulated window is reviewed anyway. An empty window still records
+   'no_window'.
 4. if a shadow observer task is already running, return `shadow_child_running`
    without advancing the cursor; retry the same window next tick.
 5. spawn a slim child with SHADOW_REVIEW_PROMPT + window dump; write_origin='shadow_review',
@@ -952,10 +963,10 @@ every SHADOW_REVIEW_INTERVAL_S (default 0=off, typical prod 900s):
 7. Child-side MCP startup sees `THREADKEEPER_SPAWNED_CHILD=1` /
    `write_origin='shadow_review'` and refuses to start its own shadow daemon.
 8. Write events.kind='shadow_review_pass' with the new high-water rowid only
-   after a child is actually spawned or the window was intentionally classified
-   as `no_window`/`too_short`; spawn `ERR ...` rejections, exceptions, and
+   after a child is actually spawned or the window was empty (`no_window`);
+   `too_short`, spawn `ERR ...` rejections, exceptions, and
    already-running-child deferrals keep the old cursor so the same window is
-   retried.
+   retried/accumulated.
 ```
 
 Dedupe — via an **ingest-order** cursor in `events.target` (the rowid of the
@@ -1666,8 +1677,10 @@ unsupported CLI overrides still fall through to the next priority, and
 | `THREADKEEPER_SHADOW_REVIEW_INTERVAL_S` | 0 | shadow daemon tick; 0 disables |
 | `THREADKEEPER_SHADOW_REVIEW_WINDOW_S` | 900 | sliding window for shadow |
 | `THREADKEEPER_SHADOW_REVIEW_MIN_CHARS` | 500 | spawn threshold |
+| `THREADKEEPER_SHADOW_REVIEW_FLUSH_AGE_S` | 21600 | review an under-min-chars window once its oldest message is this old (0 = accumulate until min_chars) |
 | `THREADKEEPER_CANDIDATE_REVIEW_INTERVAL_S` | 0 | candidate-reviewer daemon tick, restart-throttled by the last `candidate_review_pass`; 3600 = 1h recommended |
 | `THREADKEEPER_CANDIDATE_REVIEW_MIN` | 3 | min pending candidates before reviewer engages |
+| `THREADKEEPER_CANDIDATE_REVIEW_FLUSH_AGE_S` | 259200 | review an undersized queue once its oldest candidate is this old (0 = threshold only) |
 | `THREADKEEPER_CURATOR_INTERVAL_S` | 259200 | deep curator audit every three days; set `0` to disable |
 | `THREADKEEPER_CURATOR_MIN_LESSONS` | 3 | min lessons before curator engages |
 | `THREADKEEPER_CURATOR_DESTRUCTIVE` | `1` | curator child writes its REPORT then applies PATCH/PRUNE/CONSOLIDATE directly; set `0` for advisory-only; protected entries are refused server-side |

--- a/tests/test_candidate_reviewer.py
+++ b/tests/test_candidate_reviewer.py
@@ -427,3 +427,52 @@ def test_mcp_candidate_review_status(tmp_path, monkeypatch):
     assert "interval_s=0" in out
     assert "pending_now=1" in out
     assert "below_threshold" in out
+
+
+def _seed_candidate(conn, content, age_s):
+    now = int(time.time())
+    conn.execute(
+        "INSERT INTO extract_candidates (kind, source_uuid, source_cid, "
+        "content, rationale, status, created_at) "
+        "VALUES ('verbatim', ?, 'sess', ?, 'H1 user_want pattern', 'pending', ?)",
+        (f"u-{abs(hash(content)) % 99999}", content, now - age_s),
+    )
+
+
+def test_below_threshold_age_flush_reviews_anyway(tmp_path, monkeypatch):
+    """A lone candidate older than the flush age is reviewed instead of
+    waiting for the min-count gate until the 30-day stale window drops it."""
+    pkg = _bootstrap(tmp_path, monkeypatch, min_n="3")
+    conn = pkg["db"].get_db()
+    _seed_candidate(
+        conn, "I want the aged lone candidate reviewed anyway", 5 * 86400,
+    )
+    conn.commit()
+    captured = []
+    import threadkeeper.tools.spawn as spawn_mod
+    monkeypatch.setattr(
+        spawn_mod, "spawn",
+        lambda **kw: captured.append(kw) or "ok task=tk_flush pid=0",
+    )
+
+    out = pkg["candidate_reviewer"].run_review_pass(force=True)
+
+    assert out.startswith("ok task="), out
+    assert captured, "age-flush must spawn the reviewer child"
+
+
+def test_below_threshold_fresh_queue_stays_pending(tmp_path, monkeypatch):
+    pkg = _bootstrap(tmp_path, monkeypatch, min_n="3")
+    conn = pkg["db"].get_db()
+    _seed_candidate(conn, "I want a fresh lone candidate to wait", 3600)
+    conn.commit()
+
+    def _boom(**kw):
+        raise AssertionError("fresh below-threshold queue must not spawn")
+
+    import threadkeeper.tools.spawn as spawn_mod
+    monkeypatch.setattr(spawn_mod, "spawn", _boom)
+
+    out = pkg["candidate_reviewer"].run_review_pass(force=True)
+
+    assert out == "below_threshold n=1"

--- a/tests/test_dialectic_validator.py
+++ b/tests/test_dialectic_validator.py
@@ -831,3 +831,35 @@ def test_ensure_requeue_column_idempotent(tmp_path, monkeypatch):
         ).fetchall()
     ]
     assert cols.count("requeue_count") == 1
+
+
+def test_below_threshold_age_flush_validates_anyway(tmp_path, monkeypatch):
+    """A lone strong observation older than the flush age is validated
+    instead of aging out to the 30-day stale skip unvalidated."""
+    pkg = _bootstrap(tmp_path, monkeypatch, min_n="5", batch_size="3")
+    conn = pkg["db"].get_db()
+    _seed_obs(conn, "одинокое сильное always правило юзера", age_s=5 * 86400)
+    conn.commit()
+
+    captured: list[dict] = []
+    _patch_validator_spawn(pkg, monkeypatch, captured)
+
+    out = pkg["dialectic_validator"].run_validate_pass(force=True)
+
+    assert captured, "age-flush must spawn the validator child"
+    assert captured[0]["task_id"] in out
+
+
+def test_below_threshold_fresh_buffer_waits(tmp_path, monkeypatch):
+    pkg = _bootstrap(tmp_path, monkeypatch, min_n="5", batch_size="3")
+    conn = pkg["db"].get_db()
+    _seed_obs(conn, "свежее must правило юзера", age_s=60)
+    conn.commit()
+
+    captured: list[dict] = []
+    _patch_validator_spawn(pkg, monkeypatch, captured)
+
+    out = pkg["dialectic_validator"].run_validate_pass(force=True)
+
+    assert out == "below_threshold n=1"
+    assert not captured

--- a/tests/test_extract_daemon.py
+++ b/tests/test_extract_daemon.py
@@ -70,7 +70,7 @@ def _seed_dialog(conn, role, content, ts, session_id="user-sess",
 def test_cursor_initial_is_zero(tmp_path, monkeypatch):
     pkg = _bootstrap(tmp_path, monkeypatch)
     conn = pkg["db"].get_db()
-    assert pkg["extract_daemon"]._last_extract_ts(conn) == 0
+    assert pkg["extract_daemon"]._last_extract_rowid(conn) == 0
 
 
 def test_cursor_advances_after_pass(tmp_path, monkeypatch):
@@ -78,7 +78,30 @@ def test_cursor_advances_after_pass(tmp_path, monkeypatch):
     conn = pkg["db"].get_db()
     pkg["extract_daemon"]._record_extract_pass(conn, 12345, "no_dialog window=30m")
     pkg["extract_daemon"]._record_extract_pass(conn, 67890, "ok scanned=5")
-    assert pkg["extract_daemon"]._last_extract_ts(conn) == 67890
+    assert pkg["extract_daemon"]._last_extract_rowid(conn) == 67890
+
+
+def test_cursor_translates_legacy_created_at_watermark(tmp_path, monkeypatch):
+    """A pre-migration created_at watermark maps to the matching rowid once."""
+    pkg = _bootstrap(tmp_path, monkeypatch)
+    conn = pkg["db"].get_db()
+    now = int(time.time())
+    uid = _seed_dialog(
+        conn, "user",
+        "I want the already-scanned early row excluded after the cursor "
+        "migration, without replaying history.",
+        now - 600, session_id="old-sess",
+    )
+    conn.commit()
+    rowid = conn.execute(
+        "SELECT rowid FROM dialog_messages WHERE uuid=?", (uid,)
+    ).fetchone()[0]
+    # Legacy watermark: a wall-clock timestamp above the seeded row's
+    # created_at (>= LEGACY_TS_FLOOR, so it is translated, not used as-is).
+    pkg["extract_daemon"]._record_extract_pass(
+        conn, now - 300, "ok window=30m scanned=1",
+    )
+    assert pkg["extract_daemon"]._last_extract_rowid(conn) == rowid
 
 
 # ──────────────────────────────────────────────────────────────────────
@@ -127,35 +150,52 @@ def test_run_extract_pass_picks_up_user_want_pattern(tmp_path, monkeypatch):
     assert "verbatim" in kinds, f"got kinds: {kinds}"
 
 
-def test_run_extract_pass_covers_interval_window_gap(tmp_path, monkeypatch):
-    """When interval > window, the daemon must scan back to its cursor so a
-    message after the previous tick but before the next sliding window is kept."""
+def test_run_extract_pass_covers_gap_and_late_ingest(tmp_path, monkeypatch):
+    """The ingest-order cursor keeps both kinds of stragglers (issue #69):
+    messages landing between ticks (interval > window) AND late-ingested rows
+    whose created_at predates the window entirely — a wall-clock cutoff
+    silently dropped the latter."""
     pkg = _bootstrap(tmp_path, monkeypatch, interval="3600", window_min="1")
     conn = pkg["db"].get_db()
-    first_tick = 1_800_000_000
-    next_tick = first_tick + 3600
-    pkg["extract_daemon"]._record_extract_pass(
-        conn, first_tick, "ok window=1m scanned=0",
+    now = int(time.time())
+
+    # Pass 1 scans a baseline row and establishes a real rowid cursor.
+    _seed_dialog(
+        conn, "user",
+        "I want a baseline utterance scanned first so the extract cursor "
+        "lands on a real ingest-order rowid.",
+        now - 45, session_id="base-sess",
     )
+    conn.commit()
+    out1 = pkg["extract_daemon"].run_extract_pass(force=True)
+    assert "ok" in out1
+    assert pkg["extract_daemon"]._last_extract_rowid(conn) > 0
+
+    # Late arrival: created_at hours below the 1-minute window AND below the
+    # cursor's wall-clock — only a fresh rowid keeps it visible.
+    _seed_dialog(
+        conn, "user",
+        "I want you to harvest late-ingested dialog from a post-downtime "
+        "backfill into candidates too, never skip it silently.",
+        now - 7200, session_id="late-sess",
+    )
+    # Gap arrival: an ordinary fresh row between daemon ticks.
     _seed_dialog(
         conn, "user",
         "I want you to always preserve dialog that lands between daemon "
         "ticks, even when the extract interval is longer than the window.",
-        first_tick + 120, session_id="gap-sess",
+        now - 30, session_id="gap-sess",
     )
     conn.commit()
 
-    monkeypatch.setattr(pkg["extract_daemon"].time, "time", lambda: next_tick)
-    out = pkg["extract_daemon"].run_extract_pass(force=True)
-    assert "ok" in out
-    rows = conn.execute(
-        "SELECT source_cid, content FROM extract_candidates WHERE status='pending'"
-    ).fetchall()
-    assert any(
-        r["source_cid"] == "gap-sess"
-        and "between daemon ticks" in r["content"]
-        for r in rows
-    )
+    out2 = pkg["extract_daemon"].run_extract_pass(force=True)
+    assert "ok" in out2
+    cids = {
+        r["source_cid"] for r in conn.execute(
+            "SELECT source_cid FROM extract_candidates WHERE status='pending'"
+        ).fetchall()
+    }
+    assert {"late-sess", "gap-sess"} <= cids
 
 
 def test_extract_filters_noise_content_prefixes(tmp_path, monkeypatch):

--- a/tests/test_retention.py
+++ b/tests/test_retention.py
@@ -227,3 +227,64 @@ def test_prune_then_vacuum_checkpoint_round_trip(fresh_mp, monkeypatch):
     )
     conn.commit()
     assert _count(conn, "notes", "content='after prune'") == 1
+
+
+def test_vacuum_rebases_dialog_cursors_and_rebuilds_fts(fresh_mp, monkeypatch):
+    """VACUUM may renumber dialog_messages' implicit rowids once dialog rows
+    were pruned. The retention vacuum must rebase the rowid ingest cursors to
+    created_at form (translated back on next read) and rebuild the
+    external-content FTS indexes so search and the shadow/miner/extract loops
+    survive the renumbering."""
+    from threadkeeper import retention
+    from threadkeeper.helpers import LEGACY_TS_FLOOR, resolve_ingest_watermark
+
+    conn = fresh_mp["db"].get_db()
+    now = int(time.time())
+    old = now - 90 * 86400
+    for i in range(3):
+        _insert_dialog(conn, f"old-{i}", old + i)
+    _insert_dialog(conn, "keep-1", now - 120)
+    _insert_dialog(conn, "keep-2", now - 60)
+    keep1_rowid = conn.execute(
+        "SELECT rowid FROM dialog_messages WHERE uuid='keep-1'"
+    ).fetchone()[0]
+    conn.execute(
+        "INSERT INTO events (session_id, kind, target, summary, created_at) "
+        "VALUES ('s', 'shadow_review_pass', ?, 'spawned earlier', ?)",
+        (str(keep1_rowid), now),
+    )
+    conn.commit()
+
+    _retention_config(
+        monkeypatch,
+        retention,
+        DIALOG_RETENTION_DAYS=30,
+        RETENTION_VACUUM_AFTER_ROWS=1,
+    )
+    out = retention.run_retention_pass(force=True)
+
+    assert "dialog=3" in out, out
+    assert "vacuum=ok" in out, out
+    assert "rebased_cursors=1" in out, out
+    assert "fts_rebuild=dialog_fts+notes_fts" in out, out
+    # The rebased cursor is stored in legacy created_at form…
+    row = conn.execute(
+        "SELECT target FROM events WHERE kind='shadow_review_pass' "
+        "ORDER BY id DESC LIMIT 1"
+    ).fetchone()
+    assert int(row[0]) >= LEGACY_TS_FLOOR
+    # …and resolves to keep-1's post-vacuum rowid regardless of whether this
+    # build actually renumbered: keep-2 stays above the cursor (unreviewed),
+    # keep-1 and everything below are not re-reviewed.
+    resolved = resolve_ingest_watermark(conn, int(row[0]))
+    new_keep1 = conn.execute(
+        "SELECT rowid FROM dialog_messages WHERE uuid='keep-1'"
+    ).fetchone()[0]
+    new_keep2 = conn.execute(
+        "SELECT rowid FROM dialog_messages WHERE uuid='keep-2'"
+    ).fetchone()[0]
+    assert resolved == new_keep1
+    assert new_keep2 > resolved
+    # FTS still maps the surviving rows correctly after prune+vacuum+rebuild.
+    assert _fts_has(conn, "keep-1")
+    assert _fts_has(conn, "keep-2")

--- a/tests/test_shadow_review.py
+++ b/tests/test_shadow_review.py
@@ -82,7 +82,7 @@ def test_cursor_reads_summary_from_events(tmp_path, monkeypatch):
 def test_collect_window_returns_nothing_when_empty(tmp_path, monkeypatch):
     pkg = _bootstrap(tmp_path, monkeypatch)
     conn = pkg["db"].get_db()
-    dump, hw, n_chars = pkg["shadow_review"]._collect_window(conn, 0, 3600)
+    dump, hw, n_chars, _ = pkg["shadow_review"]._collect_window(conn, 0, 3600)
     assert dump == "" and n_chars == 0
 
 
@@ -100,7 +100,7 @@ def test_collect_window_skips_rows_at_or_below_floor_rowid(tmp_path, monkeypatch
     fresh_rowid = conn.execute(
         "SELECT MAX(rowid) FROM dialog_messages"
     ).fetchone()[0]
-    dump, hw, n_chars = pkg["shadow_review"]._collect_window(conn, floor, 3600)
+    dump, hw, n_chars, _ = pkg["shadow_review"]._collect_window(conn, floor, 3600)
     assert "fresh message" in dump
     assert "old message" not in dump
     assert hw == fresh_rowid
@@ -118,14 +118,14 @@ def test_collect_window_picks_up_late_out_of_order_ingest(tmp_path, monkeypatch)
     _seed_dialog(conn, "user", "fresh forward message advancing the cursor",
                  now - 10)
     conn.commit()
-    dump1, hw1, n1 = pkg["shadow_review"]._collect_window(conn, 0, 3600)
+    dump1, hw1, n1, _ = pkg["shadow_review"]._collect_window(conn, 0, 3600)
     assert "fresh forward message" in dump1
     # Now a late/out-of-order row lands: created_at is far BELOW the cursor's
     # transcript time, but its rowid is higher (ingested later).
     _seed_dialog(conn, "user", "late backfilled resumed-session message",
                  now - 5000, session_id="resumed-sess")
     conn.commit()
-    dump2, hw2, n2 = pkg["shadow_review"]._collect_window(conn, hw1, 3600)
+    dump2, hw2, n2, _ = pkg["shadow_review"]._collect_window(conn, hw1, 3600)
     assert "late backfilled resumed-session message" in dump2
     assert hw2 > hw1
 
@@ -164,7 +164,7 @@ def test_collect_window_excludes_shadow_observer_sessions(
                  now - 14, session_id="review-sess-2")
     conn.commit()
 
-    dump, _, n_chars = pkg["shadow_review"]._collect_window(conn, 0, 3600)
+    dump, _, n_chars, _ts = pkg["shadow_review"]._collect_window(conn, 0, 3600)
     assert "flaky network in WDA" in dump
     assert "WDA start, read networksetup" in dump
     assert "SHADOW LEARNING OBSERVER" not in dump
@@ -210,7 +210,7 @@ def test_collect_window_excludes_codex_spawned_marker_sessions(
     )
     conn.commit()
 
-    dump, _, n_chars = pkg["shadow_review"]._collect_window(conn, 0, 3600)
+    dump, _, n_chars, _ts = pkg["shadow_review"]._collect_window(conn, 0, 3600)
     assert "foreground English prompt" in dump
     assert "fake-child-learning" not in dump
     assert "You were spawned" not in dump
@@ -256,7 +256,7 @@ def test_collect_window_excludes_native_agent_parent_lineage(
     )
     conn.commit()
 
-    dump, _, n_chars = pkg["shadow_review"]._collect_window(conn, 0, 3600)
+    dump, _, n_chars, _ts = pkg["shadow_review"]._collect_window(conn, 0, 3600)
     assert "foreground English prompt" in dump
     assert "fake native-agent preference" not in dump
     assert "Native agent analysis" not in dump
@@ -289,7 +289,7 @@ def test_collect_window_strips_tool_results_keeps_thinking(
                  now - 25, session_id="real")
     conn.commit()
 
-    dump, _, n_chars = pkg["shadow_review"]._collect_window(conn, 0, 3600)
+    dump, _, n_chars, _ts = pkg["shadow_review"]._collect_window(conn, 0, 3600)
     # Tool results stripped
     assert "[tool_result]" not in dump
     assert "[tool_call]" not in dump
@@ -311,7 +311,7 @@ def test_collect_window_caps_long_messages(tmp_path, monkeypatch):
     huge = "X" * 5000  # well above the 1500-cap per-turn
     _seed_dialog(conn, "user", huge, int(time.time()) - 5)
     conn.commit()
-    dump, _, n_chars = pkg["shadow_review"]._collect_window(conn, 0, 3600)
+    dump, _, n_chars, _ts = pkg["shadow_review"]._collect_window(conn, 0, 3600)
     # capped to 1500 + ellipsis char ≈ 1501
     assert n_chars <= 1502
     assert "…" in dump
@@ -817,3 +817,54 @@ def test_mcp_shadow_review_status_includes_telemetry_and_snapshot(
     md = snap.read_text(encoding="utf-8")
     assert "# Shadow-review telemetry" in md
     assert "| window |" in md
+
+
+def test_too_short_accumulates_until_flush_age(tmp_path, monkeypatch):
+    """A below-min-chars window keeps the cursor so sparse dialog accumulates,
+    then flushes to a review once its oldest message ages past the knob."""
+    pkg = _bootstrap(tmp_path, monkeypatch, min_chars="500")
+    sr = pkg["shadow_review"]
+    conn = pkg["db"].get_db()
+    now = int(time.time())
+    _seed_dialog(conn, "user", "anchor row reviewed by an earlier pass", now - 7200)
+    conn.commit()
+    anchor = conn.execute("SELECT MAX(rowid) FROM dialog_messages").fetchone()[0]
+    sr._record_shadow_pass(conn, anchor, "spawned earlier")
+    _seed_dialog(conn, "user", "sparse but sharp correction", now - 3600)
+    conn.commit()
+
+    out1 = sr.run_shadow_pass(force=True)
+    assert out1 == "too_short"
+    row = conn.execute(
+        "SELECT target, summary FROM events WHERE kind='shadow_review_pass' "
+        "ORDER BY id DESC LIMIT 1"
+    ).fetchone()
+    assert row["target"] == str(anchor)  # cursor preserved — accumulating
+    assert row["summary"].startswith("too_short accumulating")
+
+    # Consecutive accumulation ticks are edge-triggered: no event flood.
+    n_before = conn.execute(
+        "SELECT COUNT(*) FROM events WHERE kind='shadow_review_pass'"
+    ).fetchone()[0]
+    assert sr.run_shadow_pass(force=True) == "too_short"
+    n_after = conn.execute(
+        "SELECT COUNT(*) FROM events WHERE kind='shadow_review_pass'"
+    ).fetchone()[0]
+    assert n_after == n_before
+
+    # Age past the flush knob → the accumulated window is reviewed anyway.
+    monkeypatch.setattr(sr, "SHADOW_REVIEW_FLUSH_AGE_S", 1800.0)
+    captured = []
+    import threadkeeper.tools.spawn as spawn_mod
+    monkeypatch.setattr(
+        spawn_mod, "spawn",
+        lambda **kw: captured.append(kw) or "ok task=tk_flush pid=0",
+    )
+    out3 = sr.run_shadow_pass(force=True)
+    assert out3.startswith("ok task="), out3
+    assert captured, "flush must spawn the evaluator child"
+    row = conn.execute(
+        "SELECT target FROM events WHERE kind='shadow_review_pass' "
+        "ORDER BY id DESC LIMIT 1"
+    ).fetchone()
+    assert int(row["target"]) > anchor  # cursor advanced by the spawn

--- a/threadkeeper/candidate_reviewer.py
+++ b/threadkeeper/candidate_reviewer.py
@@ -41,6 +41,7 @@ import threading
 import time
 
 from .config import (
+    CANDIDATE_REVIEW_FLUSH_AGE_S,
     CANDIDATE_REVIEW_INTERVAL_S,
     CANDIDATE_REVIEW_MIN,
 )
@@ -254,6 +255,20 @@ def _collect_pending(conn: sqlite3.Connection) -> tuple[str, int]:
     return ("\n".join(parts), len(rows))
 
 
+def _oldest_pending_ts(conn: sqlite3.Connection) -> int:
+    """created_at of the oldest surfaced (non-stale) pending candidate, or 0."""
+    stale_cutoff = int(time.time()) - 30 * 86400
+    try:
+        row = conn.execute(
+            "SELECT MIN(created_at) FROM extract_candidates "
+            "WHERE status='pending' AND created_at > ?",
+            (stale_cutoff,),
+        ).fetchone()
+    except sqlite3.OperationalError:
+        return 0
+    return int(row[0]) if row and row[0] else 0
+
+
 def _running_reviewer_children(conn: sqlite3.Connection) -> list[str]:
     """Running candidate-review task ids, reaping dead rows.
 
@@ -338,12 +353,22 @@ def run_review_pass(force: bool = False, *, scheduled: bool = False) -> str:
 
         inventory, n_pending = _collect_pending(conn)
         if n_pending < CANDIDATE_REVIEW_MIN:
-            _record_review_pass(
-                conn, now,
-                f"below_threshold pending={n_pending} "
-                f"min={CANDIDATE_REVIEW_MIN}",
+            flush_age = float(CANDIDATE_REVIEW_FLUSH_AGE_S or 0)
+            oldest = _oldest_pending_ts(conn)
+            aged_out = (
+                n_pending > 0 and flush_age > 0
+                and oldest and now - oldest >= flush_age
             )
-            return f"below_threshold n={n_pending}"
+            if not aged_out:
+                _record_review_pass(
+                    conn, now,
+                    f"below_threshold pending={n_pending} "
+                    f"min={CANDIDATE_REVIEW_MIN}",
+                )
+                return f"below_threshold n={n_pending}"
+            # Age-flush: a trickle of candidates must not be starved by the
+            # min-count gate until the 30-day stale window silently drops
+            # them — review the undersized queue anyway.
 
         active_skills = _active_skills_dump(conn)
         # The harvested candidate `content` snippets are untrusted observed

--- a/threadkeeper/config.py
+++ b/threadkeeper/config.py
@@ -291,6 +291,11 @@ class Settings(BaseSettings):
     shadow_review_interval_s: float = 0.0
     shadow_review_window_s: int = 900
     shadow_review_min_chars: int = 500
+    # Age-flush for the accumulating shadow window: a below-min-chars window
+    # is retried (cursor kept) until its oldest eligible message is this old,
+    # then reviewed anyway so sparse dialog is never silently dropped.
+    # 0 = never flush (accumulate until min_chars).
+    shadow_review_flush_age_s: float = 21600.0
 
     # ── Curator daemon ───────────────────────────────────────────────────────
     # Deep library audit every three days by default. The pass snapshots before
@@ -325,6 +330,10 @@ class Settings(BaseSettings):
     # ── Candidate reviewer daemon ─────────────────────────────────────────────
     candidate_review_interval_s: float = 0.0
     candidate_review_min: int = 3
+    # Age-flush for the review threshold: an undersized pending queue is still
+    # reviewed once its oldest candidate is this old, so a trickle of signal
+    # is not starved by the min-count gate. 0 = threshold only.
+    candidate_review_flush_age_s: float = 259200.0
     learning_loop_skill_create_limit: int = 2
 
     # ── Probe daemon ─────────────────────────────────────────────────────────
@@ -418,6 +427,11 @@ class Settings(BaseSettings):
     dialectic_mine_interval_s: float = 0.0
     dialectic_validate_interval_s: float = 0.0
     dialectic_validate_min: int = 5
+    # Age-flush for the validate threshold: an undersized observation buffer
+    # is still validated once its oldest eligible row is this old, so a lone
+    # strong signal cannot age out to the 30-day stale skip unvalidated.
+    # 0 = threshold only.
+    dialectic_validate_flush_age_s: float = 259200.0
     dialectic_validate_batch_size: int = 50
     dialectic_max_new_claims: int = 3
     # How many times a claimed observation may be requeued (validator child
@@ -754,6 +768,7 @@ def _derive_constants(s: "Settings") -> dict:
         "SHADOW_REVIEW_INTERVAL_S": s.shadow_review_interval_s,
         "SHADOW_REVIEW_WINDOW_S": s.shadow_review_window_s,
         "SHADOW_REVIEW_MIN_CHARS": s.shadow_review_min_chars,
+        "SHADOW_REVIEW_FLUSH_AGE_S": float(s.shadow_review_flush_age_s),
         "CURATOR_INTERVAL_S": s.curator_interval_s,
         "CURATOR_MIN_LESSONS": s.curator_min_lessons,
         "CURATOR_REPORTS_DIR": curator_reports_dir,
@@ -766,6 +781,7 @@ def _derive_constants(s: "Settings") -> dict:
         "EXTRACT_WINDOW_MIN": s.extract_window_min,
         "CANDIDATE_REVIEW_INTERVAL_S": s.candidate_review_interval_s,
         "CANDIDATE_REVIEW_MIN": s.candidate_review_min,
+        "CANDIDATE_REVIEW_FLUSH_AGE_S": float(s.candidate_review_flush_age_s),
         "LEARNING_LOOP_SKILL_CREATE_LIMIT": s.learning_loop_skill_create_limit,
         "PROBE_INTERVAL_S": s.probe_interval_s,
         "PROBE_COOLDOWN_S": s.probe_cooldown_s,
@@ -795,6 +811,7 @@ def _derive_constants(s: "Settings") -> dict:
         "DIALECTIC_MINE_INTERVAL_S": s.dialectic_mine_interval_s,
         "DIALECTIC_VALIDATE_INTERVAL_S": s.dialectic_validate_interval_s,
         "DIALECTIC_VALIDATE_MIN": s.dialectic_validate_min,
+        "DIALECTIC_VALIDATE_FLUSH_AGE_S": float(s.dialectic_validate_flush_age_s),
         "DIALECTIC_VALIDATE_BATCH_SIZE": s.dialectic_validate_batch_size,
         "DIALECTIC_MAX_NEW_CLAIMS": s.dialectic_max_new_claims,
         "DIALECTIC_OBS_MAX_REQUEUES": s.dialectic_obs_max_requeues,

--- a/threadkeeper/dialectic_validator.py
+++ b/threadkeeper/dialectic_validator.py
@@ -19,6 +19,7 @@ import time
 
 from .config import (
     DIALECTIC_VALIDATE_BATCH_SIZE,
+    DIALECTIC_VALIDATE_FLUSH_AGE_S,
     DIALECTIC_VALIDATE_INTERVAL_S,
     DIALECTIC_VALIDATE_MIN,
     DIALECTIC_MAX_NEW_CLAIMS,
@@ -392,6 +393,19 @@ def _release_finished_claims(conn: sqlite3.Connection, now: int) -> int:
     return len(ids)
 
 
+def _oldest_pending_ts(conn: sqlite3.Connection, stale_cutoff: int) -> int:
+    """created_at of the oldest unclaimed non-stale pending observation, or 0."""
+    try:
+        row = conn.execute(
+            "SELECT MIN(created_at) FROM dialectic_observations "
+            "WHERE status='pending' AND claimed_at IS NULL AND created_at > ?",
+            (stale_cutoff,),
+        ).fetchone()
+    except sqlite3.OperationalError:
+        return 0
+    return int(row[0]) if row and row[0] else 0
+
+
 def _collect_pending(conn: sqlite3.Connection) -> tuple[str, int, int, list[int]]:
     """Inventory of a bounded high-signal pending batch within the last 30 days."""
     now = int(time.time())
@@ -638,10 +652,19 @@ def run_validate_pass(force: bool = False, *, scheduled: bool = False) -> str:
             _record_pass(conn, now, f"no_eligible pending={total_pending}")
             return f"no_eligible n={total_pending}"
         if total_pending < DIALECTIC_VALIDATE_MIN:
-            _record_pass(conn, now,
-                         f"below_threshold pending={total_pending} "
-                         f"min={DIALECTIC_VALIDATE_MIN}")
-            return f"below_threshold n={total_pending}"
+            flush_age = float(DIALECTIC_VALIDATE_FLUSH_AGE_S or 0)
+            oldest = _oldest_pending_ts(conn, stale_cutoff)
+            aged_out = (
+                total_pending > 0 and flush_age > 0
+                and oldest and now - oldest >= flush_age
+            )
+            if not aged_out:
+                _record_pass(conn, now,
+                             f"below_threshold pending={total_pending} "
+                             f"min={DIALECTIC_VALIDATE_MIN}")
+                return f"below_threshold n={total_pending}"
+            # Age-flush: a lone strong signal must not age out to the 30-day
+            # stale skip unvalidated — validate the undersized buffer anyway.
 
         task_id = _new_validator_task_id()
         claimed_ids = _claim_batch(conn, batch_ids, task_id, now)

--- a/threadkeeper/extract_daemon.py
+++ b/threadkeeper/extract_daemon.py
@@ -4,11 +4,16 @@ from dialog_messages into the extract_candidates queue.
 Architecture mirror of shadow_review:
 
   1. Daemon thread wakes every EXTRACT_INTERVAL_S seconds (0 = off).
-  2. Runs the same extraction logic as extract_recent(), but floors the scan
-     at the previous successful pass when the interval is wider than the base
-     window so dialog cannot fall between ticks.
+  2. Runs the same heuristics as extract_recent(), but scans by the
+     ingest-order rowid cursor (issue #69, same scheme as shadow_review and
+     dialectic_miner): nothing falls between ticks, a capped batch drains on
+     the next pass, and a late/out-of-order ingested message (old created_at,
+     fresh rowid) is harvested exactly once instead of falling below a
+     wall-clock cutoff.
   3. Records events.kind='extract_pass' with the per-pass counters so
-     `extract_review_status()` can show health at a glance.
+     `extract_review_status()` can show health at a glance; `target` carries
+     the rowid high-water mark (legacy created_at watermarks are translated
+     once on first read).
 
 Where shadow_review extracts CLASS-LEVEL durable RULES (skills, lessons),
 extract harvests PER-INCIDENT DECISION-SHAPED utterances and adds them
@@ -31,7 +36,11 @@ import time
 
 from .config import EXTRACT_INTERVAL_S, EXTRACT_WINDOW_MIN
 from .db import get_db
-from .helpers import daemon_sleep
+from .helpers import (
+    daemon_sleep,
+    dialog_rowid_at_or_before,
+    resolve_ingest_watermark,
+)
 from . import daemon_state, identity
 
 logger = logging.getLogger(__name__)
@@ -39,8 +48,15 @@ logger = logging.getLogger(__name__)
 _started = False
 
 
-def _last_extract_ts(conn: sqlite3.Connection) -> int:
-    """Timestamp cursor from the most recent extract pass, or 0."""
+def _last_extract_rowid(conn: sqlite3.Connection) -> int:
+    """Ingest-order rowid high-water mark for the extract daemon (issue #69).
+
+    The watermark in the latest `events.kind='extract_pass'.target` is a
+    dialog_messages rowid (ingest order), not a transcript timestamp, so a
+    late/out-of-order ingested message can't fall below it — a created_at
+    cursor silently stepped over post-downtime backfills and freshly-installed
+    adapters. A pre-migration watermark held a created_at timestamp; it is
+    translated to the matching rowid once. Returns 0 when no prior pass."""
     try:
         row = conn.execute(
             "SELECT target FROM events WHERE kind='extract_pass' "
@@ -51,9 +67,10 @@ def _last_extract_ts(conn: sqlite3.Connection) -> int:
     if not row or not row["target"]:
         return 0
     try:
-        return int(row["target"])
+        stored = int(row["target"])
     except (ValueError, TypeError):
         return 0
+    return resolve_ingest_watermark(conn, stored)
 
 
 def _record_extract_pass(conn: sqlite3.Connection,
@@ -71,19 +88,6 @@ def _record_extract_pass(conn: sqlite3.Connection,
         logger.debug("extract_daemon: failed to record pass", exc_info=True)
 
 
-def _extract_scan_cutoff(now: int, last_cursor: int) -> int:
-    """Earliest dialog timestamp this pass must scan.
-
-    The MCP tool keeps its simple sliding wall-clock window. The daemon adds a
-    cursor so interval > window does not leave an uncovered gap between the
-    previous pass end and the next pass's window start.
-    """
-    window_cutoff = int(now) - max(1, int(EXTRACT_WINDOW_MIN)) * 60
-    if int(last_cursor) <= 0:
-        return window_cutoff
-    return min(window_cutoff, int(last_cursor))
-
-
 def run_extract_pass(force: bool = False, *, scheduled: bool = False) -> str:
     """Execute one extract pass synchronously. Used by the daemon AND by
     the MCP tool for manual triggering.
@@ -92,7 +96,7 @@ def run_extract_pass(force: bool = False, *, scheduled: bool = False) -> str:
     window=… scanned=… verbatim=… distill=… concept=… note=…
     skipped_existing=…" or "no_dialog window=…m"), or 'not_due' for a
     scheduled tick when another server already ran this loop within the
-    interval. Plus advances the `extract_pass` cursor for telemetry.
+    interval. Plus advances the `extract_pass` rowid cursor.
     """
     if EXTRACT_INTERVAL_S <= 0 and not force:
         return "disabled"
@@ -102,20 +106,25 @@ def run_extract_pass(force: bool = False, *, scheduled: bool = False) -> str:
         return "not_due"
     conn = get_db()
     started_at = int(time.time())
-    last_cursor = _last_extract_ts(conn)
-    cutoff = _extract_scan_cutoff(started_at, last_cursor)
+    floor = _last_extract_rowid(conn)
+    if floor <= 0:
+        # First-ever pass: seed the floor from the lookback window so a
+        # long-running install doesn't replay its whole transcript history.
+        floor = dialog_rowid_at_or_before(
+            conn, started_at - max(1, int(EXTRACT_WINDOW_MIN)) * 60,
+        )
     # Late import — tools.extract registers MCP tools at import time, and
     # the daemon module loads before all tools are registered.
-    from .tools.extract import _extract_recent_from_cutoff
+    from .tools.extract import _extract_from_rowid
     try:
-        result = _extract_recent_from_cutoff(
-            cutoff, window_min=EXTRACT_WINDOW_MIN,
+        result, high_water = _extract_from_rowid(
+            floor, window_min=EXTRACT_WINDOW_MIN,
         )
     except Exception as e:
         logger.debug("extract_daemon: pass failed", exc_info=True)
-        _record_extract_pass(conn, last_cursor, f"error: {e}")
+        _record_extract_pass(conn, floor, f"error: {e}")
         return f"error: {e}"
-    _record_extract_pass(conn, started_at, str(result)[:200])
+    _record_extract_pass(conn, high_water, str(result)[:200])
     return str(result)
 
 

--- a/threadkeeper/helpers.py
+++ b/threadkeeper/helpers.py
@@ -231,10 +231,14 @@ def alive(pid: int) -> bool:
 # adapter, or a post-downtime `_ingest_all` backfill lands rows whose
 # `created_at` is BELOW a cursor that fresher sessions already pushed
 # forward), so a created_at cursor silently steps over those late arrivals.
-# `dialog_messages` is append-only (no DELETE / no VACUUM in the package), so
-# its rowid is assigned in strict ingest order — a late row always lands
-# ABOVE the cursor and is evaluated exactly once, and the monotonic advance
-# means shadow_review never re-spawns a window it already saw.
+# `dialog_messages` rowids are assigned in strict ingest order — a late row
+# always lands ABOVE the cursor and is evaluated exactly once, and the
+# monotonic advance means shadow_review never re-spawns a window it already
+# saw. Deletes DO exist behind opt-in knobs (retention's dialog pruning,
+# forget), and VACUUM (retention threshold / db_compact) may then renumber
+# these implicit rowids — both VACUUM paths therefore rebase the stored
+# cursors to created_at (legacy form, translated back on next read) and
+# rebuild the external-content FTS indexes; see retention._vacuum.
 #
 # Pre-#69 deployments stored a created_at unix timestamp in `events.target`.
 # A rowid is orders of magnitude smaller than any real unix timestamp, so a

--- a/threadkeeper/retention.py
+++ b/threadkeeper/retention.py
@@ -162,12 +162,108 @@ def _checkpoint_wal(conn: sqlite3.Connection) -> str:
     return f"ok busy={row[0]} log={row[1]} checkpointed={row[2]}"
 
 
+# Event kinds whose `target` is a dialog_messages ingest-order rowid watermark
+# (issue #69). dialog_messages has a TEXT primary key, so its rowid is
+# implicit and SQLite's VACUUM contract permits renumbering it once dialog
+# deletions have left gaps — which would silently invalidate these cursors.
+_DIALOG_CURSOR_EVENT_KINDS = (
+    "shadow_review_pass",
+    "dialectic_mine_pass",
+    "extract_pass",
+)
+
+
+def _rebase_dialog_cursors_to_created_at(conn: sqlite3.Connection) -> int:
+    """Rewrite rowid watermarks as legacy created_at values before a VACUUM.
+
+    A created_at value (>= helpers.LEGACY_TS_FLOOR) survives rowid
+    renumbering: the next cursor read runs it through
+    `resolve_ingest_watermark`, which translates it back to the matching
+    post-VACUUM rowid. Granularity note: a late-ingested row whose created_at
+    is below the rebased timestamp is skipped once — the same one-time cost
+    as the original #69 legacy migration — which is why this runs only around
+    an actual VACUUM instead of storing created_at cursors permanently.
+    Returns the number of cursors rebased."""
+    from .helpers import LEGACY_TS_FLOOR, resolve_ingest_watermark
+
+    rebased = 0
+    for kind in _DIALOG_CURSOR_EVENT_KINDS:
+        try:
+            row = conn.execute(
+                "SELECT target FROM events WHERE kind=? ORDER BY id DESC LIMIT 1",
+                (kind,),
+            ).fetchone()
+        except sqlite3.OperationalError:
+            return rebased
+        target = (row[0] if row else None) or ""
+        try:
+            stored = int(target)
+        except (TypeError, ValueError):
+            continue
+        if stored <= 0:
+            continue
+        rowid = resolve_ingest_watermark(conn, stored)
+        if rowid <= 0:
+            continue
+        try:
+            ts_row = conn.execute(
+                "SELECT MAX(created_at) FROM dialog_messages WHERE rowid <= ?",
+                (rowid,),
+            ).fetchone()
+        except sqlite3.OperationalError:
+            continue
+        ts = ts_row[0] if ts_row else None
+        if ts is None or int(ts) < LEGACY_TS_FLOOR:
+            continue
+        conn.execute(
+            "INSERT INTO events (session_id, kind, target, summary, created_at) "
+            "VALUES (?,?,?,?,?)",
+            (
+                identity._session_id or "",
+                kind,
+                str(int(ts)),
+                f"vacuum_cursor_rebase rowid={rowid}",
+                int(time.time()),
+            ),
+        )
+        rebased += 1
+    if rebased:
+        conn.commit()
+    return rebased
+
+
+def _rebuild_content_fts(conn: sqlite3.Connection) -> str:
+    """Rebuild every external-content FTS index keyed by an implicit rowid."""
+    rebuilt: list[str] = []
+    for fts in ("dialog_fts", "notes_fts"):
+        try:
+            conn.execute(f"INSERT INTO {fts}({fts}) VALUES('rebuild')")
+            rebuilt.append(fts)
+        except sqlite3.OperationalError:
+            continue
+    if rebuilt:
+        conn.commit()
+    return "+".join(rebuilt) or "none"
+
+
 def _vacuum(conn: sqlite3.Connection) -> str:
+    """VACUUM with the implicit-rowid safety protocol.
+
+    dialog_messages and (post re-id migration) notes have TEXT primary keys,
+    so VACUUM may renumber their implicit rowids once deletions left gaps.
+    Three things depend on those rowids: the shadow/miner/extract ingest
+    cursors and the external-content dialog_fts / notes_fts indexes
+    (`content_rowid='rowid'`). Protocol: rebase the cursors to created_at
+    form first, VACUUM, then rebuild the FTS indexes. Mirrors the manual
+    `db_compact` tool."""
+    rebased = _rebase_dialog_cursors_to_created_at(conn)
     try:
+        conn.commit()  # VACUUM cannot run inside a transaction
         conn.execute("VACUUM")
     except sqlite3.OperationalError as e:
         return f"err:{e.__class__.__name__}"
-    return "ok"
+    rebuilt = _rebuild_content_fts(conn)
+    return f"ok rebased_cursors={rebased} fts_rebuild={rebuilt}"
 
 
 def _record_pass(conn: sqlite3.Connection, summary: str) -> None:

--- a/threadkeeper/shadow_review.py
+++ b/threadkeeper/shadow_review.py
@@ -32,6 +32,7 @@ from pathlib import Path
 from typing import Optional
 
 from .config import (
+    SHADOW_REVIEW_FLUSH_AGE_S,
     SHADOW_REVIEW_INTERVAL_S,
     SHADOW_REVIEW_MIN_CHARS,
     SHADOW_REVIEW_WINDOW_S,
@@ -179,6 +180,18 @@ def _record_shadow_pass(conn: sqlite3.Connection,
         logger.debug("shadow: failed to record pass", exc_info=True)
 
 
+def _last_shadow_pass_summary(conn: sqlite3.Connection) -> str:
+    """Summary of the most recent shadow_review_pass row, or ''."""
+    try:
+        row = conn.execute(
+            "SELECT summary FROM events WHERE kind='shadow_review_pass' "
+            "ORDER BY id DESC LIMIT 1"
+        ).fetchone()
+    except sqlite3.OperationalError:
+        return ""
+    return (row["summary"] or "") if row else ""
+
+
 def _running_shadow_children(conn: sqlite3.Connection) -> list[str]:
     """Return running shadow-observer task ids, refreshing dead rows.
 
@@ -271,15 +284,17 @@ _COLLECT_ROW_CAP = 4000
 
 def _collect_window(conn: sqlite3.Connection,
                     floor_rowid: int,
-                    window_s: int) -> tuple[str, int, int]:
+                    window_s: int) -> tuple[str, int, int, int]:
     """Pull dialog messages ingested after `floor_rowid` (ingest order, #69),
     excluding any session whose opening user prompt is one of our own
     internal spawn prompts (shadow-observer or close_thread reviewer).
 
-    Returns (dump_text, high_water_rowid, char_count).
+    Returns (dump_text, high_water_rowid, char_count, oldest_ts).
       - dump_text: human-readable rendering ready for the shadow prompt
       - high_water_rowid: largest rowid seen (== floor for next tick)
       - char_count: total visible char length (input to MIN_CHARS guard)
+      - oldest_ts: created_at of the oldest row contributing content (0 when
+        none) — input to the accumulate-vs-flush decision for short windows
 
     The cursor is the ingest-order rowid, not the transcript `created_at`, so
     a late/out-of-order ingested message (old created_at, fresh rowid) lands
@@ -311,10 +326,11 @@ def _collect_window(conn: sqlite3.Connection,
         (*exclusion_params, floor_rowid, _COLLECT_ROW_CAP),
     ).fetchall()
     if not rows:
-        return ("", floor_rowid, 0)
+        return ("", floor_rowid, 0, 0)
     lines: list[str] = []
     char_count = 0
     high_water = floor_rowid
+    oldest_ts = 0
     for r in rows:
         body = _strip_tool_noise(r["content"] or "")
         if not body:
@@ -328,9 +344,11 @@ def _collect_window(conn: sqlite3.Connection,
             body = body[:1500] + "…"
         char_count += len(body)
         high_water = max(high_water, int(r["rowid"]))
+        if not oldest_ts:
+            oldest_ts = int(r["created_at"] or 0)
         sid = (r["session_id"] or "?")[-6:]
         lines.append(f"[{r['role']} @{sid}]\n{body}\n")
-    return ("\n".join(lines), high_water, char_count)
+    return ("\n".join(lines), high_water, char_count, oldest_ts)
 
 
 # ──────────────────────────────────────────────────────────────────────
@@ -539,15 +557,30 @@ def run_shadow_pass(force: bool = False, *, scheduled: bool = False) -> str:
     ):
         return "not_due"
     floor = _last_shadow_rowid(conn)
-    dump, high_water, n_chars = _collect_window(
+    dump, high_water, n_chars, oldest_ts = _collect_window(
         conn, floor, SHADOW_REVIEW_WINDOW_S,
     )
     if n_chars == 0:
         _record_shadow_pass(conn, high_water, "no_window")
         return "no_window"
     if n_chars < SHADOW_REVIEW_MIN_CHARS:
-        _record_shadow_pass(conn, high_water, "too_short")
-        return "too_short"
+        flush_age = float(SHADOW_REVIEW_FLUSH_AGE_S or 0)
+        window_age = int(time.time()) - oldest_ts if oldest_ts else 0
+        if not (flush_age > 0 and window_age >= flush_age):
+            # Keep the cursor: sparse dialog ACCUMULATES until it clears
+            # MIN_CHARS (or ages past the flush knob) instead of being
+            # permanently skipped one under-sized window at a time. Record
+            # the outcome edge-triggered so the accumulation ticks don't
+            # write one telemetry row per interval.
+            prev = _last_shadow_pass_summary(conn)
+            if not prev.startswith("too_short"):
+                _record_shadow_pass(
+                    conn, floor,
+                    f"too_short accumulating n_chars={n_chars}",
+                )
+            return "too_short"
+        # Age-flush: the window stayed under MIN_CHARS for flush_age —
+        # review what accumulated rather than dropping a slow day's dialog.
 
     with single_flight_lock("shadow-review") as locked:
         if not locked:

--- a/threadkeeper/tools/db_maintenance.py
+++ b/threadkeeper/tools/db_maintenance.py
@@ -134,6 +134,15 @@ def db_compact() -> str:
             _ensure_session(conn)
             before = DB_PATH.stat().st_size
             t0 = time.time()
+            # Rebase the rowid ingest cursors (shadow/miner/extract) to their
+            # created_at form BEFORE the vacuum: renumbered rowids would
+            # silently invalidate them. Harmless if the vacuum then skips —
+            # the legacy-form watermark translates straight back on next read.
+            from ..retention import (
+                _rebase_dialog_cursors_to_created_at,
+                _rebuild_content_fts,
+            )
+            _rebase_dialog_cursors_to_created_at(conn)
             conn.commit()  # VACUUM cannot run inside a transaction
             try:
                 conn.execute("VACUUM")
@@ -142,12 +151,12 @@ def db_compact() -> str:
                     f"vacuum skipped: {e} — DB busy; retry in a quiet window "
                     f"(no rowids were changed, index is still consistent)"
                 )
-            # MANDATORY: VACUUM may have renumbered dialog_messages'
-            # implicit rowids (SQLite's contract permits it; preserved on
-            # the builds we tested); the external-content index maps by
-            # rowid and could now be stale — rebuild is defensive.
-            conn.execute("INSERT INTO dialog_fts(dialog_fts) VALUES('rebuild')")
-            conn.commit()
+            # MANDATORY: VACUUM may have renumbered the implicit rowids of
+            # dialog_messages and notes (both have TEXT primary keys; SQLite's
+            # contract permits it — preserved on the builds we tested); the
+            # external-content indexes map by rowid and could now be stale —
+            # rebuild both defensively.
+            _rebuild_content_fts(conn)
             after = DB_PATH.stat().st_size
             return (
                 f"ok vacuum+fts_rebuild {time.time() - t0:.1f}s "

--- a/threadkeeper/tools/extract.py
+++ b/threadkeeper/tools/extract.py
@@ -127,22 +127,17 @@ def _enqueue(conn, kind, source_uuid, source_cid, content, rationale):
     return cur.lastrowid
 
 
-def _extract_recent_from_cutoff(
-    cutoff: int,
-    *,
-    window_min: int = 60,
-    max_messages: int = 500,
-) -> str:
-    """Shared extract implementation for wall-clock and cursor-based scans.
+def _fetch_extract_rows(
+    conn,
+    where_sql: str,
+    where_params: tuple,
+    order_sql: str,
+    max_messages: int,
+):
+    """Fetch heuristic-eligible dialog rows for one extract scan.
 
-    H1 user_want         → verbatim (normative phrasing)
-    H2 long_insight      → distill (assistant ≥500ch + ## headers + conclusion marker)
-    H3 example_regularity→ concept (bullets≥3 OR example-marker≥2 + abstract frame)
-    H4 paraphrase_repeat → note (≥3 msgs cosine ≥0.80 within same session)"""
-    conn = get_db()
-    _ensure_session(conn)
-    window_min = max(1, int(window_min))
-    cutoff = int(cutoff)
+    Shared by the wall-clock (created_at) MCP path and the ingest-order
+    (rowid) daemon path — only the predicate and ordering differ."""
     # Exclude autonomous review/audit lineage before applying heuristics.
     from ..harvest import harvest_exclusion_cte
 
@@ -156,11 +151,12 @@ def _extract_recent_from_cutoff(
     )
     msg_noise_params = [p + "%" for p in _NOISE_CONTENT_PREFIXES]
     dialog_join, dialog_embedding = _dialog_embedding_parts(conn, "d")
-    rows = conn.execute(
+    return conn.execute(
         exclusion_cte +
-        "SELECT d.uuid, d.role, d.content, d.session_id, d.created_at, "
+        "SELECT d.rowid AS rowid, d.uuid, d.role, d.content, d.session_id, "
+        "       d.created_at, "
         f"       {dialog_embedding} AS embedding "
-        f"FROM dialog_messages d {dialog_join} WHERE d.created_at >= ? "
+        f"FROM dialog_messages d {dialog_join} WHERE {where_sql} "
         "AND coalesce(d.project, '') != 'subagents' "
         "AND d.role IN ('user','assistant') "
         "AND d.content NOT LIKE '[tool_result]%' AND d.content NOT LIKE '[Image%' "
@@ -169,12 +165,63 @@ def _extract_recent_from_cutoff(
         "AND d.session_id NOT IN ("
         "  SELECT session_id FROM harvest_excluded_sessions"
         ") "
-        "ORDER BY d.created_at ASC LIMIT ?",
-        (*exclusion_params, cutoff, *msg_noise_params,
+        f"ORDER BY {order_sql} LIMIT ?",
+        (*exclusion_params, *where_params, *msg_noise_params,
          max(10, int(max_messages))),
     ).fetchall()
+
+
+def _extract_recent_from_cutoff(
+    cutoff: int,
+    *,
+    window_min: int = 60,
+    max_messages: int = 500,
+) -> str:
+    """Wall-clock extract scan (manual MCP path).
+
+    H1 user_want         → verbatim (normative phrasing)
+    H2 long_insight      → distill (assistant ≥500ch + ## headers + conclusion marker)
+    H3 example_regularity→ concept (bullets≥3 OR example-marker≥2 + abstract frame)
+    H4 paraphrase_repeat → note (≥3 msgs cosine ≥0.80 within same session)"""
+    conn = get_db()
+    _ensure_session(conn)
+    window_min = max(1, int(window_min))
+    rows = _fetch_extract_rows(
+        conn, "d.created_at >= ?", (int(cutoff),), "d.created_at ASC",
+        max_messages,
+    )
     if not rows:
         return f"no_dialog window={window_min}m"
+    return _apply_extract_heuristics(conn, rows, window_min)
+
+
+def _extract_from_rowid(
+    floor_rowid: int,
+    *,
+    window_min: int = 60,
+    max_messages: int = 500,
+) -> tuple[str, int]:
+    """Ingest-order extract scan for the daemon cursor (issue #69).
+
+    Scans dialog rows with rowid > `floor_rowid` so a late/out-of-order
+    ingested message (old created_at, fresh rowid) is harvested exactly once
+    instead of falling below a wall-clock cutoff. Returns
+    (status, high_water_rowid); a capped batch drains on the next pass —
+    unfetched rows all sit above the returned high-water mark."""
+    conn = get_db()
+    _ensure_session(conn)
+    window_min = max(1, int(window_min))
+    rows = _fetch_extract_rows(
+        conn, "d.rowid > ?", (int(floor_rowid),), "d.rowid ASC", max_messages,
+    )
+    if not rows:
+        return (f"no_dialog window={window_min}m", int(floor_rowid))
+    high_water = max(int(r["rowid"]) for r in rows)
+    return (_apply_extract_heuristics(conn, rows, window_min), high_water)
+
+
+def _apply_extract_heuristics(conn, rows, window_min: int) -> str:
+    """Run H1-H4 over fetched rows, enqueue candidates, emit telemetry."""
     counts = {"verbatim": 0, "distill": 0, "concept": 0, "note": 0}
     skipped = 0
     for r in rows:

--- a/threadkeeper/tools/shadow_review.py
+++ b/threadkeeper/tools/shadow_review.py
@@ -54,7 +54,7 @@ def shadow_review_run(force: bool = False, dry_run: bool = False) -> str:
     _ensure_session(conn)
     if dry_run:
         floor = _last_shadow_rowid(conn)
-        dump, high_water, n_chars = _collect_window(
+        dump, high_water, n_chars, _oldest_ts = _collect_window(
             conn, floor, SHADOW_REVIEW_WINDOW_S,
         )
         if n_chars == 0:


### PR DESCRIPTION
Eliminates the four data-loss paths found in the learning-loop validation. Follow-up to #245 (merged); the branch is rebased onto current `main`. Replaces #246, which GitHub auto-closed when #245's base branch was squash-merged and deleted.

## 1. VACUUM can no longer corrupt rowid cursors or FTS indexes
`dialog_messages` and `notes` have TEXT primary keys, so their implicit rowids may be renumbered by a VACUUM once deletions left gaps — silently breaking the shadow/miner/extract ingest cursors (`events.target` rowid watermarks) and the external-content `dialog_fts`/`notes_fts` mappings (`content_rowid='rowid'`) as soon as dialog retention is enabled. The stale `helpers.py` claim that the package never deletes or vacuums was already false (retention pruning, `forget`, `db_compact`).

Both VACUUM paths (retention threshold and manual `db_compact`) now follow one protocol: rebase the rowid cursors to created_at form first — the existing legacy-watermark path translates them back to post-VACUUM rowids on the next read — then rebuild both FTS indexes after the VACUUM. `db_compact` previously rebuilt only `dialog_fts` and never protected the cursors. The one-time translation granularity (a late-ingested row below the rebased timestamp is skipped once) is the same cost as the original #69 migration and only applies around an actual VACUUM.

## 2. Shadow review no longer drops sparse dialog
A below-`MIN_CHARS` window advanced the cursor, permanently skipping quiet-day dialog one under-sized 15-minute slice at a time (min_chars is 1500 in production — a slow chat day could be entirely unreviewed). `too_short` now keeps the cursor so the window accumulates across ticks, with edge-triggered telemetry (no per-tick event flood), and is reviewed anyway once its oldest message ages past `THREADKEEPER_SHADOW_REVIEW_FLUSH_AGE_S` (new knob, default 6h; 0 = accumulate until the char threshold).

## 3. Extract daemon on the ingest-order rowid cursor (issue #69)
The wall-clock created_at cursor silently skipped late-ingested dialog — post-downtime backfills, freshly installed adapters, resumed sessions — whose timestamps predated the sliding window; a >500-row backlog could also drop its tail. The daemon now scans `rowid > cursor` exactly like shadow_review and dialectic_miner: nothing falls between ticks, capped batches drain losslessly, and legacy created_at watermarks translate once on first read. The manual `extract_recent()` tool keeps its wall-clock window contract. The shared row-fetch/heuristics internals were split so both paths use one implementation.

## 4. Age-flush for review thresholds
A lone strong observation/candidate below `DIALECTIC_VALIDATE_MIN` (5) / `CANDIDATE_REVIEW_MIN` (3) waited until the 30-day stale window terminally dropped it unreviewed — with the miner's real yield of ~0-2 observations/day this was the common case, not the edge. Undersized queues are now processed anyway once their oldest pending entry ages past `THREADKEEPER_DIALECTIC_VALIDATE_FLUSH_AGE_S` / `THREADKEEPER_CANDIDATE_REVIEW_FLUSH_AGE_S` (new knobs, default 3 days; 0 = threshold only).

## Tests
New: VACUUM cursor-rebase + FTS-rebuild round-trip (renumbering-agnostic assertions), shadow accumulate/edge-triggered/flush flow, extract gap + late-ingest coverage, legacy-watermark translation, age-flush spawn + fresh-queue control for both reviewer and validator. Updated to the new contracts: extract cursor tests (rowid semantics). Locally green: retention, db_compact, task_retention, helpers, extract_daemon, extract_dedup, shadow_review, candidate_reviewer, dialectic_validator, dialectic_miner, config_settings, dashboard, agent_status, verify_ingest. Full suite on CI.

Docs in the same change-set: `docs/ARCHITECTURE.md` (shadow cursor semantics, retention VACUUM protocol, knob tables), `README.md` (extract cursor description, knob rows), `.env.example`, `CHANGELOG.md`.
