### PR TITLE
ci: auto-tag green main and gate publish on pypi environment approval

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,7 +1,13 @@
 name: publish
 
-# Publish to PyPI only from a maintainer-signed annotated tag matching v*
-# after the protected pypi environment admits the upload job.
+# Publish to PyPI from a release tag matching v* after the protected
+# pypi environment admits the upload job. Two authorized tag shapes:
+#  - a maintainer-signed annotated tag pushed by hand (push trigger) —
+#    the backfill/override path;
+#  - the unsigned annotated tag release-tag.yml creates on a tested
+#    main commit and hands over via an explicit workflow_dispatch.
+# The human release gate is the pypi environment approval (required
+# reviewers — see docs/RELEASING.md).
 # Uses PyPI's Trusted Publisher OIDC flow — no API token in repo
 # secrets. Configure once on PyPI side: project → Settings → Publishing
 # → "Add a new pending publisher" with repo=po4erk91/thread-keeper,
@@ -35,10 +41,11 @@ jobs:
             exit 1
           fi
 
-      - name: Verify signed annotated tag
+      - name: Verify release tag
         env:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ github.ref_name }}
+          EVENT: ${{ github.event_name }}
         run: |
           ref_type="$(gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$TAG" --jq '.object.type')"
           tag_sha="$(gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$TAG" --jq '.object.sha')"
@@ -51,10 +58,34 @@ jobs:
           verified="$(gh api "repos/$GITHUB_REPOSITORY/git/tags/$tag_sha" --jq '.verification.verified')"
           reason="$(gh api "repos/$GITHUB_REPOSITORY/git/tags/$tag_sha" --jq '.verification.reason')"
 
-          if [ "$verified" != "true" ]; then
+          if [ "$verified" = "true" ]; then
+            echo "::notice::$TAG carries a verified maintainer signature."
+            exit 0
+          fi
+
+          # Unsigned tags are accepted only on the explicit dispatch from
+          # release-tag.yml: annotated, tagged by github-actions[bot], and
+          # pointing at a commit already merged to main. Pushed unsigned
+          # tags keep failing here.
+          if [ "$EVENT" != "workflow_dispatch" ]; then
             echo "::error::$TAG is not a verified signed tag (reason: $reason)."
             exit 1
           fi
+
+          tagger_email="$(gh api "repos/$GITHUB_REPOSITORY/git/tags/$tag_sha" --jq '.tagger.email')"
+          if [ "$tagger_email" != "41898282+github-actions[bot]@users.noreply.github.com" ]; then
+            echo "::error::$TAG is unsigned (reason: $reason) and not the release-tag.yml bot tag (tagger: $tagger_email)."
+            exit 1
+          fi
+
+          commit_sha="$(gh api "repos/$GITHUB_REPOSITORY/git/tags/$tag_sha" --jq '.object.sha')"
+          status="$(gh api "repos/$GITHUB_REPOSITORY/compare/main...$commit_sha" --jq '.status')"
+          if [ "$status" != "identical" ] && [ "$status" != "behind" ]; then
+            echo "::error::$TAG points at $commit_sha, which is not on main (compare status: $status)."
+            exit 1
+          fi
+
+          echo "::notice::$TAG authorized: bot-created annotated tag on a main commit via explicit dispatch."
 
   build:
     name: Build distribution

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -1,4 +1,20 @@
-name: release readiness
+name: release tag
+
+# Auto-release from green main: when the tests workflow succeeds on a
+# main push whose pyproject.toml version has no tag yet and CHANGELOG.md
+# carries the matching "## vX.Y.Z " section, create the annotated
+# release tag via the REST API (tagger: github-actions[bot]) and
+# dispatch publish.yml on it. This workflow only prepares the release —
+# publish.yml re-verifies the tag and then pauses at the protected
+# `pypi` environment, where a required reviewer must approve the
+# deployment before anything is uploaded. That approval is the human
+# release gate (see docs/RELEASING.md).
+#
+# A maintainer-signed annotated tag pushed by hand still publishes
+# directly through publish.yml's push trigger and skips this workflow.
+#
+# Tag refs created with GITHUB_TOKEN do not start push-triggered
+# workflow runs, hence the explicit workflow_dispatch handoff.
 
 on:
   workflow_run:
