### PR TITLE
fix: cap destructive curator deletes per pass

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -112,6 +112,7 @@ THREADKEEPER_CURATOR_INTERVAL_S=259200         # 3-day deep audit; set 0 to disa
 # THREADKEEPER_CURATOR_DESTRUCTIVE=1            # default 1: curator applies its own changes; set 0 for advisory REPORT-only
 # THREADKEEPER_CURATOR_MANAGE_FOREGROUND_SKILLS=0 # opt in to snapshotted merge/delete of foreground skills
 # THREADKEEPER_CURATOR_SNAPSHOT_RETENTION=10    # destructive pre-mutation snapshots retained under <reports_dir>/snapshots
+# THREADKEEPER_CURATOR_MAX_DESTRUCTIVE_PER_PASS=10 # shared cap for curator lesson/skill deletes per pass; 0 disables them
 # THREADKEEPER_EXTRACT_INTERVAL_S=0
 # THREADKEEPER_EXTRACT_WINDOW_MIN=30
 # THREADKEEPER_CANDIDATE_REVIEW_INTERVAL_S=0   # restart-throttled by last candidate_review_pass; force=True bypasses

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,6 +114,12 @@ version bumps follow semver per the policy in
   `THREADKEEPER_DIALECTIC_VALIDATE_FLUSH_AGE_S` /
   `THREADKEEPER_CANDIDATE_REVIEW_FLUSH_AGE_S` (default 3 days, 0 =
   threshold only).
