### PR TITLE
fix: pin Glama Dockerfile package release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,10 +7,10 @@ FROM python:3.12-slim
 
 WORKDIR /app
 
-# Install threadkeeper from PyPI. Skip the [semantic] extra (~700 MB
-# fastembed ONNX model) — Glama only inspects the MCP tool schema, not
+# Install the release this checkout declares. Skip the [semantic] extra (~700
+# MB fastembed ONNX model) — Glama only inspects the MCP tool schema, not
 # embedding quality.
-RUN pip install --no-cache-dir threadkeeper
+RUN pip install --no-cache-dir threadkeeper==0.16.3
 
 # Don't spawn shadow-review / curator / probe / dialectic daemons in
 # the Glama sandbox — they would try to invoke claude / codex / agy

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -80,13 +80,16 @@ on GitHub.
 # 1. Bump version in pyproject.toml on a normal PR branch
 $EDITOR pyproject.toml         # version = "0.4.0" → "0.4.1"
 
-# 2. Bump both server.json version fields to the same value
+# 2. Bump the Dockerfile Glama-eval pin to the same version
+$EDITOR Dockerfile              # threadkeeper==0.4.0 → threadkeeper==0.4.1
+
+# 3. Bump both server.json version fields to the same value
 $EDITOR server.json
 
-# 3. Add a matching CHANGELOG section: ## v0.4.1 — YYYY-MM-DD
+# 4. Add a matching CHANGELOG section: ## v0.4.1 — YYYY-MM-DD
 $EDITOR CHANGELOG.md
 
-# 4. Commit, open a PR, and merge it to main after tests pass
+# 5. Commit, open a PR, and merge it to main after tests pass
 git commit -am "release: 0.4.1"
 ```
 

--- a/tests/test_release_workflows.py
+++ b/tests/test_release_workflows.py
@@ -1,10 +1,12 @@
 from pathlib import Path
+import tomllib
 
 import yaml
 
 
 ROOT = Path(__file__).resolve().parents[1]
 WORKFLOWS = ROOT / ".github" / "workflows"
+DOCKERFILE = ROOT / "Dockerfile"
 
 BOT_TAGGER_EMAIL = "41898282+github-actions[bot]@users.noreply.github.com"
 
@@ -85,3 +87,10 @@ def test_releasing_docs_describe_the_approval_flow():
     assert "The output must include a `required_reviewers` rule" in docs
     # The manual signed-tag path stays documented as backfill/override.
     assert "git tag -s" in docs
+    assert "Dockerfile Glama-eval pin" in docs
+
+
+def test_glama_dockerfile_pin_matches_the_project_release():
+    version = tomllib.loads((ROOT / "pyproject.toml").read_text())["project"]["version"]
+
+    assert f"threadkeeper=={version}" in DOCKERFILE.read_text()


### PR DESCRIPTION
## Summary
- pin the Dockerfile's Glama-evaluation install to the declared project release
- document the required release-time Dockerfile pin bump
- prevent future version drift with a focused release workflow test

## Validation
- env -u THREADKEEPER_NO_EMBEDDINGS .venv/bin/python -m pytest -q (five unrelated host-wedge failures under inherited worker-role markers)
- clean-environment full suite exited 0 after unsetting inherited role markers

Closes #110