### PR TITLE
feat: supervise daemon thread liveness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ version bumps follow semver per the policy in
 [CONTRIBUTING.md → Releases](CONTRIBUTING.md#releases).
 
 ## [Unreleased]
+- **Added: daemon-thread liveness supervision (#114).** Evented daemon
+  starters now retain and re-check their named `Thread` instead of letting a
+  stale `_started` flag make an exited loop unrestartable. The daemon host's
+  opt-out supervisor (`THREADKEEPER_DAEMON_SUPERVISOR_INTERVAL_S=30`) restarts
+  enabled dead threads, records compact `daemon_health` state for thin
+  servers, and emits `daemon_restarted` recovery events. `agent_status`,
+  `mp_health`, and `mp_dashboard` now show `thread_alive`, last successful-pass
+  age, and `ok` / `stale` / `dead` / `disabled`; repeated single-flight
+  `*_running` ticks no longer count as successful completion. Set
+  `THREADKEEPER_DAEMON_STALE_INTERVALS` (default 3) to tune stale reporting.
 - **Fixed: wedged-but-alive daemon-host is now recovered (#223).** A host
   whose heartbeat loop wedged while the process stayed up kept holding the
   election flock, so every replacement spawn exited 0 and the machine

--- a/README.md
+++ b/README.md
@@ -1090,6 +1090,8 @@ The most-used env knobs (full list in `threadkeeper/config.py`):
 | `THREADKEEPER_SKILL_UPDATE_ALLOW_UNTRACKED_OVERWRITE` | false | allow overwriting inferred untracked local skill copies; default false only adopts exact matches |
 | `THREADKEEPER_CONFIG_WATCH_INTERVAL_S` | 2 | hot-config reload: poll the universal `~/.threadkeeper/.env` (every host) + the host CLI's env-block file and re-apply changed env knobs in-process (no CLI restart); 0 disables |
 | `THREADKEEPER_CONFIG_WATCH_PATH` | "" | escape hatch: pin ONE settings file to watch (single-file mode); when unset, hybrid mode watches `.env` + the CLI file resolved via host identity |
+| `THREADKEEPER_DAEMON_SUPERVISOR_INTERVAL_S` | 30 | daemon-host watchdog cadence; it records thread liveness and restarts an enabled loop whose thread exited. Set `0` to disable restart supervision while retaining status reporting |
+| `THREADKEEPER_DAEMON_STALE_INTERVALS` | 3 | number of configured loop intervals without a completed pass before a live daemon is reported as `stale`; this never kills a running child |
 | `THREADKEEPER_SHADOW_REVIEW_INTERVAL_S` | 0 (off) | shadow daemon tick (s) |
 | `THREADKEEPER_SHADOW_REVIEW_WINDOW_S` | 900 | sliding window for shadow scan (s) |
 | `THREADKEEPER_EXTRACT_INTERVAL_S` | 0 (off) | extract daemon tick (s); 600 = 10 min recommended; if this exceeds the base window, the daemon extends from the previous successful `extract_pass` cursor so ticks do not leave gaps |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -309,6 +309,22 @@ read via `identity._session_id` attr-access, pinned by the test
 `identity._ensure_session()` brings up background threads on first call.
 All daemon threads are cheap (ticks 0.5–30 s), no-op when env-knobs disable them:
 
+**Thread liveness and supervision.** Every evented daemon is registered with
+its thread name, interval knob, and lazy starter. The starter keeps the live
+`Thread` object rather than trusting its historical `_started` latch, so a
+thread that exits can be started again. The daemon host's lightweight
+supervisor (`THREADKEEPER_DAEMON_SUPERVISOR_INTERVAL_S`, default 30 s; `0`
+disables it) persists one mutable `daemon_health` row per loop and emits a
+`daemon_restarted` event when it revives one. This avoids a heartbeat event
+stream while allowing thin MCP servers to report host-owned thread state.
+
+`agent_status` JSON, `mp_health()`, and `mp_dashboard()` expose each loop's
+`thread_alive`, latest successful-pass age, and `ok` / `stale` / `dead` /
+`disabled` verdict. A repeated `*_running` single-flight tick is not treated
+as pass success, so an alive loop that never completes a pass becomes `stale`
+after `THREADKEEPER_DAEMON_STALE_INTERVALS` (default 3) intervals. Stale is
+observability only: the supervisor restarts dead threads, never a live child.
+
 - **background_ingester** (`ingest._start_background_ingester`) — ticks every
   `INGEST_INTERVAL_S` (default 3 s), reads fresh jsonl chunks, tops up
   dialog_messages/_fts and backfills NULL-embeddings on notes.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -595,6 +595,14 @@ the three bare-`time.sleep` loops onto it), pruning `_last_notify_at` of
 past-cooldown / dead-pid entries each `_maybe_notify`, and collapsing
 consecutive no-op janitor passes into a single recorded row. Scope: S.
 
+**Daemon-thread liveness and supervision (done, #114).** Enabled evented
+loops now retain their `Thread` objects instead of relying on an irreversible
+`_started` latch; the host supervisor observes and restarts an exited thread,
+records a compact per-loop health row, and emits `daemon_restarted` for an
+auditable recovery. `agent_status`, `mp_health`, and `mp_dashboard` distinguish
+`disabled`, `dead`, `stale`, and `ok`; a succession of `*_running`
+single-flight records does not hide a missing completed pass. Scope: M.
+
 **Daemon robustness under load.** ✅ PARTIAL (#24/#53/#105). Curator
 single-flight has landed, #53 unified the fcntl single-flight helper across the
 spawning daemon family, and #105 bounds Curator inventory prompts plus the

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -945,9 +945,10 @@ Complements decay scoring (#27) and write-time dedup (#34). Scope: S–M.
 A follow-up audit surfaced a handful of concrete gaps that are now tracked as
 GitHub issues:
 
-- **Lesson consultation telemetry.** Lessons have no per-entry
-  read/consultation counts, so decay and prune logic cannot tell \"never read\"
-  from \"recently consulted\" (#160).
+- **Lesson consultation telemetry.** ✅ DONE (#160). `lesson_list` now
+  records views and `lesson_get` records full-body consultations in
+  `lesson_usage`; the curator inventory and stale-lesson decay score use those
+  counters and timestamps rather than registration age alone.
 - **Surgical lesson patching.** Add a `lesson_patch` primitive and a same-slug
   shadow edit path that can fix long lessons without re-transcribing them from
   scratch (#161).

--- a/tests/test_daemon_liveness.py
+++ b/tests/test_daemon_liveness.py
@@ -9,6 +9,29 @@ def _loop(snapshot, loop_id: str):
     return {row["id"]: row for row in snapshot["loops"]}[loop_id]
 
 
+def test_daemon_health_is_additive_without_schema_version_bump(mp_with_cid):
+    pkg = mp_with_cid("33334444-5555-6666-7777-888899990000")
+    db = pkg["db"]
+    conn = db.get_db()
+    conn.execute("DROP TABLE daemon_health")
+    conn.execute("PRAGMA user_version = 4")
+    conn.commit()
+    conn.close()
+
+    db._BOOTSTRAPPED = False
+    db.bootstrap_db()
+
+    conn = db.get_db()
+    try:
+        assert conn.execute("PRAGMA user_version").fetchone()[0] == 4
+        assert conn.execute(
+            "SELECT 1 FROM sqlite_master "
+            "WHERE type='table' AND name='daemon_health'"
+        ).fetchone()
+    finally:
+        conn.close()
+
+
 def test_enabled_missing_thread_reports_dead(mp_with_cid):
     pkg = mp_with_cid("33334444-5555-6666-7777-888899990000")
     pkg["config"].EXTRACT_INTERVAL_S = 10

--- a/tests/test_daemon_liveness.py
+++ b/tests/test_daemon_liveness.py
@@ -1,0 +1,103 @@
+"""Daemon-thread liveness, stale-pass, and restart coverage (#114)."""
+from __future__ import annotations
+
+import threading
+import time
+
+
+def _loop(snapshot, loop_id: str):
+    return {row["id"]: row for row in snapshot["loops"]}[loop_id]
+
+
+def test_enabled_missing_thread_reports_dead(mp_with_cid):
+    pkg = mp_with_cid("33334444-5555-6666-7777-888899990000")
+    pkg["config"].EXTRACT_INTERVAL_S = 10
+
+    from threadkeeper.agent_status import agent_status_snapshot
+
+    loop = _loop(agent_status_snapshot(refresh=False), "extract")
+    assert loop["enabled"] is True
+    assert loop["thread_alive"] is False
+    assert loop["verdict"] == "dead"
+
+
+def test_disabled_daemon_is_disabled_not_dead(mp_with_cid):
+    pkg = mp_with_cid("33334444-5555-6666-7777-888899990000")
+    pkg["config"].EXTRACT_INTERVAL_S = 0
+
+    from threadkeeper.agent_status import agent_status_snapshot
+
+    loop = _loop(agent_status_snapshot(refresh=False), "extract")
+    assert loop["thread_alive"] is False
+    assert loop["verdict"] == "disabled"
+
+
+def test_running_single_flight_past_grace_reports_stale(mp_with_cid, monkeypatch):
+    pkg = mp_with_cid("33334444-5555-6666-7777-888899990000")
+    pkg["config"].EXTRACT_INTERVAL_S = 10
+    now = int(time.time())
+    conn = pkg["db"].get_db()
+    conn.execute(
+        "INSERT INTO events (session_id, kind, target, summary, created_at) "
+        "VALUES ('s', 'extract_pass', '', 'extract_running n=1', ?)",
+        (now - 1,),
+    )
+    conn.commit()
+
+    import threadkeeper.agent_status as status
+
+    monkeypatch.setattr(
+        status,
+        "daemon_thread_status",
+        lambda name: {"thread_alive": True, "thread_started_at": now - 31},
+    )
+    loop = _loop(status.agent_status_snapshot(refresh=False), "extract")
+    assert loop["thread_alive"] is True
+    assert loop["last_success_age_s"] >= 31
+    assert loop["verdict"] == "stale"
+
+
+def test_supervisor_restarts_dead_thread_and_clears_stale(mp_with_cid, monkeypatch):
+    pkg = mp_with_cid("33334444-5555-6666-7777-888899990000")
+    cfg = pkg["config"]
+    cfg.EXTRACT_INTERVAL_S = 10
+    cfg.BACKGROUND_DAEMONS_ALLOWED = True
+    cfg.SEMANTIC_AVAILABLE = True
+    now = int(time.time())
+    conn = pkg["db"].get_db()
+    conn.execute(
+        "INSERT INTO events (session_id, kind, target, summary, created_at) "
+        "VALUES ('s', 'extract_pass', '', 'completed', ?)",
+        (now - 100,),
+    )
+    conn.commit()
+
+    import threadkeeper.agent_status as status
+    import threadkeeper.daemon_liveness as liveness
+    import threadkeeper.daemon_supervisor as supervisor
+    import threadkeeper.extract_daemon as extract
+
+    extract._started = True  # reproduces the old permanent-latch failure mode
+    monkeypatch.setattr(
+        status,
+        "daemon_thread_status",
+        lambda name: {"thread_alive": True, "thread_started_at": now - 100},
+    )
+    assert _loop(status.agent_status_snapshot(refresh=False), "extract")["verdict"] == "stale"
+
+    stop = threading.Event()
+    monkeypatch.setattr(extract, "_serve_loop", stop.wait)
+    monkeypatch.setattr(status, "daemon_thread_status", liveness.daemon_thread_status)
+    result = supervisor.supervise_once(now=now)
+    try:
+        loop = _loop(status.agent_status_snapshot(refresh=False), "extract")
+        assert result["restarted"] >= 1
+        assert loop["thread_alive"] is True
+        assert loop["verdict"] == "ok"
+        assert extract._started is True
+    finally:
+        stop.set()
+        thread = liveness.daemon_thread("extract_daemon")
+        if thread is not None:
+            thread.join(timeout=1)
+        extract._started = False

--- a/tests/test_db_runtime.py
+++ b/tests/test_db_runtime.py
@@ -25,6 +25,26 @@ def test_get_db_reuses_process_bootstrap(fresh_mp, monkeypatch):
         second.close()
 
 
+def test_managed_evolve_checkout_cannot_open_colocated_db(
+    fresh_mp, monkeypatch, tmp_path
+):
+    db = fresh_mp["db"]
+    state_dir = tmp_path / "guarded-state"
+    managed_root = state_dir / "evolve-repo"
+    monkeypatch.setattr(db, "DB_PATH", state_dir / "db.sqlite")
+    monkeypatch.setattr(
+        db,
+        "__file__",
+        str(managed_root / "threadkeeper" / "db.py"),
+    )
+    db._BOOTSTRAPPED = False
+
+    with pytest.raises(RuntimeError, match="managed evolve checkout"):
+        db.bootstrap_db()
+
+    assert not db.DB_PATH.exists()
+
+
 def test_read_db_is_query_only_and_closes(fresh_mp):
     db = fresh_mp["db"]
     with db.read_db() as conn:

--- a/tests/test_embedding_storage_dedup.py
+++ b/tests/test_embedding_storage_dedup.py
@@ -58,7 +58,9 @@ def test_v3_migration_replaces_catch_all_dialog_trigger(fresh_mp):
         "AND name='dialog_fts_au'"
     ).fetchone()[0]
     assert "AFTER UPDATE OF content" in ddl
-    assert migrated.execute("PRAGMA user_version").fetchone()[0] == 4
+    assert migrated.execute("PRAGMA user_version").fetchone()[0] == (
+        db.CURRENT_SCHEMA_VERSION
+    )
     migrated.close()
 
 

--- a/tests/test_host_wedged.py
+++ b/tests/test_host_wedged.py
@@ -16,6 +16,7 @@ import sys, importlib, threading, time
 def _reimport(monkeypatch, tmp_path):
     for k, v in {"THREADKEEPER_DB": str(tmp_path / "db.sqlite"),
                  "THREADKEEPER_DAEMON_HOST": "1",
+                 "THREADKEEPER_ROLE": "server",
                  "THREADKEEPER_DISABLE_BG_DAEMONS": "1"}.items():
         monkeypatch.setenv(k, v)
     for name in [m for m in list(sys.modules) if m.startswith("threadkeeper")]:

--- a/threadkeeper/agent_status.py
+++ b/threadkeeper/agent_status.py
@@ -19,6 +19,7 @@ from .db import get_db
 from .github_budget import format_github_budget, github_budget_state
 from .helpers import alive, fmt_age
 from .agent_metadata import role_metadata
+from .daemon_liveness import daemon_thread_status
 
 
 _ROLE_HINTS: tuple[tuple[re.Pattern[str], str], ...] = (
@@ -257,6 +258,41 @@ _LOOP_DEFS: tuple[dict[str, Any], ...] = (
     },
 )
 
+# This is the daemon registry as well as the status-loop registry.  Imports
+# remain lazy in the supervisor so merely rendering status never imports every
+# daemon module (or starts a background loop as a side effect).
+_DAEMON_BINDINGS: dict[str, tuple[str, str, str]] = {
+    "ingest": ("thread-keeper-live-ingest", "ingest", "_start_background_ingester"),
+    "retention": ("retention", "retention", "start_retention_daemon"),
+    "shadow_review": ("shadow_review", "shadow_review", "start_shadow_daemon"),
+    "extract": ("extract_daemon", "extract_daemon", "start_extract_daemon"),
+    "candidate_reviewer": (
+        "candidate_reviewer", "candidate_reviewer", "start_candidate_reviewer_daemon",
+    ),
+    "curator": ("curator", "curator", "start_curator_daemon"),
+    "dialectic_miner": (
+        "dialectic_miner", "dialectic_miner", "start_dialectic_miner_daemon",
+    ),
+    "dialectic_validator": (
+        "dialectic_validator", "dialectic_validator", "start_dialectic_validator_daemon",
+    ),
+    "evolve_review": ("evolve_daemon", "evolve_daemon", "start_evolve_daemon"),
+    "evolve_apply": (
+        "evolve_applier_daemon", "evolve_applier", "start_evolve_applier_daemon",
+    ),
+    "probe": ("probe_daemon", "probe_daemon", "start_probe_daemon"),
+    "thread_janitor": ("thread_janitor", "thread_janitor", "start_thread_janitor"),
+    "auto_update": ("auto_update_daemon", "auto_update", "start_auto_update_daemon"),
+    "skill_update": ("skill_update_daemon", "skill_updater", "start_skill_update_daemon"),
+}
+for _loop_def in _LOOP_DEFS:
+    _thread_name, _module_name, _start_name = _DAEMON_BINDINGS[_loop_def["id"]]
+    _loop_def.update(
+        thread_name=_thread_name,
+        starter_module=_module_name,
+        starter_name=_start_name,
+    )
+
 _RESULT_WINDOW_S = 3600
 _RESULT_SUMMARY_LIMIT = 240
 _ISSUE_BACKLOG_CACHE: dict[str, int] = {"at": 0, "count": 0}
@@ -475,6 +511,104 @@ def _last_event(conn, kind: str | tuple[str, ...], now: int) -> dict[str, Any]:
     }
 
 
+def _last_successful_pass(conn, kind: str | tuple[str, ...], now: int) -> dict[str, Any]:
+    """Latest completed pass, ignoring repeated single-flight ``*_running`` ticks.
+
+    The loop still records those ticks for diagnostics, but they only prove
+    that the scheduler woke up — not that the enabled loop completed work.
+    """
+    kinds = (kind,) if isinstance(kind, str) else tuple(k for k in kind if k)
+    if not kinds:
+        kinds = ("",)
+    placeholders = ",".join("?" for _ in kinds)
+    try:
+        row = conn.execute(
+            f"SELECT summary, created_at FROM events WHERE kind IN ({placeholders}) "
+            "AND lower(COALESCE(summary, '')) NOT LIKE '%_running%' "
+            "AND lower(COALESCE(summary, '')) NOT LIKE '%single-flight lock%' "
+            "ORDER BY created_at DESC, id DESC LIMIT 1",
+            kinds,
+        ).fetchone()
+    except Exception:
+        row = None
+    if not row:
+        return {"summary": "", "at": None, "age_s": None, "age": "never"}
+    age_s = max(0, now - int(row["created_at"] or now))
+    return {
+        "summary": row["summary"] or "",
+        "at": row["created_at"],
+        "age_s": age_s,
+        "age": fmt_age(age_s),
+    }
+
+
+def _daemon_health(
+    conn, loop: dict[str, Any], interval_s: float, now: int
+) -> dict[str, Any]:
+    """Return local-or-host daemon liveness plus a non-destructive verdict."""
+    enabled = interval_s > 0
+    from . import config
+
+    local = daemon_thread_status(loop["thread_name"])
+    observed_at = None
+    # Thin servers cannot enumerate the daemon host's threads.  Prefer a fresh
+    # host observation when no local live thread exists.
+    if (
+        not local["thread_alive"]
+        and config.DAEMON_HOST_ENABLED
+        and config.PROCESS_ROLE == "server"
+    ):
+        try:
+            row = conn.execute(
+                "SELECT thread_alive, thread_started_at, observed_at "
+                "FROM daemon_health WHERE name=?",
+                (loop["id"],),
+            ).fetchone()
+        except Exception:
+            row = None
+        if row:
+            local = {
+                "thread_alive": bool(row["thread_alive"]),
+                "thread_started_at": row["thread_started_at"],
+            }
+            observed_at = row["observed_at"]
+            max_age = max(2.0, float(config.DAEMON_SUPERVISOR_INTERVAL_S or 0) * 2)
+            if now - int(observed_at or 0) > max_age:
+                local["thread_alive"] = False
+
+    successful = _last_successful_pass(
+        conn, loop.get("result_events", loop["event"]), now
+    )
+    started_at = local["thread_started_at"]
+    success_at = successful["at"]
+    if success_at is not None and started_at is not None and success_at < started_at:
+        success_at = None  # a restart gets a full stale grace window
+    if success_at is None and started_at is not None:
+        success_age_s: int | None = max(0, now - int(started_at))
+    elif success_at is None:
+        success_age_s = None
+    else:
+        success_age_s = max(0, now - int(success_at))
+
+    if not enabled:
+        verdict = "disabled"
+    elif not local["thread_alive"]:
+        verdict = "dead"
+    else:
+        intervals = max(1, int(getattr(config, "DAEMON_STALE_INTERVALS", 3) or 3))
+        stale_after_s = max(1.0, interval_s) * intervals
+        verdict = "stale" if success_age_s is not None and success_age_s > stale_after_s else "ok"
+    return {
+        "thread_alive": bool(local["thread_alive"]),
+        "thread_started_at": started_at,
+        "thread_observed_at": observed_at,
+        "last_success_at": successful["at"],
+        "last_success_age_s": success_age_s,
+        "last_success_age": fmt_age(success_age_s) if success_age_s is not None else "never",
+        "verdict": verdict,
+    }
+
+
 def _human_summary(summary: str, fallback: str) -> str:
     s = (summary or "").strip()
     if not s:
@@ -541,6 +675,7 @@ def _loop_status(
     ready_backlog_min = int(loop.get("ready_backlog_min", 0) or 0)
     backlog = _backlog_count(conn, loop, now)
     last = _last_event(conn, loop.get("result_events", loop["event"]), now)
+    health = _daemon_health(conn, loop, interval_s, now)
     running = agents_by_role.get(loop.get("role", ""), [])
     rss_mb = sum(a["rss_mb"] for a in running)
     due = False
@@ -594,6 +729,7 @@ def _loop_status(
         "running_agent_count": len(running),
         "rss_mb": rss_mb,
         "rss_kb": rss_mb * 1024,
+        **health,
     }
 
 
@@ -614,6 +750,31 @@ def _loop_statuses(conn, agents: list[dict[str, Any]], now: int) -> list[dict[st
     for row in loops:
         row.pop("_order", None)
     return loops
+
+
+def daemon_liveness_statuses(conn=None, now: int | None = None) -> list[dict[str, Any]]:
+    """Read-only daemon-thread liveness rows for status tools and dashboards."""
+    own_conn = conn is None
+    if conn is None:
+        conn = get_db()
+    at = int(time.time() if now is None else now)
+    try:
+        from . import config
+
+        rows = []
+        for loop in _LOOP_DEFS:
+            interval_s = float(getattr(config, loop["interval"], 0) or 0)
+            rows.append({
+                "id": loop["id"],
+                "name": loop["name"],
+                "enabled": interval_s > 0,
+                "interval_s": interval_s,
+                **_daemon_health(conn, loop, interval_s, at),
+            })
+        return rows
+    finally:
+        if own_conn:
+            conn.close()
 
 
 def _role_to_loop() -> dict[str, dict[str, str]]:
@@ -1012,7 +1173,10 @@ def format_agent_status(snapshot: dict[str, Any]) -> str:
             backlog = f" backlog={loop['backlog_count']} {loop['backlog_label']}"
         lines.append(
             f"  {loop['name']} status={loop['status']} "
-            f"last={loop['last_age']} rss={loop['rss_mb']}MB{backlog} "
+            f"verdict={loop.get('verdict', 'unknown')} "
+            f"thread_alive={loop.get('thread_alive', False)} "
+            f"last={loop['last_age']} success={loop.get('last_success_age', 'never')} "
+            f"rss={loop['rss_mb']}MB{backlog} "
             f"desc={json.dumps(loop.get('description', ''), ensure_ascii=False)} "
             f"work={json.dumps(loop['work'], ensure_ascii=False)}"
         )

--- a/threadkeeper/auto_update.py
+++ b/threadkeeper/auto_update.py
@@ -629,14 +629,12 @@ def _serve_loop() -> None:
 def start_auto_update_daemon() -> None:
     """Start the once-per-day auto-update daemon in foreground MCP parents."""
     global _started
-    if _started:
+    from .daemon_liveness import daemon_thread_alive, start_daemon_thread
+    if _started and daemon_thread_alive("auto_update_daemon"):
         return
     if AUTO_UPDATE_INTERVAL_S <= 0:
         return
     if not BACKGROUND_DAEMONS_ALLOWED:
         return
-    t = threading.Thread(
-        target=_serve_loop, name="auto_update_daemon", daemon=True,
-    )
-    t.start()
+    start_daemon_thread("auto_update_daemon", _serve_loop)
     _started = True

--- a/threadkeeper/candidate_reviewer.py
+++ b/threadkeeper/candidate_reviewer.py
@@ -429,7 +429,8 @@ def start_candidate_reviewer_daemon() -> None:
     """Idempotent daemon starter. Uses the same spawned/background child
     cascade prevention as shadow_review / curator / extract."""
     global _started
-    if _started:
+    from .daemon_liveness import daemon_thread_alive, start_daemon_thread
+    if _started and daemon_thread_alive("candidate_reviewer"):
         return
     if CANDIDATE_REVIEW_INTERVAL_S <= 0:
         return
@@ -438,8 +439,5 @@ def start_candidate_reviewer_daemon() -> None:
         return
     if not SEMANTIC_AVAILABLE:
         return
-    t = threading.Thread(
-        target=_serve_loop, name="candidate_reviewer", daemon=True,
-    )
-    t.start()
+    start_daemon_thread("candidate_reviewer", _serve_loop)
     _started = True

--- a/threadkeeper/config.py
+++ b/threadkeeper/config.py
@@ -171,6 +171,15 @@ class Settings(BaseSettings):
     # (~/.claude/settings.json). Tests point this at a tmp file.
     config_watch_path: str = ""
 
+    # ── Daemon thread supervision ──────────────────────────────────────────
+    # The host checks enabled loop threads on this cadence and restarts a
+    # thread that exited.  0 leaves reporting available but disables restart.
+    daemon_supervisor_interval_s: float = 30.0
+    # A live thread that has not completed a non-"*_running" pass for this
+    # many configured intervals is reported as stale.  This is observability,
+    # not a kill/restart threshold: a legitimately long child remains intact.
+    daemon_stale_intervals: int = 3
+
     # ── Ingest ───────────────────────────────────────────────────────────────
     # env: THREADKEEPER_INGEST_CAP (not INGEST_CAP_PER_CALL)
     ingest_cap: int = Field(
@@ -739,6 +748,8 @@ def _derive_constants(s: "Settings") -> dict:
         ),
         "CONFIG_WATCH_INTERVAL_S": s.config_watch_interval_s,
         "CONFIG_WATCH_PATH": s.config_watch_path,
+        "DAEMON_SUPERVISOR_INTERVAL_S": s.daemon_supervisor_interval_s,
+        "DAEMON_STALE_INTERVALS": s.daemon_stale_intervals,
         "CLAUDE_SKILLS_DIR": s.claude_skills_dir,
         "CLAUDE_PROJECTS_DIR": s.claude_projects_dir,
         "TASK_LOG_DIR": s.task_log_dir,

--- a/threadkeeper/curator.py
+++ b/threadkeeper/curator.py
@@ -1287,7 +1287,8 @@ def start_curator_daemon() -> None:
     start_shadow_daemon: spawned/background children refuse to start
     the daemon so spawn() doesn't recurse."""
     global _started
-    if _started:
+    from .daemon_liveness import daemon_thread_alive, start_daemon_thread
+    if _started and daemon_thread_alive("curator"):
         return
     if CURATOR_INTERVAL_S <= 0:
         return
@@ -1296,8 +1297,5 @@ def start_curator_daemon() -> None:
         return
     if not SEMANTIC_AVAILABLE:
         return  # slim child: don't fire curator from here
-    t = threading.Thread(
-        target=_serve_loop, name="curator", daemon=True,
-    )
-    t.start()
+    start_daemon_thread("curator", _serve_loop)
     _started = True

--- a/threadkeeper/daemon_liveness.py
+++ b/threadkeeper/daemon_liveness.py
@@ -1,0 +1,67 @@
+"""Local thread tracking shared by long-lived daemon starters.
+
+The daemon host is a process, so ``threading.enumerate()`` is the only source
+of truth for a thread's current liveness.  Keeping the latest ``Thread``
+object as well gives a starter a reliable way to replace a thread that exited
+after its old module-level ``_started`` latch was set.
+"""
+from __future__ import annotations
+
+import threading
+import time
+from dataclasses import dataclass
+from typing import Callable
+
+
+@dataclass
+class _TrackedThread:
+    thread: threading.Thread
+    started_at: int
+
+
+_threads: dict[str, _TrackedThread] = {}
+_lock = threading.RLock()
+
+
+def daemon_thread(name: str) -> threading.Thread | None:
+    """Return the current named daemon thread, if it exists in this process."""
+    with _lock:
+        tracked = _threads.get(name)
+        if tracked is not None:
+            return tracked.thread
+    for thread in threading.enumerate():
+        if thread.name == name:
+            return thread
+    return None
+
+
+def daemon_thread_status(name: str) -> dict[str, int | bool | None]:
+    """Small serializable liveness snapshot for one named daemon thread."""
+    thread = daemon_thread(name)
+    with _lock:
+        tracked = _threads.get(name)
+        started_at = tracked.started_at if tracked is not None else None
+    return {
+        "thread_alive": bool(thread and thread.is_alive()),
+        "thread_started_at": started_at,
+    }
+
+
+def daemon_thread_alive(name: str) -> bool:
+    return bool(daemon_thread_status(name)["thread_alive"])
+
+
+def start_daemon_thread(name: str, target: Callable[[], None]) -> threading.Thread:
+    """Return a live daemon thread for ``name``, creating one when needed.
+
+    This is deliberately idempotent.  A dead tracked thread is replaced even
+    when its owning module's legacy ``_started`` flag remains true.
+    """
+    with _lock:
+        current = daemon_thread(name)
+        if current is not None and current.is_alive():
+            return current
+        thread = threading.Thread(target=target, name=name, daemon=True)
+        _threads[name] = _TrackedThread(thread=thread, started_at=int(time.time()))
+        thread.start()
+        return thread

--- a/threadkeeper/daemon_supervisor.py
+++ b/threadkeeper/daemon_supervisor.py
@@ -1,0 +1,100 @@
+"""Watch enabled daemon threads and restart ones that exited.
+
+Only this lightweight loop performs restarts.  It writes one mutable
+``daemon_health`` row per daemon for cross-process status and emits an event
+only when it actually restarts a thread, keeping normal telemetry quiet.
+"""
+from __future__ import annotations
+
+import importlib
+import logging
+import time
+
+from . import config
+from .daemon_liveness import daemon_thread_alive, daemon_thread_status, start_daemon_thread
+from .helpers import daemon_sleep
+
+logger = logging.getLogger(__name__)
+_started = False
+
+
+def supervise_once(now: int | None = None) -> dict[str, int]:
+    """Persist liveness for registered daemons and revive dead enabled ones."""
+    from .agent_status import _LOOP_DEFS
+    from .db import get_db
+
+    at = int(time.time() if now is None else now)
+    restarted = 0
+    observed = 0
+    conn = get_db()
+    try:
+        for loop in _LOOP_DEFS:
+            interval_s = float(getattr(config, loop["interval"], 0) or 0)
+            enabled = interval_s > 0
+            before = daemon_thread_status(loop["thread_name"])
+            after = before
+            if enabled and not before["thread_alive"]:
+                try:
+                    module = importlib.import_module(
+                        f"threadkeeper.{loop['starter_module']}"
+                    )
+                    getattr(module, loop["starter_name"])()
+                    after = daemon_thread_status(loop["thread_name"])
+                except Exception:
+                    logger.warning(
+                        "daemon supervisor could not restart %s", loop["id"],
+                        exc_info=True,
+                    )
+                if after["thread_alive"]:
+                    restarted += 1
+                    conn.execute(
+                        "INSERT INTO events (session_id, kind, target, summary, created_at) "
+                        "VALUES (?, 'daemon_restarted', ?, ?, ?)",
+                        (
+                            "daemon-supervisor",
+                            loop["id"],
+                            f"thread={loop['thread_name']}",
+                            at,
+                        ),
+                    )
+            conn.execute(
+                "INSERT INTO daemon_health "
+                "(name, thread_alive, thread_started_at, observed_at) "
+                "VALUES (?, ?, ?, ?) ON CONFLICT(name) DO UPDATE SET "
+                "thread_alive=excluded.thread_alive, "
+                "thread_started_at=excluded.thread_started_at, "
+                "observed_at=excluded.observed_at",
+                (
+                    loop["id"],
+                    int(bool(after["thread_alive"])),
+                    after["thread_started_at"],
+                    at,
+                ),
+            )
+            observed += 1
+        conn.commit()
+    finally:
+        conn.close()
+    return {"observed": observed, "restarted": restarted}
+
+
+def _serve_loop() -> None:
+    while True:
+        try:
+            supervise_once()
+        except Exception:
+            logger.debug("daemon supervisor tick failed", exc_info=True)
+        daemon_sleep(config.DAEMON_SUPERVISOR_INTERVAL_S)
+
+
+def start_daemon_supervisor() -> None:
+    """Start the opt-out daemon-thread watchdog in a foreground host."""
+    global _started
+    if _started and daemon_thread_alive("daemon_supervisor"):
+        return
+    if config.DAEMON_SUPERVISOR_INTERVAL_S <= 0:
+        return
+    if not config.BACKGROUND_DAEMONS_ALLOWED:
+        return
+    start_daemon_thread("daemon_supervisor", _serve_loop)
+    _started = True

--- a/threadkeeper/db.py
+++ b/threadkeeper/db.py
@@ -34,7 +34,7 @@ __all__ = [
     "SCHEMA",
 ]
 
-CURRENT_SCHEMA_VERSION = 4
+CURRENT_SCHEMA_VERSION = 5
 
 # sqlite-vec extension state. We probe once at first get_db() call and
 # cache the verdict. _VEC_AVAILABLE = True means vec0 virtual tables work
@@ -502,6 +502,16 @@ CREATE TABLE IF NOT EXISTS daemon_state (
     last_run_at INTEGER NOT NULL
 );
 
+-- Current in-process daemon-thread observations, written by the daemon host.
+-- One row per daemon avoids turning the events log into a 30-second heartbeat
+-- stream while allowing thin MCP servers to report host-owned thread state.
+CREATE TABLE IF NOT EXISTS daemon_health (
+    name              TEXT PRIMARY KEY,
+    thread_alive      INTEGER NOT NULL,
+    thread_started_at INTEGER,
+    observed_at       INTEGER NOT NULL
+);
+
 -- Shared GitHub API rate-limit/cooldown ledger. Roadmap automation uses this
 -- across foreground status processes, reviewer/applier daemons, and spawned
 -- gh-wrapper children so one account-level throttle stops all workers.
@@ -871,7 +881,7 @@ def _rebuild_dialog_fts_if_needed(conn: sqlite3.Connection) -> None:
 
 
 def _run_schema_migrations(conn: sqlite3.Connection, from_version: int) -> None:
-    if from_version not in (0, 1, 2, 3):
+    if from_version not in (0, 1, 2, 3, 4):
         raise RuntimeError(
             f"unsupported SQLite schema version {from_version}; "
             f"expected 0..{CURRENT_SCHEMA_VERSION}"

--- a/threadkeeper/db.py
+++ b/threadkeeper/db.py
@@ -9,6 +9,7 @@ import random
 import sqlite3
 import threading
 import time
+from pathlib import Path
 from typing import TypeVar
 
 from .config import CURATOR_REPORTS_DIR, DB_PATH, EMBED_DIM, _ENV_FILE
@@ -34,7 +35,7 @@ __all__ = [
     "SCHEMA",
 ]
 
-CURRENT_SCHEMA_VERSION = 5
+CURRENT_SCHEMA_VERSION = 4
 
 # sqlite-vec extension state. We probe once at first get_db() call and
 # cache the verdict. _VEC_AVAILABLE = True means vec0 virtual tables work
@@ -645,6 +646,21 @@ CREATE TRIGGER IF NOT EXISTS notes_fts_au AFTER UPDATE OF content ON notes BEGIN
 END;
 """
 
+# Optional additive tables that are safe for older builds to ignore.
+#
+# These are materialized during bootstrap even when user_version is already
+# current.  That lets a feature branch add isolated telemetry without claiming
+# an incompatible global schema version and breaking still-running clients.
+# Keep this block strictly backward-compatible: CREATE ... IF NOT EXISTS only.
+ADDITIVE_RUNTIME_SCHEMA = """
+CREATE TABLE IF NOT EXISTS daemon_health (
+    name              TEXT PRIMARY KEY,
+    thread_alive      INTEGER NOT NULL,
+    thread_started_at INTEGER,
+    observed_at       INTEGER NOT NULL
+);
+"""
+
 # Historical column migrations layered on top of the baseline SCHEMA.
 # Some columns are already present in new-table definitions; duplicate column
 # errors are the only expected no-op.
@@ -881,7 +897,7 @@ def _rebuild_dialog_fts_if_needed(conn: sqlite3.Connection) -> None:
 
 
 def _run_schema_migrations(conn: sqlite3.Connection, from_version: int) -> None:
-    if from_version not in (0, 1, 2, 3, 4):
+    if from_version not in (0, 1, 2, 3):
         raise RuntimeError(
             f"unsupported SQLite schema version {from_version}; "
             f"expected 0..{CURRENT_SCHEMA_VERSION}"
@@ -918,6 +934,24 @@ def _run_schema_migrations(conn: sqlite3.Connection, from_version: int) -> None:
     if from_version < 2:
         _rebuild_dialog_fts_if_needed(conn)
     _set_user_version(conn, CURRENT_SCHEMA_VERSION)
+
+
+def _ensure_additive_runtime_schema(conn: sqlite3.Connection) -> None:
+    """Materialize backward-compatible tables without a version migration."""
+    for statement in _iter_sql_statements(ADDITIVE_RUNTIME_SCHEMA):
+        conn.execute(statement)
+
+
+def _guard_managed_checkout_live_db() -> None:
+    """Keep unmerged evolve-checkout code away from its co-located live DB."""
+    package_root = Path(__file__).resolve().parent.parent
+    managed_checkout = (DB_PATH.parent / "evolve-repo").resolve()
+    if package_root == managed_checkout:
+        raise RuntimeError(
+            "managed evolve checkout cannot open the live ThreadKeeper DB; "
+            "set THREADKEEPER_DB to an isolated task database or use the "
+            "configured ThreadKeeper MCP server"
+        )
 
 
 def _ensure_schema(conn: sqlite3.Connection, wait_s: float = 600.0) -> None:
@@ -1127,6 +1161,7 @@ def bootstrap_db(force: bool = False) -> None:
     when repointing ``DB_PATH`` to a fresh file mid-process.
     """
     global _BOOTSTRAPPED
+    _guard_managed_checkout_live_db()
     if _BOOTSTRAPPED and not force:
         return
     with _BOOTSTRAP_LOCK:
@@ -1145,6 +1180,7 @@ def bootstrap_db(force: bool = False) -> None:
             # bootstrap and retains the bounded startup retry.
             _execute_startup_pragma(conn, "PRAGMA journal_mode=WAL")
             _ensure_schema(conn)
+            _ensure_additive_runtime_schema(conn)
             _ensure_vec_tables(conn, vec_loaded=vec_loaded)
             _ensure_sync_capture(conn)
             conn.commit()

--- a/threadkeeper/dialectic_miner.py
+++ b/threadkeeper/dialectic_miner.py
@@ -438,13 +438,13 @@ def start_dialectic_miner_daemon() -> None:
     """Idempotent. Mechanical capture needs no embeddings, so it is gated only
     by BACKGROUND_DAEMONS_ALLOWED (not SEMANTIC_AVAILABLE)."""
     global _started
-    if _started:
+    from .daemon_liveness import daemon_thread_alive, start_daemon_thread
+    if _started and daemon_thread_alive("dialectic_miner"):
         return
     if DIALECTIC_MINE_INTERVAL_S <= 0:
         return
     from .config import BACKGROUND_DAEMONS_ALLOWED
     if not BACKGROUND_DAEMONS_ALLOWED:
         return
-    t = threading.Thread(target=_serve_loop, name="dialectic_miner", daemon=True)
-    t.start()
+    start_daemon_thread("dialectic_miner", _serve_loop)
     _started = True

--- a/threadkeeper/dialectic_validator.py
+++ b/threadkeeper/dialectic_validator.py
@@ -736,7 +736,8 @@ def start_dialectic_validator_daemon() -> None:
     """Idempotent. Spawns children -> same cascade-prevention as
     candidate_reviewer (BACKGROUND_DAEMONS_ALLOWED + SEMANTIC_AVAILABLE)."""
     global _started
-    if _started:
+    from .daemon_liveness import daemon_thread_alive, start_daemon_thread
+    if _started and daemon_thread_alive("dialectic_validator"):
         return
     if DIALECTIC_VALIDATE_INTERVAL_S <= 0:
         return
@@ -745,6 +746,5 @@ def start_dialectic_validator_daemon() -> None:
         return
     if not SEMANTIC_AVAILABLE:
         return
-    t = threading.Thread(target=_serve_loop, name="dialectic_validator", daemon=True)
-    t.start()
+    start_daemon_thread("dialectic_validator", _serve_loop)
     _started = True

--- a/threadkeeper/evolve_applier.py
+++ b/threadkeeper/evolve_applier.py
@@ -167,6 +167,10 @@ DO, strictly in order:
 HARD CONSTRAINTS (non-negotiable):
   • NEVER commit, push, or force-push to main. main has branch protection.
   • NEVER merge the PR — a human does that.
+  • For every Python/CLI/test command that imports checkout code, set
+    THREADKEEPER_DB to a task-local temporary database and
+    THREADKEEPER_DISABLE_BG_DAEMONS=1. Use configured thread-keeper MCP tools
+    for live state; never import checkout code against the inherited live DB.
   • If you CANNOT make the full suite green, do NOT open a PR and do NOT call
     evolve_mark_applied. Broadcast a one-line failure summary and stop.
   • When you report, paraphrase in plain language; don't cite internal IDs.

--- a/threadkeeper/evolve_applier.py
+++ b/threadkeeper/evolve_applier.py
@@ -3149,15 +3149,13 @@ def start_evolve_applier_daemon() -> None:
     children / non-foreground origins refuse to start it so spawn() can't
     recurse (same cascade prevention as the other daemons)."""
     global _started
-    if _started:
+    from .daemon_liveness import daemon_thread_alive, start_daemon_thread
+    if _started and daemon_thread_alive("evolve_applier_daemon"):
         return
     if EVOLVE_APPLY_INTERVAL_S <= 0:
         return
     from .config import BACKGROUND_DAEMONS_ALLOWED
     if not BACKGROUND_DAEMONS_ALLOWED:
         return
-    t = threading.Thread(
-        target=_serve_loop, name="evolve_applier_daemon", daemon=True,
-    )
-    t.start()
+    start_daemon_thread("evolve_applier_daemon", _serve_loop)
     _started = True

--- a/threadkeeper/evolve_daemon.py
+++ b/threadkeeper/evolve_daemon.py
@@ -218,6 +218,11 @@ OUTPUTS
 HARD CONSTRAINTS
 ----------------
   - Do not implement roadmap issues. That is evolve_applier's job.
+  - The managed checkout is isolated from the live ThreadKeeper DB. For every
+    Python/CLI/test command that imports checkout code, set THREADKEEPER_DB to
+    a task-local temporary database and THREADKEEPER_DISABLE_BG_DAEMONS=1.
+    Use the configured thread-keeper MCP tools for live queue/thread updates;
+    never import checkout `threadkeeper` code against the inherited live DB.
   - Do not close issues unless they are exact duplicates and you state which
     issue supersedes them.
   - Do not create duplicate issues. Search open and closed issues first.

--- a/threadkeeper/evolve_daemon.py
+++ b/threadkeeper/evolve_daemon.py
@@ -1242,15 +1242,13 @@ def start_evolve_daemon() -> None:
     cascade prevention as the other daemons: spawned children / non-
     foreground origins refuse to start it so spawn() can't recurse."""
     global _started
-    if _started:
+    from .daemon_liveness import daemon_thread_alive, start_daemon_thread
+    if _started and daemon_thread_alive("evolve_daemon"):
         return
     if EVOLVE_REVIEW_INTERVAL_S <= 0:
         return
     from .config import BACKGROUND_DAEMONS_ALLOWED
     if not BACKGROUND_DAEMONS_ALLOWED:
         return
-    t = threading.Thread(
-        target=_serve_loop, name="evolve_daemon", daemon=True,
-    )
-    t.start()
+    start_daemon_thread("evolve_daemon", _serve_loop)
     _started = True

--- a/threadkeeper/extract_daemon.py
+++ b/threadkeeper/extract_daemon.py
@@ -144,7 +144,8 @@ def start_extract_daemon() -> None:
     spawned/background children refuse to start the daemon so spawn()
     doesn't recurse."""
     global _started
-    if _started:
+    from .daemon_liveness import daemon_thread_alive, start_daemon_thread
+    if _started and daemon_thread_alive("extract_daemon"):
         return
     if EXTRACT_INTERVAL_S <= 0:
         return
@@ -153,8 +154,5 @@ def start_extract_daemon() -> None:
         return
     if not SEMANTIC_AVAILABLE:
         return  # slim child: don't fire extract from here
-    t = threading.Thread(
-        target=_serve_loop, name="extract_daemon", daemon=True,
-    )
-    t.start()
+    start_daemon_thread("extract_daemon", _serve_loop)
     _started = True

--- a/threadkeeper/host.py
+++ b/threadkeeper/host.py
@@ -44,6 +44,9 @@ _DAEMON_STARTERS = [
     ("thread_janitor", "start_thread_janitor"),
     ("dialectic_miner", "start_dialectic_miner_daemon"),
     ("dialectic_validator", "start_dialectic_validator_daemon"),
+    # Must start after the monitored loops so its first observation is a
+    # health snapshot, not a burst of startup retries.
+    ("daemon_supervisor", "start_daemon_supervisor"),
     # Notifier: surfaces silent loop/spawn failures + materialization (issue #257).
     ("notify", "start_notify_daemon"),
     # Cross-machine sync: HTTP server (peers pull/push) + client reconcile loop.

--- a/threadkeeper/ingest.py
+++ b/threadkeeper/ingest.py
@@ -864,10 +864,8 @@ def _start_background_ingester() -> None:
             except Exception:
                 pass  # never crash the daemon
 
-    _ingest_thread = threading.Thread(
-        target=_loop, name="thread-keeper-live-ingest", daemon=True
-    )
-    _ingest_thread.start()
+    from .daemon_liveness import start_daemon_thread
+    _ingest_thread = start_daemon_thread("thread-keeper-live-ingest", _loop)
 
 
 def _start_initial_ingest() -> None:

--- a/threadkeeper/probe_daemon.py
+++ b/threadkeeper/probe_daemon.py
@@ -277,15 +277,13 @@ def start_probe_daemon() -> None:
     prevention as shadow_review/extract: spawned children and non-foreground
     origins refuse to start the daemon so spawn() can't recurse."""
     global _started
-    if _started:
+    from .daemon_liveness import daemon_thread_alive, start_daemon_thread
+    if _started and daemon_thread_alive("probe_daemon"):
         return
     if PROBE_INTERVAL_S <= 0:
         return
     from .config import BACKGROUND_DAEMONS_ALLOWED
     if not BACKGROUND_DAEMONS_ALLOWED:
         return
-    t = threading.Thread(
-        target=_serve_loop, name="probe_daemon", daemon=True,
-    )
-    t.start()
+    start_daemon_thread("probe_daemon", _serve_loop)
     _started = True

--- a/threadkeeper/retention.py
+++ b/threadkeeper/retention.py
@@ -356,12 +356,12 @@ def _serve_loop() -> None:
 def start_retention_daemon() -> None:
     """Idempotent foreground-only retention daemon starter."""
     global _started
-    if _started:
+    from .daemon_liveness import daemon_thread_alive, start_daemon_thread
+    if _started and daemon_thread_alive("retention"):
         return
     if RETENTION_INTERVAL_S <= 0:
         return
     if not BACKGROUND_DAEMONS_ALLOWED:
         return
-    t = threading.Thread(target=_serve_loop, name="retention", daemon=True)
-    t.start()
+    start_daemon_thread("retention", _serve_loop)
     _started = True

--- a/threadkeeper/shadow_review.py
+++ b/threadkeeper/shadow_review.py
@@ -671,7 +671,8 @@ def start_shadow_daemon() -> None:
     the semantic guard as a second belt for older slim children.
     """
     global _started
-    if _started:
+    from .daemon_liveness import daemon_thread_alive, start_daemon_thread
+    if _started and daemon_thread_alive("shadow_review"):
         return
     if SHADOW_REVIEW_INTERVAL_S <= 0:
         return
@@ -680,8 +681,5 @@ def start_shadow_daemon() -> None:
         return
     if not SEMANTIC_AVAILABLE:
         return  # slim child: don't fire shadow review from here
-    t = threading.Thread(
-        target=_serve_loop, name="shadow_review", daemon=True,
-    )
-    t.start()
+    start_daemon_thread("shadow_review", _serve_loop)
     _started = True

--- a/threadkeeper/skill_updater.py
+++ b/threadkeeper/skill_updater.py
@@ -641,16 +641,12 @@ def _serve_loop() -> None:
 def start_skill_update_daemon() -> None:
     """Start the twice-weekly skill updater in foreground MCP parents."""
     global _started
-    if _started:
+    from .daemon_liveness import daemon_thread_alive, start_daemon_thread
+    if _started and daemon_thread_alive("skill_update_daemon"):
         return
     if SKILL_UPDATE_INTERVAL_S <= 0:
         return
     if not BACKGROUND_DAEMONS_ALLOWED:
         return
-    t = threading.Thread(
-        target=_serve_loop,
-        name="skill_update_daemon",
-        daemon=True,
-    )
-    t.start()
+    start_daemon_thread("skill_update_daemon", _serve_loop)
     _started = True

--- a/threadkeeper/thread_janitor.py
+++ b/threadkeeper/thread_janitor.py
@@ -149,15 +149,13 @@ def start_thread_janitor() -> None:
     foreground origins refuse to start it, so a review child the janitor
     triggers can't spin up its own janitor."""
     global _started
-    if _started:
+    from .daemon_liveness import daemon_thread_alive, start_daemon_thread
+    if _started and daemon_thread_alive("thread_janitor"):
         return
     if THREAD_JANITOR_INTERVAL_S <= 0:
         return
     from .config import BACKGROUND_DAEMONS_ALLOWED
     if not BACKGROUND_DAEMONS_ALLOWED:
         return
-    t = threading.Thread(
-        target=_serve_loop, name="thread_janitor", daemon=True,
-    )
-    t.start()
+    start_daemon_thread("thread_janitor", _serve_loop)
     _started = True

--- a/threadkeeper/tools/dashboard.py
+++ b/threadkeeper/tools/dashboard.py
@@ -29,6 +29,7 @@ import time
 
 from .._mcp import read_tool, write_tool
 from ..agent_status import _LOOP_DEFS
+from ..agent_status import daemon_liveness_statuses
 from ..config import DB_PATH
 from ..db import get_db
 from ..helpers import fmt_age
@@ -273,6 +274,18 @@ def mp_dashboard(window_days: int = 7) -> str:
         f"dashboard window={window_days}d now="
         f"{time.strftime('%Y-%m-%dT%H:%MZ', time.gmtime(now))}"
     ]
+
+    # Thread liveness is deliberately a separate compact block from pass
+    # counters below: a loop can be alive but stale even while its historical
+    # event count looks healthy.
+    out.append("")
+    out.append("daemon_threads")
+    for daemon in daemon_liveness_statuses(conn, now):
+        out.append(
+            f"  daemon={daemon['id']} verdict={daemon['verdict']} "
+            f"thread_alive={daemon['thread_alive']} "
+            f"last_success={daemon['last_success_age']}"
+        )
 
     # ── stores ────────────────────────────────────────────────────────
     threads = _group_counts(conn, "threads", "state")

--- a/threadkeeper/tools/process_health.py
+++ b/threadkeeper/tools/process_health.py
@@ -7,6 +7,7 @@ loaded). These tools surface the situation and let you clean up.
 
 from .._mcp import read_tool, write_tool, structured_result
 from .. import process_health
+from ..agent_status import daemon_liveness_statuses
 from ..tool_schemas import MpHealth, MpProcess
 
 
@@ -18,8 +19,9 @@ def mp_health() -> MpHealth:
     heartbeat from its session).
 
     Self (the process answering this call) is always marked is_self=true
-    and never flagged as orphan. Returns structuredContent (MpHealth) plus
-    the legacy text block."""
+    and never flagged as orphan. The text view also includes each registered
+    daemon thread's liveness verdict. Returns structuredContent (MpHealth)
+    plus the legacy text block."""
     procs = process_health.scan()
     total_kb = sum(p["rss_kb"] for p in procs)
     orphans = [p for p in procs if p.get("is_orphaned")]
@@ -31,13 +33,14 @@ def mp_health() -> MpHealth:
         rss_total_mb=total_kb // 1024,
         processes=[MpProcess(**p) for p in procs],
     )
-    if not procs:
-        return structured_result("no_mp_processes_running", model)
-
-    out = [
-        f"total={len(procs)} live={len(live)} orphans={len(orphans)} "
-        f"rss_total={total_kb // 1024}MB"
-    ]
+    out = (
+        ["no_mp_processes_running"]
+        if not procs
+        else [
+            f"total={len(procs)} live={len(live)} orphans={len(orphans)} "
+            f"rss_total={total_kb // 1024}MB"
+        ]
+    )
     for p in procs:
         flag = "self" if p["is_self"] else ("ORPHAN" if p["is_orphaned"] else "live")
         hb = p["heartbeat_age_s"]
@@ -48,6 +51,15 @@ def mp_health() -> MpHealth:
             f"  pid={p['pid']:<6} ppid={p['ppid']:<6} ({parent})  "
             f"rss={rss_mb}MB  hb={hb_disp}  etime={p['etime']}  "
             f"[{flag}]  {p.get('orphan_reason','-')}"
+        )
+    daemon_rows = daemon_liveness_statuses()
+    out.append("\ndaemon_threads")
+    for daemon in daemon_rows:
+        out.append(
+            f"  {daemon['id']} enabled={daemon['enabled']} "
+            f"thread_alive={daemon['thread_alive']} "
+            f"verdict={daemon['verdict']} "
+            f"last_success={daemon['last_success_age']}"
         )
     if orphans:
         out.append(


### PR DESCRIPTION
## Summary
- Track daemon threads and restart enabled threads that exit.
- Surface thread liveness, successful-pass age, and dead/stale/ok verdicts in status tools.
- Persist host health for thin servers and document the new controls.

## Tests
- env -u THREADKEEPER_NO_EMBEDDINGS .venv/bin/python -m pytest -q (0 failed)

Closes #114