### PR TITLE
fix: cap evolve reviewer backlog

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -124,6 +124,7 @@ THREADKEEPER_CURATOR_INTERVAL_S=259200         # 3-day deep audit; set 0 to disa
 # THREADKEEPER_PROBE_COOLDOWN_S=604800       # 86400 = 1d active per-category cooldown
 # THREADKEEPER_EVOLVE_REVIEW_INTERVAL_S=0
 # THREADKEEPER_EVOLVE_REVIEW_MIN=2
+# THREADKEEPER_EVOLVE_REVIEW_BACKLOG_MAX=25 # skip a privileged issue-creating audit at/above this open roadmap backlog; 0=unlimited
 # THREADKEEPER_EVOLVE_APPLY_INTERVAL_S=0       # applier tick (s); applies latest complete Curator report first, then promoted evolve PR work. 0=off (manual tools still work)
 # THREADKEEPER_EVOLVE_REPO_ROOT=               # pin the thread-keeper checkout the reviewer/applier branch+test+PR against. Empty=auto: a dedicated managed checkout under the DB dir (~/.threadkeeper/evolve-repo), isolated from your own working tree (#164) so the loops never branch-switch it
 # THREADKEEPER_EVOLVE_AUTO_CLONE=1             # auto-provision (clone + .venv with [semantic,dev]) the managed checkout so the evolve loops work by default without touching your checkout. 0=disable: falls back to in-place on an editable install (pre-isolation behaviour), else needs EVOLVE_REPO_ROOT

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ version bumps follow semver per the policy in
 [CONTRIBUTING.md → Releases](CONTRIBUTING.md#releases).
 
 ## [Unreleased]
+- **Fixed: evolve reviewer backlog is mechanically bounded (#115).** Before
+  dispatching its privileged issue-creating audit phase, the reviewer now
+  counts open, not-yet-applied roadmap issues and records
+  `backlog_saturated open=<n> cap=<max>` instead of spawning at or above
+  `THREADKEEPER_EVOLVE_REVIEW_BACKLOG_MAX` (default 25; `0` disables the
+  governor). The read-only research phase remains available, and the recorded
+  pass summary makes saturation visible through status telemetry.
 - **Added: daemon-thread liveness supervision (#114).** Evented daemon
   starters now retain and re-check their named `Thread` instead of letting a
   stale `_started` flag make an exited loop unrestartable. The daemon host's

--- a/README.md
+++ b/README.md
@@ -786,6 +786,13 @@ shell/`bypassPermissions` to the same child:
 
 A full research → audit cycle therefore spans two due passes.
 
+Before a privileged audit can create more issues, the parent counts open,
+not-yet-applied roadmap work with a paginated GitHub REST read. At
+`THREADKEEPER_EVOLVE_REVIEW_BACKLOG_MAX` (default 25), it withholds that audit
+and records `backlog_saturated open=<n> cap=<max>` on the
+`evolve_review_pass` event; set the knob to `0` to opt out. The read-only
+research phase is unaffected.
+
 Before an audit child can open a roadmap-doc PR, the parent preflights open PRs
 with `gh pr list --json ... files` and reports any automation-owned PR already
 touching `docs/ROADMAP.md`. The child must append to that PR or skip when no
@@ -1143,6 +1150,7 @@ The most-used env knobs (full list in `threadkeeper/config.py`):
 | `THREADKEEPER_DIALECTIC_VALIDATE_FLUSH_AGE_S` | 259200 | age-flush: an undersized observation buffer is still validated once its oldest eligible row is this old (0 = threshold only) |
 | `THREADKEEPER_DIALECTIC_VALIDATE_BATCH_SIZE` | 50 | max observations sent to one validator child; prevents oversized prompts and drains large queues incrementally |
 | `THREADKEEPER_EVOLVE_REVIEW_INTERVAL_S` | 0 (off) | evolve-reviewer daemon tick (s); audits thread-keeper for safety/leaks/optimization/new ideas, updates roadmap/issues, and includes legacy evolve suggestions as input. Runs as two alternating phases — read-only web research, then a privileged web-free audit that consumes the fenced research digest (#79) — so a full cycle spans two ticks |
+| `THREADKEEPER_EVOLVE_REVIEW_BACKLOG_MAX` | 25 | max open, not-yet-applied roadmap issues before the issue-creating audit is skipped and records `backlog_saturated`; `0` disables the cap |
 | `THREADKEEPER_EVOLVE_APPLY_INTERVAL_S` | 0 (off) | evolve-applier daemon tick (s); implements one open GitHub issue at a time, then falls back to Curator reports and promoted legacy evolve suggestions. Empty checks are throttled between intervals; actionable work and manual apply tools still dispatch |
 | `THREADKEEPER_EVOLVE_REPO_ROOT` | (auto) | absolute path to the thread-keeper git checkout the evolve reviewer/applier branch, test, and open PRs against. When empty, the repo is resolved automatically: the package's parent dir for an editable `install.sh`, else a managed checkout under the DB dir that is auto-cloned on first use. Set this to pin an explicit checkout |
 | `THREADKEEPER_EVOLVE_AUTO_CLONE` | true | auto-provision (git clone + `.venv` with `[semantic,dev]`) a managed checkout when installed without a source tree (PyPI/site-packages), so the evolve loops work by default. Set `0`/`false` to disable — then a non-checkout install requires an editable install or an explicit `EVOLVE_REPO_ROOT`, otherwise the loops return `ERR evolve_repo_unavailable` |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -530,7 +530,12 @@ moving the high-water forward; `force=True` bypasses this due gate.
   against the local `evolve_issues` fingerprint ledger, and records duplicate
   skips as telemetry before any `gh issue create` call. Same-pass duplicates
   hit the ledger after the first file, so repeated candidates file once. Before
-  that child can create a roadmap-doc PR, the parent also checks open PRs for
+  an issue-creating audit is dispatched, the parent also counts open,
+  not-yet-applied roadmap work with a paginated REST read; at
+  `THREADKEEPER_EVOLVE_REVIEW_BACKLOG_MAX` (default 25; `0` disables it), it
+  records `backlog_saturated open=<n> cap=<max>` and withholds the audit.
+  This gate applies only to the privileged audit phase, not read-only research.
+  Before that child can create a roadmap-doc PR, the parent also checks open PRs for
   automation-owned changes touching `docs/ROADMAP.md` and embeds the result in
   the audit prompt. Existing roadmap-doc PRs are appended to or skipped; new
   ones use/reuse the deterministic daily `docs/roadmap-audit-YYYY-MM-DD` branch

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -80,6 +80,11 @@ remains a live question.
   `state=all` (including closed `not_planned` issues), records filed
   fingerprints in `evolve_issues`, skips matching ledger/GitHub/same-pass
   duplicates, and records duplicate skips as telemetry.
+- Evolve reviewer backlog governor (#115): before the privileged,
+  issue-creating audit phase, the parent counts open, not-yet-applied roadmap
+  issues. At `THREADKEEPER_EVOLVE_REVIEW_BACKLOG_MAX` (default 25; `0` disables
+  it), the audit is withheld and `evolve_review_pass` records
+  `backlog_saturated open=<n> cap=<max>`; read-only research remains eligible.
 - Evolve roadmap automation git safety (#43): before a privileged reviewer
   audit or code/PR applier child can spawn, the parent rejects tracked-file WIP
   with `skipped_dirty_worktree` (untracked scratch files do not block), refuses

--- a/tests/test_config_settings.py
+++ b/tests/test_config_settings.py
@@ -241,6 +241,7 @@ def test_all_exported_names_present(monkeypatch):
         "EMBED_MODEL_NAME",
         "EVOLVE_REVIEW_INTERVAL_S",
         "EVOLVE_REVIEW_MIN",
+        "EVOLVE_REVIEW_BACKLOG_MAX",
         "EXTRACT_INTERVAL_S",
         "EXTRACT_WINDOW_MIN",
         "FASTEMBED_MODEL_ID",

--- a/tests/test_evolve_daemon.py
+++ b/tests/test_evolve_daemon.py
@@ -20,7 +20,7 @@ _FAKE_CID = "dddd4444-5555-6666-7777-888899990000"
 
 
 def _bootstrap(tmp_path, monkeypatch, interval="0", review_min="2",
-               pin_repo=True):
+               review_backlog_max="25", pin_repo=True):
     env = {
         "THREADKEEPER_DB": str(tmp_path / "db.sqlite"),
         "CLAUDE_PROJECTS_DIR": str(tmp_path / "fake_claude_projects"),
@@ -37,6 +37,7 @@ def _bootstrap(tmp_path, monkeypatch, interval="0", review_min="2",
         "THREADKEEPER_PROBE_INTERVAL_S": "0",
         "THREADKEEPER_EVOLVE_REVIEW_INTERVAL_S": interval,
         "THREADKEEPER_EVOLVE_REVIEW_MIN": review_min,
+        "THREADKEEPER_EVOLVE_REVIEW_BACKLOG_MAX": review_backlog_max,
         "THREADKEEPER_DISABLE_BG_DAEMONS": "1",
         "THREADKEEPER_TASK_LOG_DIR": str(tmp_path / "tasks"),
         "THREADKEEPER_CLIENT": "pytest",
@@ -61,6 +62,12 @@ def _bootstrap(tmp_path, monkeypatch, interval="0", review_min="2",
     monkeypatch.setattr(
         evolve_daemon, "_open_roadmap_doc_prs",
         lambda repo_root, branch: ([], ""),
+    )
+    # Audit-phase tests do not exercise the GitHub-backed backlog governor by
+    # default. Keep their dispatch assertions offline; the dedicated governor
+    # test below replaces this with controlled backlog sizes.
+    monkeypatch.setattr(
+        evolve_daemon, "_open_roadmap_backlog_count", lambda conn, repo_root: (0, ""),
     )
     # Pin a ready tmp checkout so the reviewer's _ensure_repo_ready() gate does
     # not run a real `git clone` + venv + `pip install` (~30 s/test) against the
@@ -612,6 +619,39 @@ def test_run_evolve_pass_audit_phase_no_web_consumes_fenced_research(
     assert "No open reviewer roadmap-doc PR touching docs/ROADMAP.md" in (
         calls["prompt"]
     )
+
+
+def test_run_evolve_pass_audit_backlog_governor(tmp_path, monkeypatch):
+    pkg = _bootstrap(tmp_path, monkeypatch, review_backlog_max="2")
+    conn = pkg["db"].get_db()
+    _seed_research(pkg, conn)
+    calls = []
+    import threadkeeper.tools.spawn as spawn_mod
+    monkeypatch.setattr(
+        spawn_mod, "spawn", lambda **kw: calls.append(kw) or "ok task=tk_ev pid=1"
+    )
+    monkeypatch.setattr(
+        pkg["ed"], "_open_roadmap_backlog_count", lambda conn, repo: (2, ""),
+    )
+
+    out = pkg["ed"].run_evolve_pass(force=True)
+
+    assert out == "backlog_saturated open=2 cap=2"
+    assert calls == []
+    summary = conn.execute(
+        "SELECT summary FROM events WHERE kind='evolve_review_pass' "
+        "ORDER BY id DESC LIMIT 1"
+    ).fetchone()["summary"]
+    assert summary == out
+
+    monkeypatch.setattr(
+        pkg["ed"], "_open_roadmap_backlog_count", lambda conn, repo: (1, ""),
+    )
+
+    out = pkg["ed"].run_evolve_pass(force=True)
+
+    assert out.startswith("spawned audit")
+    assert len(calls) == 1
 
 
 def test_run_evolve_pass_audit_skips_dirty_worktree_and_records_event(

--- a/threadkeeper/config.py
+++ b/threadkeeper/config.py
@@ -386,6 +386,9 @@ class Settings(BaseSettings):
     # ── Evolve review daemon ──────────────────────────────────────────────────
     evolve_review_interval_s: float = 0.0
     evolve_review_min: int = 2
+    # Maximum open, not-yet-applied roadmap issues allowed before the
+    # privileged reviewer audit is withheld. 0 opts out of the governor.
+    evolve_review_backlog_max: int = Field(default=25, ge=0)
 
     # ── Evolve applier daemon ─────────────────────────────────────────────────
     # Periodically picks the top promoted+unapplied evolve suggestion and fires
@@ -835,6 +838,7 @@ def _derive_constants(s: "Settings") -> dict:
         "PANEL_EFFORT": s.panel_effort,
         "EVOLVE_REVIEW_INTERVAL_S": s.evolve_review_interval_s,
         "EVOLVE_REVIEW_MIN": s.evolve_review_min,
+        "EVOLVE_REVIEW_BACKLOG_MAX": s.evolve_review_backlog_max,
         "EVOLVE_APPLY_INTERVAL_S": s.evolve_apply_interval_s,
         "EVOLVE_REPO_ROOT": s.evolve_repo_root,
         "EVOLVE_AUTO_CLONE": s.evolve_auto_clone,

--- a/threadkeeper/evolve_daemon.py
+++ b/threadkeeper/evolve_daemon.py
@@ -37,14 +37,21 @@ import time
 from pathlib import Path
 from typing import Optional
 
-from .config import DB_PATH, EVOLVE_REVIEW_INTERVAL_S, EVOLVE_REVIEW_MIN
+from .config import (
+    DB_PATH,
+    EVOLVE_REVIEW_BACKLOG_MAX,
+    EVOLVE_REVIEW_INTERVAL_S,
+    EVOLVE_REVIEW_MIN,
+)
 from .db import get_db
 from .evolve_applier import (
     _base_branch_name,
     _base_ref,
     _ensure_repo_ready,
+    _fetch_open_issues,
     _git_worktree_precondition,
     _repo_root,
+    _roadmap_issue_applied,
 )
 from .github_budget import run_gh, split_gh_api_output, strip_gh_api_headers
 from .helpers import daemon_sleep, single_flight_lock
@@ -325,6 +332,30 @@ def _record_transient_evolve_pass(conn: sqlite3.Connection,
     if prev.split(" ", 1)[0] == outcome.split(" ", 1)[0]:
         return
     _record_evolve_pass(conn, _last_evolve_ts(conn), outcome)
+
+
+def _open_roadmap_backlog_count(
+    conn: sqlite3.Connection, repo_root: Path,
+) -> tuple[int, str]:
+    """Count open GitHub issues without the applier's per-issue claim checks.
+
+    The governor needs backlog pressure, not the next issue eligible for
+    autonomous pickup. A single paginated REST issue read avoids the expensive
+    GraphQL comment checks in ``_open_roadmap_issues`` while the local event
+    ledger filters issues already handed off to an applier PR.
+    """
+    issues, err = _fetch_open_issues(repo_root)
+    if err:
+        return 0, err
+    open_backlog = 0
+    for issue in issues:
+        try:
+            number = int(issue.get("number"))
+        except (TypeError, ValueError):
+            continue
+        if not _roadmap_issue_applied(conn, number):
+            open_backlog += 1
+    return open_backlog, ""
 
 
 def _pending(conn: sqlite3.Connection) -> list[sqlite3.Row]:
@@ -1170,6 +1201,7 @@ def run_evolve_pass(force: bool = False) -> str:
       'disabled'                   — knob off and not forced
       'not_due'                    — checked recently
       'reviewer_running n=<k>'     — a reviewer child is already in flight
+      'backlog_saturated …'        — audit withheld at the roadmap backlog cap
       'spawned research file=<f> …'— launched the read-only research child
       'spawned audit pending=<k> …'— launched the privileged audit child
       'spawn_error: …'             — spawn rejected
@@ -1203,6 +1235,21 @@ def run_evolve_pass(force: bool = False) -> str:
         # The audit runs even when the digest is empty — auditing the repo is
         # the valuable half and must not depend on web research succeeding.
         do_audit = _last_spawn_phase(conn) == "research"
+        if do_audit and EVOLVE_REVIEW_BACKLOG_MAX > 0:
+            open_backlog, backlog_err = _open_roadmap_backlog_count(
+                conn, repo_root
+            )
+            if backlog_err:
+                out = f"backlog_check_error {backlog_err}"
+                _record_transient_evolve_pass(conn, out)
+                return out
+            if open_backlog >= EVOLVE_REVIEW_BACKLOG_MAX:
+                out = (
+                    "backlog_saturated "
+                    f"open={open_backlog} cap={EVOLVE_REVIEW_BACKLOG_MAX}"
+                )
+                _record_transient_evolve_pass(conn, out)
+                return out
         try:
             if do_audit:
                 guard = _git_worktree_precondition(


### PR DESCRIPTION
## Summary
- cap privileged reviewer audits when open, unapplied roadmap work reaches a finite configurable threshold
- record saturation as a typed evolve_review_pass event without blocking read-only research
- document the knob and cover saturated and below-cap audit dispatch

## Tests
- env -u THREADKEEPER_NO_EMBEDDINGS -u THREADKEEPER_BRIEF_LEAN .venv/bin/python -m pytest -q

Closes #115