@@ -9,13 +25,20 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: release-tag
+  cancel-in-progress: false
+
 jobs:
-  check:
-    name: Check release-ready main build
+  tag:
+    name: Tag release-ready main build
     runs-on: ubuntu-latest
     if: >
       github.event.workflow_run.conclusion == 'success' &&
       github.event.workflow_run.event == 'push'
+    permissions:
+      contents: write
+      actions: write
     steps:
       - uses: actions/checkout@v7
         with:
@@ -41,18 +64,49 @@ jobs:
           fi
 
       - name: Validate release notes
+        id: notes
         if: steps.existing.outputs.exists == 'false'
         env:
           VERSION: ${{ steps.version.outputs.version }}
         run: |
-          grep -q "^## v${VERSION} " CHANGELOG.md
+          if grep -q "^## v${VERSION} " CHANGELOG.md; then
+            echo "present=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "present=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::CHANGELOG.md has no '## v${VERSION} ' section — not tagging. Add the section (or push a signed tag) to release v${VERSION}."
+          fi
 
-      - name: Report maintainer release action
-        if: steps.existing.outputs.exists == 'false'
+      - name: Create annotated release tag
+        if: >
+          steps.existing.outputs.exists == 'false' &&
+          steps.notes.outputs.present == 'true'
         env:
+          GH_TOKEN: ${{ github.token }}
           TAG: ${{ steps.version.outputs.tag }}
           SHA: ${{ github.event.workflow_run.head_sha }}
         run: |
-          echo "::notice::Release metadata for $TAG is present on $SHA."
-          echo "::notice::Publishing now requires a maintainer-signed annotated tag:"
-          echo "::notice::git tag -s $TAG $SHA -m 'release: $TAG' && git push origin refs/tags/$TAG"
+          tag_obj="$(gh api "repos/$GITHUB_REPOSITORY/git/tags" \
+            -f tag="$TAG" \
+            -f message="release: $TAG" \
+            -f object="$SHA" \
+            -f type="commit" \
+            -f 'tagger[name]=github-actions[bot]' \
+            -f 'tagger[email]=41898282+github-actions[bot]@users.noreply.github.com' \
+            -f "tagger[date]=$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+            --jq '.sha')"
+          gh api "repos/$GITHUB_REPOSITORY/git/refs" \
+            -f ref="refs/tags/$TAG" \
+            -f sha="$tag_obj" >/dev/null
+          echo "::notice::Created annotated tag $TAG at $SHA."
+
+      - name: Dispatch publish workflow
+        if: >
+          steps.existing.outputs.exists == 'false' &&
+          steps.notes.outputs.present == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          TAG: ${{ steps.version.outputs.tag }}
+        run: |
+          gh workflow run publish.yml --ref "$TAG"
+          echo "::notice::Dispatched publish.yml on $TAG — approve the pypi environment to release."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,27 @@ version bumps follow semver per the policy in
 
 ## [Unreleased]
 
+## v0.16.3 — 2026-07-19
+
 ### Changed
+
+- **Releases self-publish again — the human gate moved to the `pypi`
+  environment approval.** The #57 hardening (PR #207, v0.15.0) made
+  publishing require a locally-signed maintainer tag; under fully PR-driven
+  development that step was never run, so 0.15.0–0.16.2 were version-bumped
+  but never tagged and PyPI / GitHub Releases sat at v0.14.0. The
+  `release-tag.yml` workflow now (again) creates the annotated `vX.Y.Z` tag
+  once tests pass on a `main` commit whose `pyproject.toml` version is
+  untagged and has a matching CHANGELOG section, and dispatches
+  `publish.yml` on it. The authorization model keeps a human in the loop but
+  moves the checkpoint: `publish.yml` accepts either a GitHub-verified
+  signed annotated tag (manual backfill/override path) or the bot's
+  annotated tag on an already-merged `main` commit arriving via the explicit
+  dispatch — and always stops at the protected `pypi` environment, where a
+  required reviewer must approve the deployment before the Trusted Publisher
+  upload and GitHub Release run. Keeping a required reviewer configured on
+  the `pypi` environment is now the load-bearing control;
+  `docs/RELEASING.md` documents the verification command.
 
 - **Daemon-host mode is now the default** (`THREADKEEPER_DAEMON_HOST=1`).
   One elected headless host per machine (`python -m threadkeeper.host`) runs

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -266,27 +266,32 @@ contributor returns.
 
 ## Releases
 
