### PR TITLE
feat: notifier daemon for loop/spawn failures + materialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -925,6 +925,49 @@ degradation: even when agents don't actively contribute, loops 2-5
 keep the library growing from passive observation of the dialog
 stream.
 
+### Notifications
+
+The learning loops spawn paid children. When a loop **can't do its work** — a
+CLI subscription runs out of credits/limits, auth expires, the binary is
+missing, a spawn times out, or a spawned child dies mid-run — thread-keeper
+quietly stops learning. For a memory system that silent degradation is the worst
+failure mode: you keep trusting it while it has stopped. The `notify` daemon
+watches the already-emitted event signals and surfaces this (and, optionally,
+skill/lesson materialization). It is a read-only consumer — no spawn, no model,
+no credit cost.
+
+Three detection sources per tick:
+
+1. **Admission failures / terminal timeouts** — a `<loop>_pass` event whose
+   summary is a spawn/budget failure (e.g. `token_budget_exceeded`,
+   `claude_cli_not_found`), plus `spawn_timeout_retry_failed`.
+2. **Dead children** — a `tasks` row that ended with a non-zero, non-timeout
+   return code. This is the important one: `spawn()` returns `ok task=…` at
+   *launch*, so a `*_pass` summary is a false success when a child later dies
+   from an exhausted subscription; the real outcome only lands in
+   `tasks.return_code`. The reason is read from the child's log tail.
+3. **Materialization** — `skill_materialized` / `skill_create` (skill) and
+   `lesson_append` (lesson).
+
+A per-loop cooldown collapses a lapsed-subscription storm into one actionable
+alert; the first run seeds its cursor to the current position, so historical
+backlog never fires. `events`/`tasks`/`daemon_state` are node-local, so each
+machine notifies about its **own** loops.
+
+```bash
+# off by default — set a poll interval to enable
+THREADKEEPER_NOTIFY_POLL_S=30           # daemon tick (seconds); 0 = off
+THREADKEEPER_NOTIFY_LOOP_FAILURE=true   # alert when a loop fails to run (default on)
+THREADKEEPER_NOTIFY_SKILL_MATERIALIZED=false  # alert on skill materialization
+THREADKEEPER_NOTIFY_LESSON=false        # alert on lesson append
+THREADKEEPER_NOTIFY_CHANNEL=macos,log   # comma list: macos (osascript), log
+THREADKEEPER_NOTIFY_FAILURE_COOLDOWN_S=3600   # min seconds between repeats of one loop's failure
+```
+
+Channels are macOS notifications (`osascript`) and a `[notify]` log line;
+`macos` self-noops off Darwin. A webhook channel (headless Linux / phone push)
+is a planned follow-up.
+
 ### Dialectic user model
 
 A model of you, accumulated as you use the agent. `dialectic_claim`,