+- **Curator deletion blast radius is capped (#106).** A destructive Curator
+  pass now atomically admits at most
+  `THREADKEEPER_CURATOR_MAX_DESTRUCTIVE_PER_PASS` (default 10) combined lesson
+  removals and skill deletes across all child batches. Cap refusals are durable
+  events and `mp_dashboard` reports `curator_destructive_cap status=HIT`;
+  foreground deletes and advisory Curator mode are unchanged.
 
 ## v0.16.2 — 2026-07-19
 

--- a/README.md
+++ b/README.md
@@ -691,6 +691,14 @@ tombstones for curator prunes/deletes. Retention is bounded by
 `THREADKEEPER_CURATOR_SNAPSHOT_RETENTION` (default 10, current pass always kept).
 Use `curator_restore(pass_id, lesson_slug="...")` or
 `curator_restore(pass_id, skill_name="...")` to restore an item from a snapshot.
+As a prevention layer before recovery is needed, a destructive Curator pass
+has one server-side shared admission budget for `lesson_remove` and
+`skill_manage(action='delete')`, including across bounded child batches.
+`THREADKEEPER_CURATOR_MAX_DESTRUCTIVE_PER_PASS` defaults to 10; set it to 0 to
+disable those autonomous deletes. The pass ID makes the count durable and
+cross-process, while foreground/human deletes are unaffected. `mp_dashboard`
+shows admitted and refused operations with `status=HIT` when the Curator reaches
+the ceiling.
 Before `lesson_remove` or `skill_manage(action='delete')` removes anything, it
 also writes a recovery artifact under `<db dir>/curator/trash/`: lessons store
 the exact sentinel section plus usage row, and skills store the full skill
@@ -1028,6 +1036,7 @@ The most-used env knobs (full list in `threadkeeper/config.py`):
 | `THREADKEEPER_CURATOR_MANAGE_FOREGROUND_SKILLS` | 0 | allow snapshot-scoped Curator repair/merge/delete of foreground skills; pinned/untracked skills remain protected |
 | `THREADKEEPER_CURATOR_MIN_LESSONS` | 3 | min lessons before curator engages |
 | `THREADKEEPER_CURATOR_DESTRUCTIVE` | `1` (on) | curator child writes its REPORT then applies its own PATCH/PRUNE/CONSOLIDATE directly (incl. `lesson_remove` for prune/consolidate); set `0` for advisory REPORT-only. `[PROTECTED]` entries are refused server-side |
+| `THREADKEEPER_CURATOR_MAX_DESTRUCTIVE_PER_PASS` | 10 | shared server-side ceiling for one destructive Curator pass across `lesson_remove` and `skill_manage(action='delete')`; `0` disables autonomous deletes and foreground deletes bypass it |
 | `THREADKEEPER_CURATOR_SNAPSHOT_RETENTION` | 10 | number of destructive curator pre-mutation snapshots to retain under `<reports_dir>/snapshots`; current pass is always retained |
 | `THREADKEEPER_CURATOR_TRASH_TTL_DAYS` | 30 | days to retain recovery artifacts under `<db dir>/curator/trash` for `lesson_remove` and `skill_manage(action='delete')`; expired artifacts are swept on new trash writes |
 | `THREADKEEPER_PROBE_INTERVAL_S` | 0 (off) | probe daemon tick (s); 1800 = 30 min recommended so finished probe answers are graded promptly |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -477,6 +477,14 @@ moving the high-water forward; `force=True` bypasses this due gate.
   endorsed `inventory_sha256` and the current inventory hash. Spawned
   `curator_pass` events record total entries, batch count, compressed
   `batch_entries`, and max rendered batch chars.
+  Destructive lesson removals and skill deletes reserve from one atomic,
+  pass-ID-scoped server-side budget before touching disk. The default
+  `CURATOR_MAX_DESTRUCTIVE_PER_PASS=10` is shared across child batches and
+  processes; the reservation event makes a cap refusal visible as
+  `curator_destructive_cap status=HIT` in `mp_dashboard`. Recovery snapshots
+  remain available. Foreground deletes bypass this autonomous-delete guard;
+  advisory (`CURATOR_DESTRUCTIVE=0`) passes retain their read-only toolset and
+  therefore make no capped delete calls.
 - **evolve_reviewer** (`evolve_daemon.start_evolve_daemon`) — once per
   `EVOLVE_REVIEW_INTERVAL_S` (default 0 = off) it reviews thread-keeper itself
   for security/privacy risks, memory leaks, runaway daemons, cost waste,

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -394,6 +394,13 @@ plus trash safety net (#52); bounding the candidate_reviewer prompt payload so
 its full queue dump cannot hit `E2BIG` — the Curator side is done in #105.
 Scope: S–M each.
 
+✅ DONE (#106): destructive Curator passes now have a server-side shared
+admission ceiling before `lesson_remove` or `skill_manage(action='delete')`
+can mutate. `CURATOR_MAX_DESTRUCTIVE_PER_PASS` defaults to 10, is keyed by the
+spawned pass ID across all batches/processes, and records admitted/refused rows
+so `mp_dashboard` surfaces `curator_destructive_cap status=HIT` instead of a
+silent prune storm. Foreground deletes and advisory passes are unaffected.
+
 ✅ DONE (#105): destructive Curator passes no longer dump the entire
 lessons/skills/concepts inventory into one child prompt. The pass now renders
 bounded inventory batches, records `entries` / `batches` / `batch_entries` /

--- a/tests/test_curator.py
+++ b/tests/test_curator.py
@@ -53,6 +53,7 @@ def _bootstrap(
     min_lessons="3",
     destructive=None,
     retention=None,
+    max_destructive=None,
     write_origin="foreground",
 ):
     env = {
@@ -79,6 +80,8 @@ def _bootstrap(
         env["THREADKEEPER_CURATOR_DESTRUCTIVE"] = destructive
     if retention is not None:
         env["THREADKEEPER_CURATOR_SNAPSHOT_RETENTION"] = retention
+    if max_destructive is not None:
+        env["THREADKEEPER_CURATOR_MAX_DESTRUCTIVE_PER_PASS"] = max_destructive
     for k, v in env.items():
         monkeypatch.setenv(k, v)
     Path(env["CLAUDE_PROJECTS_DIR"]).mkdir(parents=True, exist_ok=True)
@@ -450,6 +453,7 @@ def test_run_curator_pass_force_bypasses_recent_high_water(
 def test_run_curator_pass_advisory_writes_no_snapshot(tmp_path, monkeypatch):
     pkg = _bootstrap(
         tmp_path, monkeypatch, min_lessons="2", destructive="0",
+        max_destructive="0",
     )
     pkg["lessons"].append_lesson(
         title="lesson one", body="body one", source="shadow"
@@ -476,6 +480,73 @@ def test_run_curator_pass_advisory_writes_no_snapshot(tmp_path, monkeypatch):
     allowed = captured[0]["extra_allowed_tools"]
     assert "lesson_remove" not in allowed
     assert "skill_manage" not in allowed
+
+
+def test_curator_delete_cap_is_shared_across_lesson_and_skill_deletes(
+    tmp_path, monkeypatch,
+):
+    pkg = _bootstrap(
+        tmp_path, monkeypatch, write_origin="curator", max_destructive="2",
+    )
+    for name in ("first lesson", "second lesson"):
+        pkg["lessons"].append_lesson(
+            title=name, body="loop-authored and eligible for curation", source="shadow",
+        )
+
+    from threadkeeper._mcp import mcp
+    from threadkeeper.curator_snapshots import CAP_EVENT, PASS_ID_ENV
+
+    remove = mcp._tool_manager._tools["lesson_remove"].fn
+    manage = mcp._tool_manager._tools["skill_manage"].fn
+    assert manage(
+        action="create",
+        name="cap-target",
+        description="A skill used to verify curator deletion admission.",
+        content="# Cap target\n\nThis is safe test content.",
+    ).startswith("ok")
+
+    monkeypatch.setenv(PASS_ID_ENV, "cap-pass")
+    assert remove(slug="first-lesson") == "ok removed=first-lesson"
+    assert manage(action="delete", name="cap-target") == "ok"
+    blocked = remove(slug="second-lesson")
+
+    assert blocked.startswith("ERR curator_destructive_cap_exceeded"), blocked
+    assert "limit=2" in blocked
+    assert (pkg["skills_dir"] / "cap-target").exists() is False
+    assert "second-lesson" in pkg["lessons_path"].read_text()
+    conn = pkg["db"].get_db()
+    rows = conn.execute(
+        "SELECT summary FROM events WHERE kind=? AND target='cap-pass' "
+        "ORDER BY id",
+        (CAP_EVENT,),
+    ).fetchall()
+    assert ["outcome=admitted" in r["summary"] for r in rows] == [True, True, False]
+    assert "outcome=refused" in rows[-1]["summary"]
+
+
+def test_foreground_deletes_bypass_curator_delete_cap(tmp_path, monkeypatch):
+    pkg = _bootstrap(tmp_path, monkeypatch, max_destructive="0")
+    pkg["lessons"].append_lesson(
+        title="foreground deletion", body="human-owned content", source="user",
+    )
+    from threadkeeper._mcp import mcp
+    from threadkeeper.curator_snapshots import CAP_EVENT
+
+    remove = mcp._tool_manager._tools["lesson_remove"].fn
+    manage = mcp._tool_manager._tools["skill_manage"].fn
+    assert manage(
+        action="create",
+        name="foreground-cap-bypass",
+        description="A skill used to verify foreground deletion behavior.",
+        content="# Foreground\n\nThis is safe test content.",
+    ).startswith("ok")
+
+    assert remove(slug="foreground-deletion", force=True).startswith("ok")
+    assert manage(action="delete", name="foreground-cap-bypass", force=True) == "ok"
+    conn = pkg["db"].get_db()
+    assert conn.execute(
+        "SELECT COUNT(*) FROM events WHERE kind=?", (CAP_EVENT,)
+    ).fetchone()[0] == 0
 
 
 def test_curator_snapshot_retention_is_bounded(tmp_path, monkeypatch):

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -147,6 +147,11 @@ def _curator_action_field(out: str, field: str) -> int:
     return int(m.group(1)) if m else 0
 
 
+def _curator_cap_field(out: str, field: str) -> int:
+    m = re.search(rf"curator_destructive_cap [^\n]*\b{field}=(\d+)", out)
+    return int(m.group(1)) if m else 0
+
+
 def _loop_line(out: str, label: str) -> str:
     m = re.search(rf"^\s+{re.escape(label)}[^\n]+$", out, re.M)
     return m.group(0) if m else ""
@@ -328,6 +333,31 @@ def test_dashboard_surfaces_curator_destructive_action_counts(fresh_mp):
         - base["skill_deleted"]
         == 1
     )
+
+
+def test_dashboard_surfaces_curator_destructive_cap_hit(fresh_mp):
+    conn = fresh_mp["db"].get_db()
+    now = int(time.time())
+    dash = _tool(fresh_mp, "mp_dashboard")
+    before = dash(window_days=7)
+    admitted0 = _curator_cap_field(before, "admitted")
+    refused0 = _curator_cap_field(before, "refused")
+    for outcome in ("admitted", "admitted", "refused"):
+        conn.execute(
+            "INSERT INTO events (session_id, kind, target, summary, created_at) "
+            "VALUES ('s', 'curator_destructive_cap', 'pass-a', ?, ?)",
+            (
+                f"outcome={outcome} action=lesson_remove artifact=lesson "
+                "key=x limit=2 used=2",
+                now,
+            ),
+        )
+    conn.commit()
+
+    after = dash(window_days=7)
+    assert _curator_cap_field(after, "admitted") - admitted0 == 2
+    assert _curator_cap_field(after, "refused") - refused0 == 1
+    assert "curator_destructive_cap" in after and "status=HIT" in after
 
 
 def test_dashboard_lesson_append_emits_countable_outcome(fresh_mp):

--- a/threadkeeper/config.py
+++ b/threadkeeper/config.py
@@ -322,6 +322,10 @@ class Settings(BaseSettings):
     # skill delete capture full pre-images under <db dir>/curator/trash before
     # mutating; this TTL bounds disk growth.
     curator_trash_ttl_days: int = 30
+    # Server-side admission limit shared by every destructive child batch in
+    # one curator pass. 0 disables curator lesson/skill deletes for that pass;
+    # foreground deletes are never subject to this limit.
+    curator_max_destructive_per_pass: int = 10
 
     # ── Extract daemon ───────────────────────────────────────────────────────
     extract_interval_s: float = 0.0
@@ -777,6 +781,9 @@ def _derive_constants(s: "Settings") -> dict:
         "CURATOR_SNAPSHOT_RETENTION": s.curator_snapshot_retention,
         "CURATOR_TRASH_DIR": curator_reports_dir / "trash",
         "CURATOR_TRASH_TTL_DAYS": s.curator_trash_ttl_days,
+        "CURATOR_MAX_DESTRUCTIVE_PER_PASS": (
+            s.curator_max_destructive_per_pass
+        ),
         "EXTRACT_INTERVAL_S": s.extract_interval_s,
         "EXTRACT_WINDOW_MIN": s.extract_window_min,
         "CANDIDATE_REVIEW_INTERVAL_S": s.candidate_review_interval_s,

--- a/threadkeeper/curator.py
+++ b/threadkeeper/curator.py
@@ -65,6 +65,7 @@ from .config import (
     CURATOR_MIN_LESSONS,
     CURATOR_REPORTS_DIR,
     CURATOR_DESTRUCTIVE,
+    CURATOR_MAX_DESTRUCTIVE_PER_PASS,
     CURATOR_MANAGE_FOREGROUND_SKILLS,
     CURATOR_SNAPSHOT_RETENTION,
 )
@@ -1135,6 +1136,10 @@ def run_curator_pass(force: bool = False, *, scheduled: bool = False) -> str:
                 "concept_id=<id>, confidence='low|medium|high') applies a "
                 "confidence review.\n"
                 "NEVER pass force=True to lesson_remove or skill_manage. "
+                "Across every batch in this pass, the server admits at most "
+                f"{max(0, int(CURATOR_MAX_DESTRUCTIVE_PER_PASS))} combined "
+                "lesson_remove / skill_manage(action='delete') calls; stop "
+                "deleting and record the refusal in the report if that cap is hit. "
                 f"{foreground_clause} NEVER touch "
                 "any entry marked [PROTECTED], even in destructive mode. Apply "
                 "changes ONLY after the REPORT.md is "

--- a/threadkeeper/curator_snapshots.py
+++ b/threadkeeper/curator_snapshots.py
@@ -19,8 +19,10 @@ from typing import Any
 from . import identity, lessons
 from .config import (
     CLAUDE_SKILLS_DIR,
+    CURATOR_MAX_DESTRUCTIVE_PER_PASS,
     CURATOR_REPORTS_DIR,
     CURATOR_SNAPSHOT_RETENTION,
+    WRITE_ORIGIN,
 )
 from .identity import _ensure_session
 
@@ -29,6 +31,7 @@ PASS_ID_ENV = "THREADKEEPER_CURATOR_PASS_ID"
 SNAPSHOT_DIR_ENV = "THREADKEEPER_CURATOR_SNAPSHOT_DIR"
 ACTION_EVENT = "curator_destructive_action"
 SNAPSHOT_EVENT = "curator_snapshot"
+CAP_EVENT = "curator_destructive_cap"
 
 _SAFE_PASS_RE = re.compile(r"^[A-Za-z0-9_.:-]+$")
 
@@ -244,6 +247,78 @@ def record_curator_action(
     except sqlite3.OperationalError:
         return body_rel
     return body_rel
+
+
+def admit_curator_destructive_action(
+    conn: sqlite3.Connection,
+    *,
+    action: str,
+    artifact: str,
+    key: str,
+) -> str | None:
+    """Reserve one destructive curator operation for the current pass.
+
+    Every bounded-inventory child spawned for a pass inherits the same pass
+    identifier.  The ``BEGIN IMMEDIATE`` reservation serializes those children
+    across MCP server processes, so a prompt cannot race several deletes past
+    the configured total.  The admission row remains even if a later file
+    operation fails; failing closed is preferable to restoring deletion
+    authority after an uncertain partial mutation.
+
+    Returns an error reason when the caller must not mutate, otherwise ``None``.
+    Foreground and other non-curator writers deliberately bypass this guard.
+    """
+    if WRITE_ORIGIN != "curator":
+        return None
+
+    _ensure_session(conn)
+    pass_id = current_pass_id()
+    limit = max(0, int(CURATOR_MAX_DESTRUCTIVE_PER_PASS))
+    if not pass_id:
+        return (
+            "curator_destructive_cap_missing_pass_id "
+            f"action={action} limit={limit}"
+        )
+
+    def record(outcome: str, used: int) -> None:
+        conn.execute(
+            "INSERT INTO events (session_id, kind, target, summary, created_at) "
+            "VALUES (?, ?, ?, ?, strftime('%s','now'))",
+            (
+                identity._session_id or "",
+                CAP_EVENT,
+                pass_id,
+                (
+                    f"outcome={outcome} action={action} artifact={artifact} "
+                    f"key={_safe_name(key)} limit={limit} used={used}"
+                ),
+            ),
+        )
+
+    try:
+        conn.execute("BEGIN IMMEDIATE")
+        row = conn.execute(
+            "SELECT COUNT(*) AS n FROM events "
+            "WHERE kind=? AND target=? AND summary LIKE 'outcome=admitted %'",
+            (CAP_EVENT, pass_id),
+        ).fetchone()
+        used = int(row["n"] if row else 0)
+        if used >= limit:
+            record("refused", used)
+            conn.commit()
+            return (
+                "curator_destructive_cap_exceeded "
+                f"action={action} limit={limit} used={used}"
+            )
+        record("admitted", used)
+        conn.commit()
+        return None
+    except sqlite3.Error as e:
+        if conn.in_transaction:
+            conn.rollback()
+        # A server-side safety guard must fail closed when accounting cannot
+        # be persisted, rather than silently allowing an unbounded delete.
+        return f"curator_destructive_cap_unavailable action={action}: {e}"
 
 
 def _load_manifest(snapshot_dir: Path) -> dict[str, Any]:

--- a/threadkeeper/tools/dashboard.py
+++ b/threadkeeper/tools/dashboard.py
@@ -477,6 +477,23 @@ def mp_dashboard(window_days: int = 7) -> str:
         + " ".join(f"{k}={v}" for k, v in action_counts.items())
         + f" ({window_days}d)"
     )
+    cap_admitted = _scalar(
+        conn,
+        "SELECT COUNT(*) FROM events WHERE kind='curator_destructive_cap' "
+        "AND summary LIKE 'outcome=admitted%' AND created_at>=?",
+        (cut_win,),
+    )
+    cap_refused = _scalar(
+        conn,
+        "SELECT COUNT(*) FROM events WHERE kind='curator_destructive_cap' "
+        "AND summary LIKE 'outcome=refused%' AND created_at>=?",
+        (cut_win,),
+    )
+    out.append(
+        "  curator_destructive_cap "
+        f"admitted={cap_admitted} refused={cap_refused} "
+        f"status={'HIT' if cap_refused else 'ok'} ({window_days}d)"
+    )
     # ── roadmap applier (poison-issue backoff / dead-letter) ───────────
     # Issues the evolve applier has spawned a child for, split by outcome.
     # `stuck` = attempted but neither handed off (PR) nor dead-lettered yet

--- a/threadkeeper/tools/lessons.py
+++ b/threadkeeper/tools/lessons.py
@@ -38,7 +38,10 @@ from .. import identity
 from ..identity import _ensure_session
 from ..db import get_db
 from ..config import WRITE_ORIGIN
-from ..curator_snapshots import record_curator_action
+from ..curator_snapshots import (
+    admit_curator_destructive_action,
+    record_curator_action,
+)
 from ..review_prompts import screen_injection_markers
 from ..lessons import (
     _slugify,
@@ -498,6 +501,13 @@ def lesson_remove(slug: str, force: bool = False) -> str:
     snapshot = lesson_section(slug)
     if not snapshot:
         return f"ERR remove_failed slug={slug}"
+    if reason := admit_curator_destructive_action(
+        conn,
+        action="lesson_remove",
+        artifact="lesson",
+        key=slug,
+    ):
+        return f"ERR {reason}"
     post_remove = (
         snapshot["file_body"][:snapshot["start"]]
         + snapshot["file_body"][snapshot["end"]:]

--- a/threadkeeper/tools/skills.py
+++ b/threadkeeper/tools/skills.py
@@ -45,6 +45,7 @@ from ..config import (
 from ..curator_snapshots import (
     PASS_ID_ENV,
     SNAPSHOT_DIR_ENV,
+    admit_curator_destructive_action,
     capture_skill_tombstone,
     record_curator_action,
 )
@@ -923,6 +924,13 @@ def _action_delete(name: str, *, force: bool = False) -> str:
             f"ERR protected_skill name={name} reason={protected_reason}"
             f"{force_note}"
         )
+    if reason := admit_curator_destructive_action(
+        conn,
+        action="skill_delete",
+        artifact="skill",
+        key=name,
+    ):
+        return f"ERR {reason}"
     tombstone = ""
     if WRITE_ORIGIN == "curator":
         tombstone = capture_skill_tombstone("skill_deleted", name, sdir)


### PR DESCRIPTION
## Summary
- Atomically cap combined curator lesson removals and skill deletes per pass.
- Record admissions and refusals for dashboard visibility.
- Document the configuration knob and recovery boundary.

## Tests
- env -u THREADKEEPER_NO_EMBEDDINGS .venv/bin/python -m pytest -q

Closes #106