-Versions follow Conventional-Commits-driven semver, executed by the
-maintainer as part of each commit to `main`. The flow:
+Versions follow Conventional-Commits-driven semver. Releasing is part
+of the normal PR flow:
 
 1. PR title (Conventional Commits format, enforced by `pr-title.yml`)
    becomes the squash-merge commit message on `main`.
-2. **Same commit**: maintainer bumps `version` in `pyproject.toml`
-   per the bump policy below and adds a `CHANGELOG.md` entry.
-3. **Same push**: maintainer creates an annotated tag `vX.Y.Z` on the
-   bump commit and pushes both the commit and the tag.
-4. `.github/workflows/tests.yml` runs the full pytest matrix on push.
-5. The tag push triggers `.github/workflows/publish.yml`, which builds
-   sdist + wheel and uploads to PyPI via the Trusted Publisher OIDC
-   flow.
+2. **Same PR**: bump `version` in `pyproject.toml` (and both
+   `server.json` version fields) per the bump policy below and add a
+   `CHANGELOG.md` entry under a new `## vX.Y.Z — YYYY-MM-DD` heading.
+3. `.github/workflows/test.yml` runs the full pytest matrix on the
+   merge push.
+4. On a green run, `.github/workflows/release-tag.yml` creates the
+   annotated tag `vX.Y.Z` on the tested commit and dispatches
+   `.github/workflows/publish.yml`. A version bump without a matching
+   CHANGELOG section is warned about and left untagged.
+5. `publish.yml` verifies the tag, builds sdist + wheel, and waits at
+   the protected `pypi` environment for maintainer approval; on
+   approval it uploads to PyPI via the Trusted Publisher OIDC flow and
+   creates the GitHub Release from the CHANGELOG section.
 