--- a/tests/test_notify_daemon.py
+++ b/tests/test_notify_daemon.py
@@ -1,0 +1,204 @@
+"""Notifier daemon — surfaces silent loop/spawn failures + materialization
+(issue #257). Uses the log channel for observable assertions.
+"""
+from __future__ import annotations
+
+import logging
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+_FAKE_CID = "aaaa1111-2222-3333-4444-555566667777"
+
+
+def _bootstrap(tmp_path, monkeypatch, *, poll="0", channel="log",
+               loop_fail="true", skill="false", lesson="false", cooldown="3600"):
+    env = {
+        "THREADKEEPER_DB": str(tmp_path / "db.sqlite"),
+        "CLAUDE_PROJECTS_DIR": str(tmp_path / "fake_claude_projects"),
+        # every other daemon off
+        "THREADKEEPER_INGEST_INTERVAL_S": "0",
+        "THREADKEEPER_SHADOW_REVIEW_INTERVAL_S": "0",
+        "THREADKEEPER_CURATOR_INTERVAL_S": "0",
+        "THREADKEEPER_PROBE_INTERVAL_S": "0",
+        "THREADKEEPER_EXTRACT_INTERVAL_S": "0",
+        "THREADKEEPER_SPAWN_BUDGET_POLL_S": "0",
+        "THREADKEEPER_SEARCH_PROXY_POLL_S": "0",
+        # notifier under test
+        "THREADKEEPER_NOTIFY_POLL_S": poll,
+        "THREADKEEPER_NOTIFY_CHANNEL": channel,
+        "THREADKEEPER_NOTIFY_LOOP_FAILURE": loop_fail,
+        "THREADKEEPER_NOTIFY_SKILL_MATERIALIZED": skill,
+        "THREADKEEPER_NOTIFY_LESSON": lesson,
+        "THREADKEEPER_NOTIFY_FAILURE_COOLDOWN_S": cooldown,
+        "THREADKEEPER_TASK_LOG_DIR": str(tmp_path / "tasks"),
+        "THREADKEEPER_LESSONS": str(tmp_path / "lessons.md"),
+        "THREADKEEPER_CLIENT": "pytest",
+        "THREADKEEPER_FORCE_CID": _FAKE_CID,
+    }
+    for k, v in env.items():
+        monkeypatch.setenv(k, v)
+    Path(env["CLAUDE_PROJECTS_DIR"]).mkdir(parents=True, exist_ok=True)
+    Path(env["THREADKEEPER_TASK_LOG_DIR"]).mkdir(parents=True, exist_ok=True)
+    for name in [m for m in list(sys.modules) if m.startswith("threadkeeper")]:
+        del sys.modules[name]
+    import threadkeeper.server  # noqa: F401
+    from threadkeeper import db, notify, identity
+    return {"db": db, "notify": notify, "identity": identity}
+
+
+def _ev(conn, kind, summary="", target="", ts=None):
+    conn.execute(
+        "INSERT INTO events (session_id, kind, target, summary, created_at) "
+        "VALUES (?,?,?,?,?)",
+        ("s", kind, target, summary, ts or int(time.time())),
+    )
+    conn.commit()
+
+
+def _task(conn, task_id, rc, role, ended_at):
+    conn.execute(
+        "INSERT INTO tasks (id, pid, cwd, prompt, started_at, ended_at, "
+        "return_code, role) VALUES (?,?,?,?,?,?,?,?)",
+        (task_id, 0, "/tmp", "p", ended_at - 1, ended_at, rc, role),
+    )
+    conn.commit()
+
+
+# ── classifier (pure) ───────────────────────────────────────────────────────
+
+@pytest.mark.parametrize("summary,expected", [
+    ("ERR claude_cli_not_found", "failure"),
+    ("spawn_error: boom", "failure"),
+    ("graded=2 spawn_error: budget", "failure"),
+    ("spawned pending=3 :: ERR token_budget_exceeded", "failure"),
+    ("spawn_failed cli=claude reason=binary_not_found", "failure"),
+    ("not_due", "neutral"),
+    ("no_window w=30m", "neutral"),
+    ("too_short chars=5", "neutral"),
+    ("ok task=abc pid=1", "neutral"),
+    ("shadow_child_running n=1", "neutral"),
+    ("below_threshold", "neutral"),
+    ("graded=2 no_due", "neutral"),
+    ("", "neutral"),
+])
+def test_classify(tmp_path, monkeypatch, summary, expected):
+    m = _bootstrap(tmp_path, monkeypatch)
+    assert m["notify"].classify_summary(summary) == expected
+
+
+# ── failure detection ───────────────────────────────────────────────────────
+
+def test_failure_pass_fires_one_notification(tmp_path, monkeypatch, caplog):
+    m = _bootstrap(tmp_path, monkeypatch)
+    notify, db = m["notify"], m["db"]
+    conn = db.get_db()
+    assert notify.run_notify_pass(force=True) == "seed"      # first run seeds
+    _ev(conn, "curator_pass", "spawn_error: budget_exceeded", target="123")
+    with caplog.at_level(logging.WARNING, logger="threadkeeper.notify"):
+        out = notify.run_notify_pass(force=True)
+    assert out == "ok fired=1", out
+    assert "[notify]" in caplog.text and "curator loop failed" in caplog.text
+    assert "budget exhausted" in caplog.text
+
+
+def test_dead_child_fires_notification_with_log_reason(tmp_path, monkeypatch, caplog):
+    m = _bootstrap(tmp_path, monkeypatch)
+    notify, db = m["notify"], m["db"]
+    conn = db.get_db()
+    assert notify.run_notify_pass(force=True) == "seed"
+    (tmp_path / "tasks" / "child-1.log").write_text(
+        "starting…\nerror: credit balance too low\n")
+    _task(conn, "child-1", rc=1, role="curator", ended_at=int(time.time()))
+    with caplog.at_level(logging.WARNING, logger="threadkeeper.notify"):
+        out = notify.run_notify_pass(force=True)
+    assert out == "ok fired=1", out
+    assert "curator child died (rc=1)" in caplog.text
+    assert "credit balance too low" in caplog.text
+
+
+def test_timeout_and_zero_exit_children_ignored(tmp_path, monkeypatch):
+    m = _bootstrap(tmp_path, monkeypatch)
+    notify, db = m["notify"], m["db"]
+    conn = db.get_db()
+    assert notify.run_notify_pass(force=True) == "seed"
+    now = int(time.time())
+    _task(conn, "ok-child", rc=0, role="curator", ended_at=now)       # success
+    _task(conn, "timeout-child", rc=124, role="probe", ended_at=now)  # timeout (retried)
+    out = notify.run_notify_pass(force=True)
+    assert out == "ok fired=0", out
+
+
+# ── cooldown / de-dup ───────────────────────────────────────────────────────
+
+def test_cooldown_dedups_repeat_failures(tmp_path, monkeypatch):
+    m = _bootstrap(tmp_path, monkeypatch, cooldown="3600")
+    notify, db = m["notify"], m["db"]
+    conn = db.get_db()
+    assert notify.run_notify_pass(force=True) == "seed"
+    _ev(conn, "curator_pass", "spawn_error: a")
+    _ev(conn, "curator_pass", "spawn_error: b")      # same loop, same pass
+    assert notify.run_notify_pass(force=True) == "ok fired=1"   # coalesced
+    _ev(conn, "curator_pass", "spawn_error: c")      # still within cooldown
+    assert notify.run_notify_pass(force=True) == "ok fired=0"
+
+
+def test_distinct_loops_both_fire(tmp_path, monkeypatch):
+    m = _bootstrap(tmp_path, monkeypatch)
+    notify, db = m["notify"], m["db"]
+    conn = db.get_db()
+    assert notify.run_notify_pass(force=True) == "seed"
+    _ev(conn, "curator_pass", "spawn_error: x")
+    _ev(conn, "probe_pass", "graded=1 spawn_error: y")
+    assert notify.run_notify_pass(force=True) == "ok fired=2"
+
+
+# ── first-run seed ──────────────────────────────────────────────────────────
+
+def test_first_run_seeds_no_backlog(tmp_path, monkeypatch, caplog):
+    m = _bootstrap(tmp_path, monkeypatch, poll="60")   # >0 so scheduled tick runs
+    notify, db = m["notify"], m["db"]
+    conn = db.get_db()
+    _ev(conn, "curator_pass", "spawn_error: historical")   # pre-seed backlog
+    _ev(conn, "shadow_review_pass", "spawn_error: old")
+    with caplog.at_level(logging.WARNING, logger="threadkeeper.notify"):
+        assert notify.run_notify_pass(scheduled=True) == "seed"
+    assert "[notify]" not in caplog.text                   # backlog never fires
+    _ev(conn, "curator_pass", "spawn_error: fresh")        # after seed
+    with caplog.at_level(logging.WARNING, logger="threadkeeper.notify"):
+        assert notify.run_notify_pass(force=True) == "ok fired=1"
+
+
+# ── positive toggles ────────────────────────────────────────────────────────
+
+def test_positives_off_by_default(tmp_path, monkeypatch):
+    m = _bootstrap(tmp_path, monkeypatch, skill="false", lesson="false")
+    notify, db = m["notify"], m["db"]
+    conn = db.get_db()
+    assert notify.run_notify_pass(force=True) == "seed"
+    _ev(conn, "skill_materialized", target="T1", summary="/skills/foo/SKILL.md")
+    _ev(conn, "lesson_append", target="my-lesson", summary="op=create source=shadow")
+    assert notify.run_notify_pass(force=True) == "ok fired=0"
+
+
+def test_positives_on_fire(tmp_path, monkeypatch, caplog):
+    m = _bootstrap(tmp_path, monkeypatch, skill="true", lesson="true")
+    notify, db = m["notify"], m["db"]
+    conn = db.get_db()
+    assert notify.run_notify_pass(force=True) == "seed"
+    _ev(conn, "skill_materialized", target="T1", summary="/skills/foo/SKILL.md")
+    _ev(conn, "lesson_append", target="my-lesson", summary="op=create source=shadow")
+    with caplog.at_level(logging.WARNING, logger="threadkeeper.notify"):
+        out = notify.run_notify_pass(force=True)
+    assert out == "ok fired=2", out
+    assert "skill materialized" in caplog.text
+    assert "lesson added" in caplog.text and "my-lesson" in caplog.text
+
+
+# ── disabled ────────────────────────────────────────────────────────────────
+
+def test_disabled_when_poll_zero(tmp_path, monkeypatch):
+    m = _bootstrap(tmp_path, monkeypatch, poll="0")
+    assert m["notify"].run_notify_pass(scheduled=True) == "disabled"

