### PR TITLE
feat(notify): deliver macOS banners via the menu-bar app + in-app settings (#257)

### DIFF
--- a/README.md
+++ b/README.md
@@ -968,13 +968,36 @@ THREADKEEPER_NOTIFY_POLL_S=30           # daemon tick (seconds); 0 = off
 THREADKEEPER_NOTIFY_LOOP_FAILURE=true   # alert when a loop fails to run (default on)
 THREADKEEPER_NOTIFY_SKILL_MATERIALIZED=false  # alert on skill materialization
 THREADKEEPER_NOTIFY_LESSON=false        # alert on lesson append
-THREADKEEPER_NOTIFY_CHANNEL=macos,log   # comma list: macos (osascript), log
+THREADKEEPER_NOTIFY_CHANNEL=macos,log   # comma list: macos (menu-bar app banner), log
 THREADKEEPER_NOTIFY_FAILURE_COOLDOWN_S=3600   # min seconds between repeats of one loop's failure
 ```
 
-Channels are macOS notifications (`osascript`) and a `[notify]` log line;
-`macos` self-noops off Darwin. A webhook channel (headless Linux / phone push)
-is a planned follow-up.
+Channels are macOS notifications and a `[notify]` log line; `macos` self-noops
+off Darwin. A webhook channel (headless Linux / phone push) is a planned
+follow-up.
+
+**macOS delivery — the menu-bar app.** On macOS, native banners are delivered by
+the `ThreadKeeperAgentStatus` menu-bar app, not the daemon's `osascript`. The app
+already polls `tk-agent-status` and posts de-duplicated notifications through
+`UNUserNotificationCenter` (the modern API — `osascript display notification` is
+silently suppressed unless it can borrow a signed host, so it is unreliable). It
+is ad-hoc code-signed at build time (`build.sh`), which macOS requires before it
+will register the app in **System Settings ▸ Notifications** and show banners;
+banners are titled **Thread-Keeper** (`CFBundleDisplayName`). The first launch
+after an update shows a one-time permission prompt.
+
+`agent_status` feeds the app two lists — `recent_results` (positive: captured
+skills/lessons) and `recent_failures` (the two failure sources above) — each item
+tagged with a `notify` flag computed from the toggles below. The app **lists**
+every item in its menu but only **posts a banner** for flagged ones, so turning a
+category off silences the banner without hiding the history. Enabling a toggle
+never replays backlog.
+
+**Settings in the app.** The menu-bar app's **Settings ▸ Notifications** tab
+edits these same `THREADKEEPER_NOTIFY_*` keys visually — switches for the
+on/off categories, a picker for the interval, channel, and cooldown — and writes
+them to `~/.threadkeeper/.env`. `NOTIFY_POLL_S` is the master switch: `0` (Off)
+disables all notifications, including the app's banners.
 
 ### Dialectic user model
 

--- a/apps/macos-agent-status/Info.plist
+++ b/apps/macos-agent-status/Info.plist
@@ -9,6 +9,8 @@
   <string>local.threadkeeper.agent-status</string>
   <key>CFBundleName</key>
   <string>ThreadKeeperAgentStatus</string>
+  <key>CFBundleDisplayName</key>
+  <string>Thread-Keeper</string>
   <key>CFBundlePackageType</key>
   <string>APPL</string>
   <key>CFBundleShortVersionString</key>

--- a/apps/macos-agent-status/ThreadKeeperAgentStatus.swift
+++ b/apps/macos-agent-status/ThreadKeeperAgentStatus.swift
@@ -12,6 +12,7 @@ struct AgentStatusSnapshot: Decodable {
     let readyLoopCount: Int
     let loops: [LoopStatus]
     let recentResults: [UsefulResult]
+    let recentFailures: [UsefulResult]?
     let agents: [AgentStatus]
 
     enum CodingKeys: String, CodingKey {
@@ -23,6 +24,7 @@ struct AgentStatusSnapshot: Decodable {
         case readyLoopCount = "ready_loop_count"
         case loops
         case recentResults = "recent_results"
+        case recentFailures = "recent_failures"
         case agents
     }
 }
@@ -90,6 +92,12 @@ struct UsefulResult: Decodable, Identifiable {
     let title: String
     let summary: String
     let age: String
+    // When false, the item is listed in the menu but no banner is posted — the
+    // per-category Notifications toggles gate delivery server-side. Absent in
+    // older payloads, where every result was notifiable.
+    let notify: Bool?
+
+    var shouldNotify: Bool { notify ?? true }
 
     enum CodingKeys: String, CodingKey {
         case id
@@ -98,6 +106,7 @@ struct UsefulResult: Decodable, Identifiable {
         case title
         case summary
         case age
+        case notify
     }
 }
 
@@ -121,6 +130,7 @@ enum EnvSettingsSection: String, CaseIterable, Identifiable {
     case learningAgents = "Learning Loop Agents"
     case automation = "System Automation"
     case memory = "Memory & Budgets"
+    case notifications = "Notifications"
     case advanced = "Advanced .env"
 
     var id: String { rawValue }
@@ -131,6 +141,7 @@ enum EnvSettingsSection: String, CaseIterable, Identifiable {
         case .learningAgents: return "brain.head.profile"
         case .automation: return "gearshape.2"
         case .memory: return "memorychip"
+        case .notifications: return "bell.badge"
         case .advanced: return "doc.text"
         }
     }
@@ -337,6 +348,30 @@ private let hourScheduleChoices = [
     ChoiceOption("259200", label: "72 h · 3 days"),
     ChoiceOption("604800", label: "168 h · 7 days"),
     ChoiceOption("2592000", label: "720 h · 30 days"),
+]
+
+private let notifyPollChoices = [
+    ChoiceOption("0", label: "Off"),
+    ChoiceOption("30", label: "30 s"),
+    ChoiceOption("60", label: "60 s"),
+    ChoiceOption("120", label: "2 min"),
+    ChoiceOption("300", label: "5 min"),
+]
+
+private let notifyChannelChoices = [
+    ChoiceOption("macos,log", label: "Banner + log"),
+    ChoiceOption("macos", label: "Banner only"),
+    ChoiceOption("log", label: "Log only"),
+]
+
+private let notifyCooldownChoices = [
+    ChoiceOption("0", label: "No cooldown"),
+    ChoiceOption("300", label: "5 min"),
+    ChoiceOption("900", label: "15 min"),
+    ChoiceOption("1800", label: "30 min"),
+    ChoiceOption("3600", label: "1 h"),
+    ChoiceOption("10800", label: "3 h"),
+    ChoiceOption("21600", label: "6 h"),
 ]
 
 private let scheduleDefaultValues: [String: String] = [
@@ -555,6 +590,54 @@ private let baseEnvSettingDefinitions: [EnvSettingDefinition] = [
         detail: "Number of MCP server processes to keep after reclaim.",
         defaultValue: "1",
         kind: .choice(serverCountChoices)
+    ),
+    EnvSettingDefinition(
+        group: "Notifications",
+        key: "THREADKEEPER_NOTIFY_POLL_S",
+        title: "Notifications",
+        detail: "Master switch. How often to check loop health; Off disables all notifications.",
+        defaultValue: "0",
+        kind: .choice(notifyPollChoices)
+    ),
+    EnvSettingDefinition(
+        group: "Notifications",
+        key: "THREADKEEPER_NOTIFY_CHANNEL",
+        title: "Delivery channel",
+        detail: "Native macOS banner, a log line, or both.",
+        defaultValue: "macos,log",
+        kind: .choice(notifyChannelChoices)
+    ),
+    EnvSettingDefinition(
+        group: "Notifications",
+        key: "THREADKEEPER_NOTIFY_FAILURE_COOLDOWN_S",
+        title: "Failure cooldown",
+        detail: "Minimum gap between repeats of one loop's failure, so a lapsed subscription is one alert, not a storm.",
+        defaultValue: "3600",
+        kind: .choice(notifyCooldownChoices)
+    ),
+    EnvSettingDefinition(
+        group: "Notifications",
+        key: "THREADKEEPER_NOTIFY_LOOP_FAILURE",
+        title: "Loop / spawn failure",
+        detail: "Alert when a background loop can't bring up its model/CLI (credits, auth, missing binary) or a child dies mid-run.",
+        defaultValue: "true",
+        kind: .toggle
+    ),
+    EnvSettingDefinition(
+        group: "Notifications",
+        key: "THREADKEEPER_NOTIFY_SKILL_MATERIALIZED",
+        title: "Skill materialized",
+        detail: "Alert when a skill is captured.",
+        defaultValue: "false",
+        kind: .toggle
+    ),
+    EnvSettingDefinition(
+        group: "Notifications",
+        key: "THREADKEEPER_NOTIFY_LESSON",
+        title: "Lesson added",
+        detail: "Alert when a lesson is appended.",
+        defaultValue: "false",
+        kind: .toggle
     ),
 ]
 struct EnvPresetSlot: Codable, Identifiable {
@@ -1522,6 +1605,7 @@ final class AgentStatusStore: ObservableObject {
         readyLoopCount: 0,
         loops: [],
         recentResults: [],
+        recentFailures: [],
         agents: []
     )
     @Published var lastError: String?
@@ -1578,7 +1662,9 @@ final class AgentStatusStore: ObservableObject {
                 self.isRefreshing = false
                 switch result {
                 case .success(let newSnapshot):
-                    self.handleUsefulResults(newSnapshot.recentResults)
+                    self.handleUsefulResults(
+                        newSnapshot.recentResults + (newSnapshot.recentFailures ?? [])
+                    )
                     self.snapshot = newSnapshot
                     self.lastError = nil
                     self.refreshThreadKeeperToggleState()
@@ -1691,7 +1777,11 @@ final class AgentStatusStore: ObservableObject {
 
         var changed = false
         for result in results.reversed() where !seenResultIds.contains(result.id) {
-            postNotification(for: result)
+            // Gate delivery on the per-category toggle, but always mark seen so
+            // enabling a toggle later never replays historical backlog.
+            if result.shouldNotify {
+                postNotification(for: result)
+            }
             seenResultIds.insert(result.id)
             changed = true
         }
@@ -2312,6 +2402,7 @@ struct EnvSettingsView: View {
         case .learningAgents: learningAgentsSection
         case .automation: automationSection
         case .memory: memorySection
+        case .notifications: notificationsSection
         case .advanced: advancedSection
         }
     }
@@ -2392,6 +2483,36 @@ struct EnvSettingsView: View {
                     title: "Memory and resource limits",
                     definitions: baseEnvSettingDefinitions.filter {
                         $0.group == "Memory And Budgets"
+                    },
+                    envStore: envStore
+                )
+            }
+        }
+    }
+
+    private var notificationsSection: some View {
+        SettingsScroll(
+            title: "Notifications",
+            subtitle: "Native macOS banners when a background loop can't run — or when a skill/lesson is captured. All off until you pick an interval."
+        ) {
+            LazyVGrid(columns: automationColumns, alignment: .leading, spacing: 14) {
+                EnvSettingSection(
+                    title: "Delivery",
+                    definitions: baseEnvSettingDefinitions.filter {
+                        $0.group == "Notifications"
+                            && ($0.key == "THREADKEEPER_NOTIFY_POLL_S"
+                                || $0.key == "THREADKEEPER_NOTIFY_CHANNEL"
+                                || $0.key == "THREADKEEPER_NOTIFY_FAILURE_COOLDOWN_S")
+                    },
+                    envStore: envStore
+                )
+                EnvSettingSection(
+                    title: "What to notify",
+                    definitions: baseEnvSettingDefinitions.filter {
+                        $0.group == "Notifications"
+                            && ($0.key == "THREADKEEPER_NOTIFY_LOOP_FAILURE"
+                                || $0.key == "THREADKEEPER_NOTIFY_SKILL_MATERIALIZED"
+                                || $0.key == "THREADKEEPER_NOTIFY_LESSON")
                     },
                     envStore: envStore
                 )

--- a/apps/macos-agent-status/build.sh
+++ b/apps/macos-agent-status/build.sh
@@ -21,7 +21,16 @@ swiftc \
   -target "$target" \
   -framework SwiftUI \
   -framework AppKit \
+  -framework UserNotifications \
   ThreadKeeperAgentStatus.swift \
   -o "$bin_dir/$app_name"
+
+# UNUserNotificationCenter only delivers from a bundle with a stable code
+# signature. Ad-hoc sign (no cert, no entitlements) is enough to give the app a
+# durable identity so macOS registers it in Notification settings and shows
+# banners. Without this, notification requests are silently dropped.
+if command -v codesign >/dev/null 2>&1; then
+  codesign --force --sign - "$app_dir" >/dev/null 2>&1 || true
+fi
 
 echo "$app_dir"

--- a/tests/test_agent_status.py
+++ b/tests/test_agent_status.py
@@ -640,3 +640,65 @@ def test_is_result_line_ignores_prompt_echo_lines(mp_with_cid):
     assert _is_result_line(
         "Materialized skill e2e-fresh-install-per-suite with a new section."
     )
+
+
+def _insert_failed_task(pkg, task_id, prompt, log_text, role="curator"):
+    conn = pkg["db"].get_db()
+    now = int(time.time())
+    conn.execute(
+        "INSERT INTO tasks (id, pid, parent_cid, spawned_cid, cwd, prompt, "
+        "started_at, ended_at, return_code, role, chosen_cli, rss_kb, "
+        "rss_updated_at) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)",
+        (
+            task_id, os.getpid(), _FAKE_CID, f"child-{task_id}", "/tmp",
+            prompt, now - 30, now - 5, 1, role, "claude", 0, now,
+        ),
+    )
+    pkg["config"].TASK_LOG_DIR.mkdir(parents=True, exist_ok=True)
+    (pkg["config"].TASK_LOG_DIR / f"{task_id}.log").write_text(log_text)
+    conn.commit()
+
+
+def test_recent_failures_surfaces_dead_child_with_reason(mp_with_cid, monkeypatch):
+    # A spawned child that died non-zero (subscription-exhausted-mid-run) must
+    # surface in recent_failures with the log-tail reason and notify=True when
+    # notifications are enabled (NOTIFY_POLL_S>0, NOTIFY_LOOP_FAILURE default on).
+    monkeypatch.setenv("THREADKEEPER_NOTIFY_POLL_S", "30")
+    pkg = mp_with_cid(_FAKE_CID)
+    _insert_failed_task(
+        pkg,
+        "deadchild",
+        "You are the CURATOR for thread-keeper.\n\nCurate memory.",
+        "starting run\nCredit balance is too low to run this model\n",
+    )
+    from threadkeeper.agent_status import agent_status_snapshot
+
+    snap = agent_status_snapshot(refresh=False)
+    fails = {f["task_id"]: f for f in snap["recent_failures"]}
+    assert "deadchild" in fails
+    item = fails["deadchild"]
+    assert item["kind"] == "failure"
+    assert item["notify"] is True
+    assert "credit" in item["summary"].lower()
+    # A live failure never leaks into the positive recent_results feed.
+    assert all(r["task_id"] != "deadchild" for r in snap["recent_results"])
+
+
+def test_recent_failures_notify_flag_off_when_toggle_disabled(
+    mp_with_cid, monkeypatch
+):
+    monkeypatch.setenv("THREADKEEPER_NOTIFY_POLL_S", "30")     # master gate on
+    monkeypatch.setenv("THREADKEEPER_NOTIFY_LOOP_FAILURE", "false")
+    pkg = mp_with_cid(_FAKE_CID)  # factory re-imports fresh → reads the env
+    _insert_failed_task(
+        pkg,
+        "deadchild2",
+        "You are the CURATOR for thread-keeper.\n\nCurate memory.",
+        "boom\nspawn_error token_budget_exceeded\n",
+    )
+    from threadkeeper.agent_status import agent_status_snapshot
+
+    snap = agent_status_snapshot(refresh=False)
+    fails = {f["task_id"]: f for f in snap["recent_failures"]}
+    assert "deadchild2" in fails                 # still listed in the menu
+    assert fails["deadchild2"]["notify"] is False  # but no banner posted

--- a/threadkeeper/agent_status.py
+++ b/threadkeeper/agent_status.py
@@ -712,6 +712,16 @@ def _extract_useful_result(task_id: str) -> str:
 
 
 def _recent_results(conn, now: int, limit: int = 10) -> list[dict[str, Any]]:
+    from . import config
+    # Positive materialization notifications (#257). These are captured skills /
+    # lessons surfaced as useful loop output; the app posts a banner only when
+    # notifications are enabled (NOTIFY_POLL_S master gate) and a positive toggle
+    # is on, but the menu always lists them (`notify` flag).
+    enabled = float(getattr(config, "NOTIFY_POLL_S", 0) or 0) > 0
+    positive_notify = enabled and bool(
+        getattr(config, "NOTIFY_SKILL_MATERIALIZED", False)
+        or getattr(config, "NOTIFY_LESSON", False)
+    )
     role_loop = _role_to_loop()
     rows = conn.execute(
         "SELECT id, prompt, ended_at, return_code FROM tasks "
@@ -742,10 +752,107 @@ def _recent_results(conn, now: int, limit: int = 10) -> list[dict[str, Any]]:
             "ended_at": ended_at,
             "age_s": age_s,
             "age": fmt_age(age_s),
+            "notify": positive_notify,
         })
         if len(results) >= limit:
             break
     return results
+
+
+def _recent_failures(conn, now: int, limit: int = 10) -> list[dict[str, Any]]:
+    """Loop/spawn failures for the menu-bar app's notification pipeline (#257).
+
+    Two sources, mirroring `notify.py`: dead children (a spawned child that
+    ended non-zero — the subscription-died-mid-run case that stays silent
+    otherwise) and loop admission failures (a `*_pass` whose summary classifies
+    as a failure). Each item carries a `notify` flag so the app posts a banner
+    only when `NOTIFY_LOOP_FAILURE` is on; the menu lists them regardless.
+    """
+    from . import config
+    from .notify import (
+        _LOOP_PASS_KINDS,
+        _reason_from_summary,
+        _reason_from_task_log,
+        classify_summary,
+    )
+    from .spawn_budget import SPAWN_TIMEOUT_RETURN_CODE
+
+    # Master gate (NOTIFY_POLL_S) AND the per-category toggle. The menu lists
+    # every failure; only flagged ones post a banner.
+    enabled = float(getattr(config, "NOTIFY_POLL_S", 0) or 0) > 0
+    notify_flag = enabled and bool(getattr(config, "NOTIFY_LOOP_FAILURE", True))
+    role_loop = _role_to_loop()
+    floor = now - _RESULT_WINDOW_S
+    results: list[dict[str, Any]] = []
+
+    # SOURCE 2 — dead children (the key case behind the reported scenario).
+    try:
+        rows = conn.execute(
+            "SELECT id, prompt, role, chosen_cli, return_code, ended_at "
+            "FROM tasks WHERE ended_at IS NOT NULL AND ended_at>=? "
+            "AND return_code IS NOT NULL AND return_code!=0 AND return_code!=? "
+            "AND timeout_respawned_as IS NULL ORDER BY ended_at DESC LIMIT ?",
+            (floor, SPAWN_TIMEOUT_RETURN_CODE, int(limit) * 2),
+        ).fetchall()
+    except Exception:
+        rows = []
+    for row in rows:
+        role = _detect_role(row["prompt"] or "")
+        loop = role_loop.get(role)
+        label = (
+            loop["name"] if loop
+            else (row["role"] or row["chosen_cli"] or "background agent")
+        )
+        ended_at = int(row["ended_at"] or now)
+        age_s = max(0, now - ended_at)
+        results.append({
+            "id": f"fail:{row['id']}:{ended_at}",
+            "task_id": row["id"],
+            "kind": "failure",
+            "loop_name": label,
+            "title": f"{label} failed (rc={row['return_code']})",
+            "summary": _reason_from_task_log(row["id"]),
+            "ended_at": ended_at,
+            "age_s": age_s,
+            "age": fmt_age(age_s),
+            "notify": notify_flag,
+        })
+
+    # SOURCE 1 — loop admission failures (spawn_error / budget / ERR summaries).
+    ph = ",".join("?" for _ in _LOOP_PASS_KINDS)
+    try:
+        erows = conn.execute(
+            f"SELECT id, kind, summary, created_at FROM events "
+            f"WHERE created_at>=? AND kind IN ({ph}) "
+            f"ORDER BY created_at DESC LIMIT ?",
+            (floor, *_LOOP_PASS_KINDS, int(limit) * 3),
+        ).fetchall()
+    except Exception:
+        erows = []
+    for row in erows:
+        summary = row["summary"] or ""
+        if row["kind"] != "spawn_timeout_retry_failed" \
+                and classify_summary(summary) != "failure":
+            continue
+        loop_kind = row["kind"][:-5] if row["kind"].endswith("_pass") else row["kind"]
+        label = loop_kind.replace("_", " ")
+        created = int(row["created_at"] or now)
+        age_s = max(0, now - created)
+        results.append({
+            "id": f"failev:{row['id']}",
+            "task_id": "",
+            "kind": "failure",
+            "loop_name": label,
+            "title": f"{label} could not run",
+            "summary": _reason_from_summary(summary),
+            "ended_at": created,
+            "age_s": age_s,
+            "age": fmt_age(age_s),
+            "notify": notify_flag,
+        })
+
+    results.sort(key=lambda r: r["ended_at"], reverse=True)
+    return results[:limit]
 
 
 def _timed_out_count(conn, now: int) -> int:
@@ -883,6 +990,7 @@ def agent_status_snapshot(refresh: bool = True, limit: int = 50) -> dict[str, An
         "loops": loops,
         "github_budget": github_budget,
         "recent_results": _recent_results(conn, now),
+        "recent_failures": _recent_failures(conn, now),
         "timed_out_count": _timed_out_count(conn, now),
         "agents": agents,
     }

--- a/threadkeeper/assets/macos-agent-status/Info.plist
+++ b/threadkeeper/assets/macos-agent-status/Info.plist
@@ -9,6 +9,8 @@
   <string>local.threadkeeper.agent-status</string>
   <key>CFBundleName</key>
   <string>ThreadKeeperAgentStatus</string>
+  <key>CFBundleDisplayName</key>
+  <string>Thread-Keeper</string>
   <key>CFBundlePackageType</key>
   <string>APPL</string>
   <key>CFBundleShortVersionString</key>

--- a/threadkeeper/assets/macos-agent-status/ThreadKeeperAgentStatus.swift
+++ b/threadkeeper/assets/macos-agent-status/ThreadKeeperAgentStatus.swift
@@ -12,6 +12,7 @@ struct AgentStatusSnapshot: Decodable {
     let readyLoopCount: Int
     let loops: [LoopStatus]
     let recentResults: [UsefulResult]
+    let recentFailures: [UsefulResult]?
     let agents: [AgentStatus]
 
     enum CodingKeys: String, CodingKey {
@@ -23,6 +24,7 @@ struct AgentStatusSnapshot: Decodable {
         case readyLoopCount = "ready_loop_count"
         case loops
         case recentResults = "recent_results"
+        case recentFailures = "recent_failures"
         case agents
     }
 }
@@ -90,6 +92,12 @@ struct UsefulResult: Decodable, Identifiable {
     let title: String
     let summary: String
     let age: String
+    // When false, the item is listed in the menu but no banner is posted — the
+    // per-category Notifications toggles gate delivery server-side. Absent in
+    // older payloads, where every result was notifiable.
+    let notify: Bool?
+
+    var shouldNotify: Bool { notify ?? true }
 
     enum CodingKeys: String, CodingKey {
         case id
@@ -98,6 +106,7 @@ struct UsefulResult: Decodable, Identifiable {
         case title
         case summary
         case age
+        case notify
     }
 }
 
@@ -121,6 +130,7 @@ enum EnvSettingsSection: String, CaseIterable, Identifiable {
     case learningAgents = "Learning Loop Agents"
     case automation = "System Automation"
     case memory = "Memory & Budgets"
+    case notifications = "Notifications"
     case advanced = "Advanced .env"
 
     var id: String { rawValue }
@@ -131,6 +141,7 @@ enum EnvSettingsSection: String, CaseIterable, Identifiable {
         case .learningAgents: return "brain.head.profile"
         case .automation: return "gearshape.2"
         case .memory: return "memorychip"
+        case .notifications: return "bell.badge"
         case .advanced: return "doc.text"
         }
     }
@@ -337,6 +348,30 @@ private let hourScheduleChoices = [
     ChoiceOption("259200", label: "72 h · 3 days"),
     ChoiceOption("604800", label: "168 h · 7 days"),
     ChoiceOption("2592000", label: "720 h · 30 days"),
+]
+
+private let notifyPollChoices = [
+    ChoiceOption("0", label: "Off"),
+    ChoiceOption("30", label: "30 s"),
+    ChoiceOption("60", label: "60 s"),
+    ChoiceOption("120", label: "2 min"),
+    ChoiceOption("300", label: "5 min"),
+]
+
+private let notifyChannelChoices = [
+    ChoiceOption("macos,log", label: "Banner + log"),
+    ChoiceOption("macos", label: "Banner only"),
+    ChoiceOption("log", label: "Log only"),
+]
+
+private let notifyCooldownChoices = [
+    ChoiceOption("0", label: "No cooldown"),
+    ChoiceOption("300", label: "5 min"),
+    ChoiceOption("900", label: "15 min"),
+    ChoiceOption("1800", label: "30 min"),
+    ChoiceOption("3600", label: "1 h"),
+    ChoiceOption("10800", label: "3 h"),
+    ChoiceOption("21600", label: "6 h"),
 ]
 
 private let scheduleDefaultValues: [String: String] = [
@@ -555,6 +590,54 @@ private let baseEnvSettingDefinitions: [EnvSettingDefinition] = [
         detail: "Number of MCP server processes to keep after reclaim.",
         defaultValue: "1",
         kind: .choice(serverCountChoices)
+    ),
+    EnvSettingDefinition(
+        group: "Notifications",
+        key: "THREADKEEPER_NOTIFY_POLL_S",
+        title: "Notifications",
+        detail: "Master switch. How often to check loop health; Off disables all notifications.",
+        defaultValue: "0",
+        kind: .choice(notifyPollChoices)
+    ),
+    EnvSettingDefinition(
+        group: "Notifications",
+        key: "THREADKEEPER_NOTIFY_CHANNEL",
+        title: "Delivery channel",
+        detail: "Native macOS banner, a log line, or both.",
+        defaultValue: "macos,log",
+        kind: .choice(notifyChannelChoices)
+    ),
+    EnvSettingDefinition(
+        group: "Notifications",
+        key: "THREADKEEPER_NOTIFY_FAILURE_COOLDOWN_S",
+        title: "Failure cooldown",
+        detail: "Minimum gap between repeats of one loop's failure, so a lapsed subscription is one alert, not a storm.",
+        defaultValue: "3600",
+        kind: .choice(notifyCooldownChoices)
+    ),
+    EnvSettingDefinition(
+        group: "Notifications",
+        key: "THREADKEEPER_NOTIFY_LOOP_FAILURE",
+        title: "Loop / spawn failure",
+        detail: "Alert when a background loop can't bring up its model/CLI (credits, auth, missing binary) or a child dies mid-run.",
+        defaultValue: "true",
+        kind: .toggle
+    ),
+    EnvSettingDefinition(
+        group: "Notifications",
+        key: "THREADKEEPER_NOTIFY_SKILL_MATERIALIZED",
+        title: "Skill materialized",
+        detail: "Alert when a skill is captured.",
+        defaultValue: "false",
+        kind: .toggle
+    ),
+    EnvSettingDefinition(
+        group: "Notifications",
+        key: "THREADKEEPER_NOTIFY_LESSON",
+        title: "Lesson added",
+        detail: "Alert when a lesson is appended.",
+        defaultValue: "false",
+        kind: .toggle
     ),
 ]
 struct EnvPresetSlot: Codable, Identifiable {
@@ -1522,6 +1605,7 @@ final class AgentStatusStore: ObservableObject {
         readyLoopCount: 0,
         loops: [],
         recentResults: [],
+        recentFailures: [],
         agents: []
     )
     @Published var lastError: String?
@@ -1578,7 +1662,9 @@ final class AgentStatusStore: ObservableObject {
                 self.isRefreshing = false
                 switch result {
                 case .success(let newSnapshot):
-                    self.handleUsefulResults(newSnapshot.recentResults)
+                    self.handleUsefulResults(
+                        newSnapshot.recentResults + (newSnapshot.recentFailures ?? [])
+                    )
                     self.snapshot = newSnapshot
                     self.lastError = nil
                     self.refreshThreadKeeperToggleState()
@@ -1691,7 +1777,11 @@ final class AgentStatusStore: ObservableObject {
 
         var changed = false
         for result in results.reversed() where !seenResultIds.contains(result.id) {
-            postNotification(for: result)
+            // Gate delivery on the per-category toggle, but always mark seen so
+            // enabling a toggle later never replays historical backlog.
+            if result.shouldNotify {
+                postNotification(for: result)
+            }
             seenResultIds.insert(result.id)
             changed = true
         }
@@ -2312,6 +2402,7 @@ struct EnvSettingsView: View {
         case .learningAgents: learningAgentsSection
         case .automation: automationSection
         case .memory: memorySection
+        case .notifications: notificationsSection
         case .advanced: advancedSection
         }
     }
@@ -2392,6 +2483,36 @@ struct EnvSettingsView: View {
                     title: "Memory and resource limits",
                     definitions: baseEnvSettingDefinitions.filter {
                         $0.group == "Memory And Budgets"
+                    },
+                    envStore: envStore
+                )
+            }
+        }
+    }
+
+    private var notificationsSection: some View {
+        SettingsScroll(
+            title: "Notifications",
+            subtitle: "Native macOS banners when a background loop can't run — or when a skill/lesson is captured. All off until you pick an interval."
+        ) {
+            LazyVGrid(columns: automationColumns, alignment: .leading, spacing: 14) {
+                EnvSettingSection(
+                    title: "Delivery",
+                    definitions: baseEnvSettingDefinitions.filter {
+                        $0.group == "Notifications"
+                            && ($0.key == "THREADKEEPER_NOTIFY_POLL_S"
+                                || $0.key == "THREADKEEPER_NOTIFY_CHANNEL"
+                                || $0.key == "THREADKEEPER_NOTIFY_FAILURE_COOLDOWN_S")
+                    },
+                    envStore: envStore
+                )
+                EnvSettingSection(
+                    title: "What to notify",
+                    definitions: baseEnvSettingDefinitions.filter {
+                        $0.group == "Notifications"
+                            && ($0.key == "THREADKEEPER_NOTIFY_LOOP_FAILURE"
+                                || $0.key == "THREADKEEPER_NOTIFY_SKILL_MATERIALIZED"
+                                || $0.key == "THREADKEEPER_NOTIFY_LESSON")
                     },
                     envStore: envStore
                 )

--- a/threadkeeper/assets/macos-agent-status/build.sh
+++ b/threadkeeper/assets/macos-agent-status/build.sh
@@ -21,7 +21,16 @@ swiftc \
   -target "$target" \
   -framework SwiftUI \
   -framework AppKit \
+  -framework UserNotifications \
   ThreadKeeperAgentStatus.swift \
   -o "$bin_dir/$app_name"
+
+# UNUserNotificationCenter only delivers from a bundle with a stable code
+# signature. Ad-hoc sign (no cert, no entitlements) is enough to give the app a
+# durable identity so macOS registers it in Notification settings and shows
+# banners. Without this, notification requests are silently dropped.
+if command -v codesign >/dev/null 2>&1; then
+  codesign --force --sign - "$app_dir" >/dev/null 2>&1 || true
+fi
 
 echo "$app_dir"


### PR DESCRIPTION
Follow-up to #258 (issue #257). Makes macOS notifications actually deliver, and brings the toggles into the menu-bar app UI.

## Why

The `notify` daemon's `osascript` channel is **silently suppressed** on macOS — `osascript display notification` only shows a banner when it can borrow a signed host identity (Script Editor), which isn't reliably present, so background-loop failures never surfaced. Meanwhile the `ThreadKeeperAgentStatus` menu-bar app **already** posts de-duplicated notifications via `UNUserNotificationCenter` (the modern, supported API) — it just wasn't code-signed, so macOS dropped its requests too, and it only knew about positive results.

So: route macOS delivery through the app, sign it, and feed it failures.

## What

**Delivery (Swift + build)**
- `build.sh` ad-hoc code-signs the bundle (`codesign --force --sign -`) + links `UserNotifications` explicitly. `UNUserNotificationCenter` only delivers from a bundle with a stable signature; without it, requests are dropped and the app never appears in **System Settings ▸ Notifications**.
- `Info.plist` sets `CFBundleDisplayName = Thread-Keeper`, so banners are titled **Thread-Keeper** instead of the raw bundle name.
- The app decodes a new `recent_failures` list, funnels it through the existing prime/de-dup pipeline, and posts a banner **only** when the item's `notify` flag is set (it still lists every item in the menu). First-run priming is unchanged, so enabling a toggle never replays backlog.

**Feed (`agent_status`)**
- New `_recent_failures()` with the two failure sources from #258, reusing `notify.py`'s `classify_summary` / `_reason_from_summary` / `_reason_from_task_log` (dead children + admission failures). Both feeds now carry a `notify` flag = `NOTIFY_POLL_S > 0` (master switch) **and** the per-category toggle (`NOTIFY_LOOP_FAILURE` for failures; `NOTIFY_SKILL_MATERIALIZED` / `NOTIFY_LESSON` for positives).

**Settings UI**
- A **Notifications** tab in the app's `.env` editor: switches for the on/off categories, pickers for interval / channel / cooldown. Writes the same `THREADKEEPER_NOTIFY_*` keys to `~/.threadkeeper/.env` through the existing store.

## Behavior change

The menu-bar app previously posted a banner for **every** new useful loop result. It now respects the per-category toggles: **failures on by default**, **skill/lesson materialization off by default** (enable under Settings ▸ Notifications). While a server on `main` (no `notify` flag in the payload) is paired with this app, the flag reads as absent → `shouldNotify = true`, so the old always-post behavior is preserved until both sides ship. Defaults are easy to flip if you'd rather positives stay on.

## Tests

`tests/test_agent_status.py` — a dead child surfaces in `recent_failures` with its log-tail reason and `notify=true` when enabled; the `NOTIFY_LOOP_FAILURE=false` toggle keeps it listed but drops the flag. Full `test_agent_status` + `test_notify_daemon` + `test_config_*` suites green.

## Follow-ups

- webhook channel (headless Linux / phone push) — still the documented next step.