-There's no CI-side release automation — solo-repo, all commits go
-through the maintainer anyway, and the `python-semantic-release`
-machinery hit branch-protection friction (default `GITHUB_TOKEN` can't
-push to a protected `main`; the alternatives — PAT secret, GitHub App,
-release-please-style PR — all add per-release friction or one-time
-setup that wasn't worth it at this scale). Pulled it out; the rule
-lives in this section instead.
+The human release gate is the `pypi` environment approval (required
+reviewers — see [docs/RELEASING.md](docs/RELEASING.md)). A
+maintainer-signed annotated `v*` tag pushed by hand still publishes
+directly and is the backfill/override path. CI never pushes commits to
+`main` — it only tags what already merged and passed tests, which is
+what kept `python-semantic-release` (and its protected-branch
+friction) out.
 
 ### Bump policy
 
@@ -299,7 +304,7 @@ lives in this section instead.
 If a single commit touches multiple concerns (rare — squash-merge
 typically prevents this), pick the highest bump that applies.
 
-### Tagging recipe
+### Release commit recipe
 
 ```bash
 # Update pyproject.toml `version` per the bump table; bump server.json
@@ -309,11 +314,10 @@ typically prevents this), pick the highest bump that applies.
 
 git add pyproject.toml server.json CHANGELOG.md <other files for this change>
 git commit -m "feat: <imperative summary>"
-git tag -a vX.Y.Z -m "release vX.Y.Z"
-git push && git push --tags
+git push   # merge the PR; CI tags the green main build and dispatches publish.yml
 ```
 
-The tag push fans out to `publish.yml` automatically. After PyPI
+Approve the `pypi` deployment on the publish run; after the PyPI
 upload completes, republish the MCP Registry entry so the new version
 shows up there too:
 
@@ -325,5 +329,6 @@ mcp-publisher publish
 ### Promoting to 1.0.0
 
 Once the API is stable and the next BREAKING CHANGE should land 1.0.0:
-bump `pyproject.toml` to `1.0.0` directly, tag `v1.0.0`, push. No
-config flip needed — manual control by design.
+bump `pyproject.toml` to `1.0.0` directly in that release PR; the same
+auto-tag flow releases it. No config flip needed — manual control by
+design.

--- a/README.md
+++ b/README.md
@@ -64,9 +64,10 @@ Integrity API provenance from the expected GitHub Trusted Publisher. Dirty or
 diverged git checkouts are skipped rather than overwritten. Restarts are gated
 on install/setup success plus a subprocess import smoke check, so a broken or
 unverified update is recorded but the current server keeps running.
-Upstream PyPI publishing is intentionally gated: merge-to-main checks no longer
-dispatch uploads, and a release requires a maintainer-signed annotated `v*` tag
-plus the protected `pypi` GitHub Environment described in
+Upstream PyPI publishing is intentionally gated: green merge-to-main builds are
+auto-tagged, but every upload pauses for a human approval on the protected
+`pypi` GitHub Environment (a maintainer-signed annotated `v*` tag remains the
+manual override path), as described in
 [docs/RELEASING.md](docs/RELEASING.md).
 
 They also run a twice-weekly installed-skill updater by default. It keeps all

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -149,11 +149,12 @@ its current in-memory code. Set `THREADKEEPER_AUTO_UPDATE_INTERVAL_S=0` to opt
 out of the standing-consent update channel entirely; the provenance gate itself
 is controlled by `THREADKEEPER_AUTO_UPDATE_VERIFY_PROVENANCE` for break-glass
 mirrors.
-The upstream publish path is gated before that provenance exists: the
-post-test release readiness workflow is read-only and does not dispatch PyPI,
-while `publish.yml` requires a GitHub-verified signed annotated `v*` tag and
-the protected `pypi` environment before the Trusted Publisher upload job can
-run.
+The upstream publish path is gated before that provenance exists: after a
+green test run on `main`, `release-tag.yml` tags the tested commit and
+dispatches `publish.yml`, which accepts only a GitHub-verified signed
+annotated `v*` tag or that workflow's own bot tag on an already-merged
+`main` commit — and always pauses at the protected `pypi` environment for a
+human approval before the Trusted Publisher upload job can run.
 The legacy monolith `server.py` at the repo root was removed in May 2026 — the
 runtime is fully on the package.
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -3,12 +3,16 @@
 Publishing to PyPI is deliberately split into two steps. A push to `main`
 runs `.github/workflows/test.yml`; when that run succeeds,
 `.github/workflows/release-tag.yml` checks whether the version in
-`pyproject.toml` has matching changelog notes, but it does **not** create a tag,
-dispatch publishing, or hold write permissions. A maintainer then authorizes the
-release by pushing a signed annotated `v*` tag. `.github/workflows/publish.yml`
-verifies that signed tag, checks that it matches `pyproject.toml` and
-`CHANGELOG.md`, then pauses at the protected `pypi` GitHub Environment before
-uploading.
+`pyproject.toml` is untagged and has matching changelog notes, creates the
+annotated `vX.Y.Z` tag on the tested commit (tagger: `github-actions[bot]`),
+and dispatches `.github/workflows/publish.yml` on it. `publish.yml` verifies
+the tag — a GitHub-verified maintainer signature, or the bot tag on a commit
+already merged to `main` arriving via that explicit dispatch — checks that it
+matches `pyproject.toml` and `CHANGELOG.md`, then **pauses at the protected
+`pypi` GitHub Environment** before uploading. That environment approval is
+the human release gate: nothing reaches PyPI until a required reviewer
+approves the deployment, so the required-reviewer rule on the `pypi`
+environment must stay enabled (setup below).
 
 PyPI upload uses Trusted Publisher OIDC — no PyPI API token is stored in the
 repository. The publish job explicitly uploads PyPI digital attestations
@@ -52,9 +56,10 @@ gh api repos/po4erk91/thread-keeper/environments/pypi \
   --jq '.protection_rules'
 ```
 
-The output must include a `required_reviewers` rule. Without that repository
-setting, the signed tag is still required by source control, but the PyPI upload
-job will not pause for a second human approval.
+The output must include a `required_reviewers` rule. This setting is
+load-bearing: the release tag itself is created by CI, so the environment
+approval is the only human checkpoint on the automatic path. Without a
+required reviewer, a green `main` build publishes unattended.
 
 ### 3. Verify locally before tagging (optional)
 
@@ -75,19 +80,43 @@ on GitHub.
 # 1. Bump version in pyproject.toml on a normal PR branch
 $EDITOR pyproject.toml         # version = "0.4.0" → "0.4.1"
 
-# 2. Add a matching CHANGELOG section: ## v0.4.1 — YYYY-MM-DD
+# 2. Bump both server.json version fields to the same value
+$EDITOR server.json
+
+# 3. Add a matching CHANGELOG section: ## v0.4.1 — YYYY-MM-DD
 $EDITOR CHANGELOG.md
 
-# 3. Commit, open a PR, and merge it to main after tests pass
+# 4. Commit, open a PR, and merge it to main after tests pass
 git commit -am "release: 0.4.1"
 ```
 
 The workflows then:
-1. Run the full test matrix on `main`
-2. Check that an unreleased `vX.Y.Z` has a matching changelog section
-3. Stop and print the signed-tag command for the maintainer
 
-After the merge-to-main checks are green, publish with a signed annotated tag:
+1. Run the full test matrix on `main`
+2. Check that the unreleased `vX.Y.Z` has a matching changelog section
+   (a bump without notes is a warning, not a tag)
+3. Create the annotated `vX.Y.Z` tag on the tested commit and dispatch
+   `publish.yml` on it
+4. Verify the tag ref, its shape (annotated bot tag on a `main` commit,
+   or a verified signed tag), and that it matches `pyproject.toml` and
+   `CHANGELOG.md`
+5. Build sdist + wheel (`python -m build`) and run `twine check dist/*`
+6. **Wait for the protected `pypi` environment approval** — the human
+   release gate
+7. On approval: upload artifacts to PyPI via `pypa/gh-action-pypi-publish`
+   (OIDC, no token)
+8. Create a GitHub Release from the matching `CHANGELOG.md` section
+
+Approve or reject the pending deployment at
+<https://github.com/po4erk91/thread-keeper/actions> → the publish run →
+"Review deployments" → `pypi`. Rejecting drops the release; the tag
+stays, so delete it first if the version should be rebuilt and re-tagged.
+
+### Manual signed-tag path (backfill / override)
+
+A maintainer-signed annotated tag still publishes directly through the
+same workflow — use it to backfill a historical version or to release
+without the auto-tag flow:
 
 ```bash
 git fetch origin main --tags
@@ -95,20 +124,8 @@ git tag -s v0.4.1 origin/main -m "release: v0.4.1"
 git push origin refs/tags/v0.4.1
 ```
 
-The publish workflow then:
-
-1. Verifies the workflow is running from a `v*` tag ref
-2. Verifies the tag is annotated and GitHub reports its signature as valid
-3. Confirms the tag matches `pyproject.toml` and `CHANGELOG.md`
-4. Builds sdist + wheel (`python -m build`)
-5. Runs `twine check dist/*`
-6. Waits for the protected `pypi` environment approval
-7. Uploads artifacts to PyPI via `pypa/gh-action-pypi-publish` (OIDC,
-   no token)
-8. Creates a GitHub Release from the matching `CHANGELOG.md` section
-
-Watch progress at
-<https://github.com/po4erk91/thread-keeper/actions>.
+The push-triggered run verifies the signature and still waits at the
+`pypi` environment.
 
 ### Manual re-run
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -156,7 +156,13 @@ remains a live question.
   stops before tag creation or workflow dispatch. Publishing is decoupled from
   auto-tagging: `publish.yml` requires a GitHub-verified signed annotated `v*`
   tag, matching release metadata, and the protected `pypi` environment before
-  the Trusted Publisher upload job can run.
+  the Trusted Publisher upload job can run. Later amended (v0.16.3): the
+  signed-tag-only rule stalled releases entirely under PR-driven development,
+  so auto-tagging returned with the human gate moved to the protected `pypi`
+  environment approval — `release-tag.yml` tags green `main` builds and
+  dispatches `publish.yml`, which admits bot tags only on merged `main`
+  commits via that explicit dispatch and still pauses for a required reviewer
+  before upload; signed tags remain the manual override.
 - Unified fcntl single-flight for spawning daemons (#53): the local
   check-running-then-spawn mutex now lives in `helpers.single_flight_lock()`.
   Shadow review, evolve reviewer, probe daemon, candidate reviewer, curator,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "threadkeeper"
-version = "0.16.2"
+version = "0.16.3"
 description = "Multi-agent shared brain across Claude Code/Desktop, Codex, Antigravity CLI, Copilot, and VS Code. Cross-session memory, self-improving skill loops, inter-agent signaling — one local MCP server."
 requires-python = ">=3.11"
 authors = [{ name = "thread-keeper contributors" }]

--- a/server.json
+++ b/server.json
@@ -7,12 +7,12 @@
     "url": "https://github.com/po4erk91/thread-keeper",
     "source": "github"
   },
-  "version": "0.16.2",
+  "version": "0.16.3",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "threadkeeper",
-      "version": "0.16.2",
+      "version": "0.16.3",
       "transport": {
         "type": "stdio"
       }

--- a/tests/test_release_workflows.py
+++ b/tests/test_release_workflows.py
@@ -6,6 +6,8 @@ import yaml
 ROOT = Path(__file__).resolve().parents[1]
 WORKFLOWS = ROOT / ".github" / "workflows"
 
+BOT_TAGGER_EMAIL = "41898282+github-actions[bot]@users.noreply.github.com"
+
 
 def _workflow(name: str) -> dict:
     return yaml.safe_load((WORKFLOWS / name).read_text())
@@ -15,19 +17,39 @@ def _workflow_text(name: str) -> str:
     return (WORKFLOWS / name).read_text()
 
 
-def test_release_readiness_is_read_only_and_does_not_publish():
+def test_release_tag_escalates_only_inside_the_tag_job():
     data = _workflow("release-tag.yml")
     text = _workflow_text("release-tag.yml")
 
+    # Workflow-level permissions stay read-only; only the tag job may
+    # create the tag ref and dispatch publish.yml.
     assert data["permissions"] == {"contents": "read"}
-    assert "actions: write" not in text
-    assert "contents: write" not in text
-    assert "gh workflow run publish.yml" not in text
-    assert 'git push origin "refs/tags/$TAG"' not in text
-    assert "Report maintainer release action" in text
+    tag_job = data["jobs"]["tag"]
+    assert tag_job["permissions"] == {"contents": "write", "actions": "write"}
+
+    # Fires only after a successful tests run for a push to main.
+    assert 'workflows: ["tests"]' in text
+    assert "branches: [main]" in text
+    assert "conclusion == 'success'" in tag_job["if"]
+    assert "event == 'push'" in tag_job["if"]
 
 
-def test_publish_requires_signed_tag_and_pypi_environment():
+def test_release_tag_gates_on_version_and_changelog_before_dispatch():
+    text = _workflow_text("release-tag.yml")
+
+    # Never re-tags an existing version, never tags without release
+    # notes, creates an annotated bot tag via the API, and hands off to
+    # publish.yml explicitly (GITHUB_TOKEN tag pushes don't start
+    # push-triggered runs).
+    assert "git ls-remote --exit-code --tags origin" in text
+    assert "^## v${VERSION} " in text
+    assert "git/tags" in text
+    assert "refs/tags/$TAG" in text
+    assert BOT_TAGGER_EMAIL in text
+    assert "gh workflow run publish.yml" in text
+
+
+def test_publish_requires_signed_or_bot_main_tag_and_pypi_environment():
     data = _workflow("publish.yml")
     text = _workflow_text("publish.yml")
     jobs = data["jobs"]
@@ -42,16 +64,24 @@ def test_publish_requires_signed_tag_and_pypi_environment():
     }
 
     assert "Require v* tag ref" in text