--- a/threadkeeper/config.py
+++ b/threadkeeper/config.py
@@ -267,6 +267,18 @@ class Settings(BaseSettings):
     # resident while the freed arenas are still mapped). 0 disables the guard.
     memory_guard_embed_hot_s: float = 300.0
 
+    # ── Notifier (issue #257) ────────────────────────────────────────────────
+    # Surfaces silent background-loop degradation (a loop couldn't bring up its
+    # model/CLI — credits/limits exhausted, auth expired, binary missing, spawn
+    # timeout, or a spawned child died) and, optionally, skill/lesson
+    # materialization. Off by default: notify_poll_s=0 disables the daemon.
+    notify_poll_s: float = 0.0            # daemon tick; 0 = notifier off
+    notify_loop_failure: bool = True      # alert when a loop fails to run
+    notify_skill_materialized: bool = False
+    notify_lesson: bool = False
+    notify_channel: str = "macos,log"     # comma list: macos, log (webhook: TODO)
+    notify_failure_cooldown_s: int = 3600  # min seconds between repeats of one loop's failure
+
     # ── Auto-review ──────────────────────────────────────────────────────────
     auto_review: bool = Field(
         default=False,
@@ -765,6 +777,12 @@ def _derive_constants(s: "Settings") -> dict:
         "MEMORY_GUARD_NOTIFY": s.memory_guard_notify,
         "MEMORY_GUARD_COOLDOWN_S": s.memory_guard_cooldown_s,
         "MEMORY_GUARD_EMBED_HOT_S": s.memory_guard_embed_hot_s,
+        "NOTIFY_POLL_S": s.notify_poll_s,
+        "NOTIFY_LOOP_FAILURE": s.notify_loop_failure,
+        "NOTIFY_SKILL_MATERIALIZED": s.notify_skill_materialized,
+        "NOTIFY_LESSON": s.notify_lesson,
+        "NOTIFY_CHANNEL": s.notify_channel,
+        "NOTIFY_FAILURE_COOLDOWN_S": s.notify_failure_cooldown_s,
         "SHADOW_REVIEW_INTERVAL_S": s.shadow_review_interval_s,
         "SHADOW_REVIEW_WINDOW_S": s.shadow_review_window_s,
         "SHADOW_REVIEW_MIN_CHARS": s.shadow_review_min_chars,

--- a/threadkeeper/host.py
+++ b/threadkeeper/host.py
@@ -36,6 +36,8 @@ _DAEMON_STARTERS = [
     ("thread_janitor", "start_thread_janitor"),
     ("dialectic_miner", "start_dialectic_miner_daemon"),
     ("dialectic_validator", "start_dialectic_validator_daemon"),
+    # Notifier: surfaces silent loop/spawn failures + materialization (issue #257).
+    ("notify", "start_notify_daemon"),
     # Cross-machine sync: HTTP server (peers pull/push) + client reconcile loop.
     # Both no-op unless the DB is migrated and peers/token/listen are configured.
     # Centralized here so that with DAEMON_HOST_ENABLED only the host runs them —

--- a/threadkeeper/notify.py
+++ b/threadkeeper/notify.py
@@ -1,0 +1,399 @@
+"""Notifier daemon — surfaces silent background-loop degradation + materialization.
+
+thread-keeper's learning loops spawn paid children. When a loop can't do its
+work — a CLI subscription runs out of credits/limits, auth expires, the binary
+is missing, a spawn times out, or (the common one) the spawned child dies
+mid-run — TK quietly stops learning. For a memory system that silent
+degradation is the worst failure mode: you keep trusting it while it has
+stopped. This daemon watches the already-emitted signals and tells the user.
+
+Three detection sources, read-only (no LLM spawn, no credit cost):
+
+  1. Admission failures / terminal timeouts — `<loop>_pass` events whose summary
+     is a spawn/budget failure (classify_summary), plus `spawn_timeout_retry_failed`.
+  2. Dead children — `tasks` rows that ended with a non-zero, non-timeout
+     return_code. This is what catches "subscription ran out mid-run": spawn()
+     returns `ok task=…` at LAUNCH, so the *_pass summary is a false success; the
+     real outcome only lands in tasks.return_code.
+  3. Positive materialization — `skill_materialized`/`skill_create`/`lesson_append`.
+
+`events`, `tasks` and `daemon_state` are node-local (never synced), so each
+machine notifies about its own loops and keeps its own per-loop cooldown.
+
+All off by default (NOTIFY_POLL_S=0). Categories individually toggleable. Channels
+macOS (osascript) + log now; webhook is a follow-up.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import sqlite3
+import subprocess
+import threading
+import time
+
+from .config import (
+    NOTIFY_POLL_S,
+    NOTIFY_LOOP_FAILURE,
+    NOTIFY_SKILL_MATERIALIZED,
+    NOTIFY_LESSON,
+    NOTIFY_CHANNEL,
+    NOTIFY_FAILURE_COOLDOWN_S,
+)
+from .db import get_db
+from . import daemon_state, identity
+from .helpers import daemon_sleep, single_flight_lock
+
+logger = logging.getLogger(__name__)
+
+_started = False
+
+# SOURCE 1 — loop-pass kinds whose failure summaries we surface. Their pass
+# summaries embed the spawn/budget outcome. `spawn_timeout_retry_failed` is a
+# terminal timeout (transient `spawn_timeout`/`retry_skipped` are excluded — they
+# retry).
+_LOOP_PASS_KINDS = (
+    "shadow_review_pass", "candidate_review_pass", "curator_pass",
+    "probe_pass", "extract_pass", "dialectic_validate_pass",
+    "evolve_review_pass", "evolve_apply_pass", "auto_update_pass",
+    "skill_update_pass", "spawn_timeout_retry_failed",
+)
+# SOURCE 3 — positive materialization event kinds, split by toggle.
+_SKILL_KINDS = ("skill_materialized", "skill_create")
+_LESSON_KINDS = ("lesson_append",)
+
+# Failure tokens shared with shadow_review._classify_pass / agent_status._human_summary.
+_FAIL_TOKENS = (
+    "spawn_error", "spawn_failed", ":: err", "budget_exceeded",
+    "token_budget_exceeded", "cost_budget_exceeded",
+)
+_SPAWN_TIMEOUT_RETURN_CODE = 124  # spawn_budget.SPAWN_TIMEOUT_RETURN_CODE
+
+
+# ── classification ──────────────────────────────────────────────────────────
+
+def classify_summary(summary: str | None) -> str:
+    """Bucket a `*_pass` event summary: 'failure' | 'neutral'.
+
+    Failure = a spawn/budget rejection or embedded ERR. Everything else
+    (not_due / no_window / too_short / below_threshold / *_skip / *_child_running
+    / no_apply_work / claim_lost / unchanged_inventory / `ok task=…`) is neutral.
+    Mirrors shadow_review._classify_pass and agent_status._human_summary.
+    """
+    s = (summary or "").strip()
+    if not s:
+        return "neutral"
+    if s.startswith("ERR") or s.startswith("spawn_error"):
+        return "failure"
+    low = s.lower()
+    if any(tok in low for tok in _FAIL_TOKENS):
+        return "failure"
+    return "neutral"
+
+
+def _reason_from_summary(summary: str) -> str:
+    """Human, actionable reason from a failure summary."""
+    s = summary or ""
+    low = s.lower()
+    if "budget_exceeded" in low or "token_budget" in low or "cost_budget" in low:
+        return "subscription/credit budget exhausted"
+    if "binary_not_found" in low or "cli_not_found" in low:
+        return "CLI binary missing / not installed"
+    if "argument list too long" in low:
+        return "prompt too large"
+    idx = s.find("ERR")
+    tail = (s[idx:] if idx >= 0 else s).strip()
+    return (tail[:120] or "spawn failed")
+
+
+def _reason_from_task_log(task_id: str) -> str:
+    """Last meaningful line of a dead child's captured log (the failure reason)."""
+    try:
+        from .tools.spawn import task_logs  # lazy: spawn imports identity/config
+        txt = task_logs(task_id, tail_lines=12)
+    except Exception:
+        return "no_log"
+    lines = [ln for ln in txt.splitlines() if ln.strip()]
+    return (lines[-1][:180] if lines else "no_log")
+
+
+# ── watermark (dual cursor in one notify_pass row) ──────────────────────────
+
+def _read_watermark(conn: sqlite3.Connection) -> tuple[int, int]:
+    """Parse `ev=<events.id>;tk=<tasks.ended_at>` from the latest notify_pass
+    event. Returns (0, 0) when there is no prior pass."""
+    try:
+        row = conn.execute(
+            "SELECT target FROM events WHERE kind='notify_pass' "
+            "ORDER BY id DESC LIMIT 1"
+        ).fetchone()
+    except sqlite3.OperationalError:
+        return 0, 0
+    if not row or not row["target"]:
+        return 0, 0
+    ev = tk = 0
+    for part in str(row["target"]).split(";"):
+        k, _, v = part.partition("=")
+        try:
+            if k == "ev":
+                ev = int(v)
+            elif k == "tk":
+                tk = int(v)
+        except (ValueError, TypeError):
+            pass
+    return ev, tk
+
+
+def _has_prior_notify_pass(conn: sqlite3.Connection) -> bool:
+    try:
+        return conn.execute(
+            "SELECT 1 FROM events WHERE kind='notify_pass' LIMIT 1"
+        ).fetchone() is not None
+    except sqlite3.OperationalError:
+        return False
+
+
+def _max_event_id(conn: sqlite3.Connection) -> int:
+    try:
+        row = conn.execute("SELECT MAX(id) FROM events").fetchone()
+    except sqlite3.OperationalError:
+        return 0
+    return int(row[0]) if row and row[0] is not None else 0
+
+
+def _max_task_ended(conn: sqlite3.Connection) -> int:
+    try:
+        row = conn.execute("SELECT MAX(ended_at) FROM tasks").fetchone()
+    except sqlite3.OperationalError:
+        return 0
+    return int(row[0]) if row and row[0] is not None else 0
+
+
+def _record_notify_pass(conn: sqlite3.Connection, ev_id: int, tk_ended: int,
+                        outcome: str) -> None:
+    try:
+        conn.execute(
+            "INSERT INTO events (session_id, kind, target, summary, created_at) "
+            "VALUES (?, 'notify_pass', ?, ?, ?)",
+            (identity._session_id or "", f"ev={ev_id};tk={tk_ended}",
+             outcome[:300], int(time.time())),
+        )
+        conn.commit()
+    except sqlite3.OperationalError:
+        logger.debug("notify: failed to record pass", exc_info=True)
+
+
+# ── scans ───────────────────────────────────────────────────────────────────
+
+def _scan_failures(conn: sqlite3.Connection, ev_floor: int,
+                   ev_ceil: int) -> list[dict]:
+    """SOURCE 1: loop-pass failures in (ev_floor, ev_ceil]."""
+    out: list[dict] = []
+    ph = ",".join("?" for _ in _LOOP_PASS_KINDS)
+    try:
+        rows = conn.execute(
+            f"SELECT id, kind, summary FROM events "
+            f"WHERE id > ? AND id <= ? AND kind IN ({ph}) ORDER BY id",
+            (ev_floor, ev_ceil, *_LOOP_PASS_KINDS),
+        ).fetchall()
+    except sqlite3.OperationalError:
+        return out
+    for r in rows:
+        summary = r["summary"] or ""
+        # spawn_timeout_retry_failed is itself terminal; classify others.
+        if r["kind"] == "spawn_timeout_retry_failed" or \
+                classify_summary(summary) == "failure":
+            loop = r["kind"][:-5] if r["kind"].endswith("_pass") else r["kind"]
+            out.append({"kind": loop, "reason": _reason_from_summary(summary)})
+    return out
+
+
+def _scan_dead_children(conn: sqlite3.Connection, tk_floor: int,
+                        tk_ceil: int) -> list[dict]:
+    """SOURCE 2: spawned children that ended non-zero (excluding timeouts and
+    children superseded by a retry). Catches subscription-exhausted-mid-run."""
+    out: list[dict] = []
+    try:
+        rows = conn.execute(
+            "SELECT id, role, chosen_cli, return_code FROM tasks "
+            "WHERE ended_at IS NOT NULL AND ended_at > ? AND ended_at <= ? "
+            "AND return_code IS NOT NULL AND return_code != 0 AND return_code != ? "
+            "AND timeout_respawned_as IS NULL ORDER BY ended_at",
+            (tk_floor, tk_ceil, _SPAWN_TIMEOUT_RETURN_CODE),
+        ).fetchall()
+    except sqlite3.OperationalError:
+        return out
+    for r in rows:
+        label = r["role"] or r["chosen_cli"] or "child"
+        out.append({
+            "kind": f"child:{label}",
+            "label": label,
+            "rc": r["return_code"],
+            "reason": _reason_from_task_log(r["id"]),
+        })
+    return out
+
+
+def _scan_positive(conn: sqlite3.Connection, ev_floor: int, ev_ceil: int,
+                   kinds: tuple[str, ...]) -> list[dict]:
+    """SOURCE 3: positive materialization events in (ev_floor, ev_ceil]."""
+    out: list[dict] = []
+    ph = ",".join("?" for _ in kinds)
+    try:
+        rows = conn.execute(
+            f"SELECT id, kind, target, summary FROM events "
+            f"WHERE id > ? AND id <= ? AND kind IN ({ph}) ORDER BY id",
+            (ev_floor, ev_ceil, *kinds),
+        ).fetchall()
+    except sqlite3.OperationalError:
+        return out
+    for r in rows:
+        out.append({"kind": r["kind"], "target": r["target"] or "",
+                    "summary": r["summary"] or ""})
+    return out
+
+
+def _cooldown_ok(kind: str, now: float, conn: sqlite3.Connection) -> bool:
+    """One failure notification per loop-kind per NOTIFY_FAILURE_COOLDOWN_S,
+    de-duped cross-process via daemon_state (a lapsed subscription emits a
+    failure every tick — this suppresses the storm)."""
+    return daemon_state.claim_pass(
+        f"notify_fail_{kind}", NOTIFY_FAILURE_COOLDOWN_S,
+        scheduled=True, conn=conn, now=now,
+    )
+
+
+# ── channels ────────────────────────────────────────────────────────────────
+
+def _notify_log(title: str, body: str) -> None:
+    logger.warning("[notify] %s | %s", title, body)
+
+
+def _notify_macos(title: str, body: str) -> bool:
+    """Best-effort macOS banner (mirrors memory_guard._notify_user)."""
+    if os.uname().sysname != "Darwin":
+        return False
+    safe_title = title.replace("\\", "\\\\").replace('"', '\\"')
+    safe_body = body.replace("\\", "\\\\").replace('"', '\\"')
+    script = f'display notification "{safe_body}" with title "{safe_title}"'
+    try:
+        subprocess.run(
+            ["osascript", "-e", script],
+            stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, timeout=3,
+        )
+        return True
+    except (subprocess.SubprocessError, OSError):
+        logger.debug("notify: osascript failed", exc_info=True)
+        return False
+
+
+def _dispatch(title: str, body: str) -> None:
+    """Fan out to the configured channels (comma list: macos,log[,webhook])."""
+    channels = {c.strip().lower() for c in (NOTIFY_CHANNEL or "").split(",") if c.strip()}
+    if "log" in channels:
+        _notify_log(title, body)
+    if "macos" in channels:
+        _notify_macos(title, body)
+    # "webhook" — follow-up (urllib POST, see sync/daemon._post).
+
+
+def _fmt_failure(f: dict) -> tuple[str, str]:
+    return (f"Thread-keeper: {f['kind']} loop failed", f["reason"][:200])
+
+
+def _fmt_child(c: dict) -> tuple[str, str]:
+    return (f"Thread-keeper: {c['label']} child died (rc={c['rc']})",
+            c["reason"][:200])
+
+
+def _fmt_skill(s: dict) -> tuple[str, str]:
+    return ("Thread-keeper: skill materialized", (s["summary"] or s["target"])[:200])
+
+
+def _fmt_lesson(l: dict) -> tuple[str, str]:
+    return ("Thread-keeper: lesson added", f"{l['target']} ({l['summary']})"[:200])
+
+
+# ── pass + daemon lifecycle ─────────────────────────────────────────────────
+
+def run_notify_pass(force: bool = False, *, scheduled: bool = False) -> str:
+    """One notifier tick. Returns a short outcome string.
+
+    Reads new signals since the watermark, dispatches notifications for enabled
+    categories, advances the watermark. The dispatch (a non-idempotent side
+    effect) happens under single_flight_lock and strictly between the read and
+    the watermark write, so a SQLite lock-retry can never double-fire.
+    """
+    if NOTIFY_POLL_S <= 0 and not force:
+        return "disabled"
+    conn = get_db()
+    if not daemon_state.claim_pass("notify", NOTIFY_POLL_S,
+                                   scheduled=scheduled, conn=conn):
+        return "not_due"
+
+    ev_floor, tk_floor = _read_watermark(conn)
+    ev_ceil = _max_event_id(conn)
+    tk_ceil = _max_task_ended(conn)
+
+    # First run: seed to current position so historical backlog never fires.
+    if not _has_prior_notify_pass(conn):
+        _record_notify_pass(conn, ev_ceil, tk_ceil, "seed")
+        return "seed"
+
+    fails = _scan_failures(conn, ev_floor, ev_ceil) if NOTIFY_LOOP_FAILURE else []
+    children = _scan_dead_children(conn, tk_floor, tk_ceil) if NOTIFY_LOOP_FAILURE else []
+    skills = _scan_positive(conn, ev_floor, ev_ceil, _SKILL_KINDS) if NOTIFY_SKILL_MATERIALIZED else []
+    lessons = _scan_positive(conn, ev_floor, ev_ceil, _LESSON_KINDS) if NOTIFY_LESSON else []
+
+    fired = 0
+    with single_flight_lock("notify-daemon") as locked:
+        if not locked:
+            return "notify_child_running"
+        now = time.time()
+        for f in fails:
+            if _cooldown_ok(f["kind"], now, conn):
+                _dispatch(*_fmt_failure(f))
+                fired += 1
+        for c in children:
+            if _cooldown_ok(c["kind"], now, conn):
+                _dispatch(*_fmt_child(c))
+                fired += 1
+        for s in skills:
+            _dispatch(*_fmt_skill(s))
+            fired += 1
+        for l in lessons:
+            _dispatch(*_fmt_lesson(l))
+            fired += 1
+
+    # Advance to the ceilings we scanned (disabled categories are skipped, never
+    # replayed — matching the no-backlog principle).
+    _record_notify_pass(
+        conn, ev_ceil, tk_ceil,
+        f"fired={fired} fails={len(fails)} children={len(children)} "
+        f"skills={len(skills)} lessons={len(lessons)}",
+    )
+    return f"ok fired={fired}"
+
+
+def _serve_loop() -> None:
+    while True:
+        try:
+            run_notify_pass(scheduled=True)
+        except Exception:
+            logger.debug("notify_daemon tick failed", exc_info=True)
+        daemon_sleep(NOTIFY_POLL_S)
+
+
+def start_notify_daemon() -> None:
+    """Idempotent starter. No-op when NOTIFY_POLL_S<=0 (feature off by default)."""
+    global _started
+    if _started:
+        return
+    if NOTIFY_POLL_S <= 0:
+        return
+    from .config import BACKGROUND_DAEMONS_ALLOWED
+    if not BACKGROUND_DAEMONS_ALLOWED:
+        return
+    t = threading.Thread(target=_serve_loop, name="notify_daemon", daemon=True)
+    t.start()
+    _started = True


### PR DESCRIPTION
Implements #257.

Surfaces silent background-loop degradation — the worst failure mode for a memory system. When a loop can't bring up its model/CLI (subscription/credits exhausted, auth expired, binary missing, spawn timeout) or a spawned child dies mid-run, TK quietly stops learning; this daemon tells the user. Optionally notifies on skill/lesson materialization.

## Design

New `threadkeeper/notify.py` — a **read-only consumer of already-emitted signals** (no LLM spawn, no credit cost), mirroring `probe_daemon.py`. Three detection sources:

1. **Admission failures / terminal timeouts** — `<loop>_pass` events whose summary `classify_summary()` marks a failure (reusing the tokens from `shadow_review._classify_pass` / `agent_status._human_summary`), plus `spawn_timeout_retry_failed`.
2. **Dead children** — `tasks` rows that ended non-zero (excluding `124`=timeout and retry-superseded). This is the key case behind the reported scenario: `spawn()` returns `ok task=…` at **launch**, so the `*_pass` summary is a *false success* when a child later dies from quota; the real outcome only lands in `tasks.return_code`. The reason is taken from the child's log tail.
3. **Positive materialization** — `skill_materialized` / `skill_create` / `lesson_append`.

Other properties:
- **Coalescing** — a lapsed subscription emits a failure every tick; a per-loop cooldown via `daemon_state.claim_pass(f"notify_fail_{kind}", …)` collapses the storm into one actionable alert.
- **Dual watermark** (`events.id` + `tasks.ended_at`) stored in `events.kind='notify_pass'.target`; **first run seeds** to the current position so historical backlog never fires.
- **Side-effect ordering** — the (non-idempotent) dispatch runs under `single_flight_lock` strictly between the read and the watermark write, so a SQLite lock-retry can't double-fire.
- **node-local** — `events`/`tasks`/`daemon_state` are never synced, so each machine notifies about its own loops and keeps its own cooldown.
- **Channels** — macOS `osascript` (mirrors `memory_guard._notify_user`) and log. Webhook (for headless Linux / phone push) is a documented follow-up.

## Config (all off by default via `NOTIFY_POLL_S=0`)

| env | default | meaning |
|---|---|---|
| `THREADKEEPER_NOTIFY_POLL_S` | `0` | daemon tick; 0 = off (master gate) |
| `THREADKEEPER_NOTIFY_LOOP_FAILURE` | `true` | alert when a loop fails to run |
| `THREADKEEPER_NOTIFY_SKILL_MATERIALIZED` | `false` | alert on skill materialization |
| `THREADKEEPER_NOTIFY_LESSON` | `false` | alert on lesson append |
| `THREADKEEPER_NOTIFY_CHANNEL` | `macos,log` | comma list: macos, log |
| `THREADKEEPER_NOTIFY_FAILURE_COOLDOWN_S` | `3600` | min seconds between repeats of one loop's failure |

Registered in `host._DAEMON_STARTERS`.

## Tests

`tests/test_notify_daemon.py` — 22 tests: classifier fixtures (failure vs neutral), a failure `*_pass` fires one notification with the reason, a non-zero `tasks` row fires with the log-tail reason, timeout/zero-exit children ignored, cooldown de-dup, distinct loops both fire, first-run seed emits nothing on backlog, positive toggles gate, disabled returns `disabled`. Full suite green under `pytest --forked`.

## Follow-ups (noted in #257)

- **webhook channel** (aku/Linux + phone push) — small add using the `sync/daemon._post` urllib idiom.
- **richer post-spawn reason** — optionally have the spawn watchdog emit a `child_failed` event with `return_code` + log tail, so source 2 needn't scan `tasks` + read logs.
