### PR TITLE
fix: preserve discovered skill creation timestamps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,14 @@ version bumps follow semver per the policy in
   pidfile younger than the threshold is treated as a booting host and left
   alone. Recovery emits `host_wedged_sigterm`/`host_wedged_sigkill` events.
 
+### Fixed
+
+- **Skill watcher preserves discovered-skill age.** New `skill_usage` rows now
+  use a filesystem birth timestamp when available rather than an external
+  edit's mtime; filesystems without birth-time support fall back to mtime
+  capped at discovery time. `last_patched_at` continues to record the edit
+  signal used by the watcher.
+
 ## v0.16.3 — 2026-07-19
 
 ### Changed

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -240,9 +240,14 @@ Steady-state access is split by intent:
    pruning is owned by the retention daemon, not by read tools.
 
 5. **skill_usage** — telemetry for mirrored Skill.md entries. Fields:
-   `last_used_at`, `last_viewed_at`, `last_patched_at`, counters, `state`
+   `created_at`, `last_used_at`, `last_viewed_at`, `last_patched_at`, counters, `state`
    (active/stale/archived), `pinned`, `created_by_origin` (foreground vs
-   background_review vs shadow_review). This is the input for the curator.
+   background_review vs shadow_review). Agent-created skills set `created_at`
+   directly through `skill_manage`; for skills first found by `skill_watcher`,
+   it is the filesystem `st_birthtime` when available (macOS/Windows), falling
+   back to `min(mtime, scan time)` on filesystems without a birth timestamp.
+   `last_patched_at` remains the external-edit mtime. This is the input for the
+   curator.
 
 6. **lesson_usage** — telemetry for `lessons.md` slugs. `lesson_list` bumps
    `view_count`, `lesson_get` bumps `use_count`, and the curator uses
@@ -343,7 +348,9 @@ All daemon threads are cheap (ticks 0.5–30 s), no-op when env-knobs disable th
   Parent-alive retirement is opt-in via `MEMORY_GUARD_RETIRE_LIVE`.
 - **skill_watcher** — once per `SKILL_WATCH_INTERVAL_S` (default 5 s) walks
   the primary `~/.claude/skills/*/SKILL.md` root and bumps `last_patched_at`
-  if the file was changed outside `skill_manage`.
+  if the file was changed outside `skill_manage`. When first backfilling a
+  row, it uses the file birth time where available, otherwise the mtime capped
+  at scan time, so creation age and patch activity stay distinct.
 - **skill_updater** — once per `SKILL_UPDATE_INTERVAL_S` (default 302400 s,
   twice weekly) runs single-flight across live MCP servers, imports the newest
   local installed skill copy from any configured CLI root into the primary

--- a/tests/test_skill_watcher.py
+++ b/tests/test_skill_watcher.py
@@ -11,6 +11,7 @@ import os
 import sys
 import time
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -88,6 +89,35 @@ def test_scan_once_creates_row_for_new_skill(tmp_path, monkeypatch):
     assert row["created_by_origin"] == "foreground"
     assert row["last_patched_at"] == int(md.stat().st_mtime)
     assert row["patch_count"] == 1
+
+
+def test_scan_once_uses_birthtime_for_new_skill(tmp_path, monkeypatch):
+    """New rows keep the file's birth time even after a much later edit."""
+    pkg = _bootstrap(tmp_path, monkeypatch)
+    md = _write_skill(pkg["skills_root"], "old-but-edited")
+    birthtime = getattr(md.stat(), "st_birthtime", None)
+    if birthtime is None or birthtime <= 0:
+        pytest.skip("filesystem does not expose a birth timestamp")
+    old_birthtime = int(birthtime)
+    edited_at = old_birthtime + 90 * 86400
+    os.utime(md, (edited_at, edited_at))
+
+    conn = pkg["db"].get_db()
+    assert pkg["skill_watcher"]._scan_once(conn) == 1
+    row = conn.execute(
+        "SELECT created_at, last_patched_at FROM skill_usage "
+        "WHERE name='old-but-edited'"
+    ).fetchone()
+
+    assert row["created_at"] == old_birthtime
+    assert row["last_patched_at"] == edited_at
+
+
+def test_created_at_falls_back_to_mtime_capped_at_scan_time(tmp_path, monkeypatch):
+    pkg = _bootstrap(tmp_path, monkeypatch)
+    stat_result = SimpleNamespace(st_mtime=500, st_birthtime=None)
+
+    assert pkg["skill_watcher"]._created_at(stat_result, now=100) == 100
 
 
 def test_scan_once_bumps_when_mtime_advances(tmp_path, monkeypatch):

--- a/threadkeeper/skill_watcher.py
+++ b/threadkeeper/skill_watcher.py
@@ -2,6 +2,10 @@
 changes and updates skill_usage telemetry. Catches patches made via
 external editors / direct Edit/Write tool calls that bypass skill_manage.
 
+For a newly discovered skill, preserve the filesystem birth timestamp when
+available; otherwise use its mtime, capped at the scan time. This keeps the
+row's creation age distinct from its external-edit signal.
+
 Tick interval is configurable; default 10s. Daemon thread, started lazily
 on first _ensure_session() call so import-time side effects stay
 minimal. Reads only — never writes to SKILL.md.
@@ -11,6 +15,7 @@ from __future__ import annotations
 import logging
 import os
 import threading
+import time
 from typing import Optional
 
 from .config import BACKGROUND_DAEMONS_ALLOWED, CLAUDE_SKILLS_DIR
@@ -22,6 +27,14 @@ logger = logging.getLogger(__name__)
 _started = False
 _tick_interval_s = float(os.environ.get(
     'THREADKEEPER_SKILL_WATCH_INTERVAL_S', '10'))
+
+
+def _created_at(stat_result: os.stat_result, now: int) -> int:
+    """Return the best available creation timestamp for a discovered skill."""
+    birthtime = getattr(stat_result, "st_birthtime", None)
+    if birthtime is not None and birthtime > 0:
+        return int(birthtime)
+    return min(int(stat_result.st_mtime), now)
 
 
 def _scan_once(conn) -> int:
@@ -41,16 +54,18 @@ def _scan_once(conn) -> int:
         if not md.exists():
             continue
         try:
-            mtime = int(md.stat().st_mtime)
+            stat_result = md.stat()
         except OSError:
             continue
+        mtime = int(stat_result.st_mtime)
+        created_at = _created_at(stat_result, int(time.time()))
         name = skill_dir.name
         # Ensure row exists; insert with foreground origin if not present
         # (this is a user-edited skill, not agent-created).
         conn.execute(
             "INSERT INTO skill_usage (name, created_at, created_by_origin) "
             "VALUES (?, ?, 'foreground') ON CONFLICT(name) DO NOTHING",
-            (name, mtime),
+            (name, created_at),
         )
         row = conn.execute(
             "SELECT last_patched_at FROM skill_usage WHERE name=?",


### PR DESCRIPTION
## Summary
- seed new externally discovered skill telemetry from filesystem birth time when available
- retain mtime as the separate external-patch signal and cap fallback creation times at discovery
- document timestamp provenance and cover birthtime/fallback behavior

## Validation
- env -u THREADKEEPER_NO_EMBEDDINGS -u THREADKEEPER_ROLE .venv/bin/python -m pytest -q

Closes #109