-    assert "Verify signed annotated tag" in text
+    assert "Verify release tag" in text
     assert ".verification.verified" in text
     assert "must be an annotated tag" in text
     assert "Validate release metadata" in text
+
+    # The unsigned path is narrow: explicit dispatch + github-actions[bot]
+    # tagger + tag commit already merged to main. Pushed unsigned tags
+    # must keep failing authorization.
+    assert '"$EVENT" != "workflow_dispatch"' in text
+    assert BOT_TAGGER_EMAIL in text
+    assert "compare/main..." in text
 
 
 def test_releasing_docs_describe_the_approval_flow():
     docs = (ROOT / "docs" / "RELEASING.md").read_text()
 
-    assert "does **not** create a tag" in docs
+    assert "release-tag.yml" in docs
     assert "Add at least one **Required reviewer**" in docs
-    assert "git tag -s v0.4.1 origin/main" in docs
     assert "The output must include a `required_reviewers` rule" in docs
+    # The manual signed-tag path stays documented as backfill/override.
+    assert "git tag -s" in docs


### PR DESCRIPTION
## What this changes

Releases have been stalled at v0.14.0 since June 25 while `pyproject.toml` moved on to 0.16.2: the #57 hardening (PR #207, shipped in v0.15.0) made publishing require a maintainer-signed annotated tag created from local git, and under fully PR-driven development that step never ran — 0.15.0–0.16.2 were version-bumped with CHANGELOG sections but never tagged, so PyPI and GitHub Releases fell behind the code. This PR restores automatic releasing while keeping a human in the loop: the checkpoint moves from local tag signing to the protected `pypi` environment approval. Version is bumped to 0.16.3, so the first green `main` build after merge releases the whole backlog.

## How

- `release-tag.yml` (previously a read-only "readiness" notice) again acts after a successful `tests` run on a `main` push: if the `pyproject.toml` version is untagged and `CHANGELOG.md` has the matching `## vX.Y.Z ` section, it creates the annotated tag via the REST API (tagger: `github-actions[bot]`) and dispatches `publish.yml` on it — tag refs created with `GITHUB_TOKEN` don't start push-triggered runs, hence the explicit handoff. Write permissions are escalated only inside the tag job; a bump without release notes produces a warning, not a tag.
- `publish.yml`'s authorize job now accepts two tag shapes: a GitHub-verified signed annotated tag (the manual backfill/override path, unchanged), or an unsigned annotated tag **only** when it arrives via `workflow_dispatch`, is tagged by `github-actions[bot]`, and points at a commit already merged to `main` (compare-API ancestor check). Pushed unsigned tags keep failing. Every path still stops at the protected `pypi` environment before upload, and the GitHub Release is still created from the CHANGELOG section after PyPI publish.
- `tests/test_release_workflows.py` re-encodes the new invariants: workflow-level permissions stay `contents: read` with escalation confined to the tag job, the unsigned path requires dispatch + bot tagger + on-main check, and the `pypi` environment/OIDC wiring is unchanged.
- Docs aligned: `docs/RELEASING.md` (environment approval is the human gate; its required-reviewer rule is load-bearing), `CONTRIBUTING.md → Releases`, `docs/ARCHITECTURE.md`, README, and an amendment note on the #57 entry in `docs/ROADMAP.md`.
- `pyproject.toml` and both `server.json` version fields bumped to 0.16.3; the accumulated `[Unreleased]` CHANGELOG content moved into `## v0.16.3 — 2026-07-19`.

**Merge prerequisite:** verify Settings → Environments → `pypi` still has a Required reviewer — with CI creating the tag, that approval is the only human checkpoint on the automatic path.

## Test plan

Diff touches only workflows, tests, docs, and version metadata — no runtime code.

```
python -m pytest tests/test_release_workflows.py -q   # 4 passed
```

Plus manual validation: `yaml.safe_load` on both workflows, `json.load` on `server.json`, and the `publish.yml` awk/grep release-notes extraction verified against the new `## v0.16.3 ` section. Full suite left to CI.

## Checklist

- [ ] `pytest` passes locally (`pip install -e '.[semantic,dev]'`) — ran the targeted `tests/test_release_workflows.py` only; no runtime code changed
- [x] New / changed behavior has a test
- [ ] If a new MCP tool — added to `threadkeeper/tools/` AND imported in `server.py` — n/a
- [ ] If a new adapter — registered in `adapters/__init__.py` with a test in `tests/test_adapters.py` — n/a
- [x] If user-visible behavior changed — README / CONTRIBUTING reflects it
- [x] No new emoji in code or docs (per house style)
- [x] No new locale strings outside `threadkeeper/i18n.py`

## Related issues

refs #57 — amends the release authorization gate introduced there (PR #207): auto-tagging returns, the human gate moves to the `pypi` environment approval, signed tags remain the manual override.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WbW7fWd2Dm7jsV61SADDyd

---
_Generated by [Claude Code](https://claude.ai/code/session_01WbW7fWd2Dm7jsV61SADDyd)_