### PR TITLE
fix: refresh managed evolve checkout lifecycle

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -130,6 +130,8 @@ THREADKEEPER_CURATOR_INTERVAL_S=259200         # 3-day deep audit; set 0 to disa
 # THREADKEEPER_EVOLVE_AUTO_CLONE=1             # auto-provision (clone + .venv with [semantic,dev]) the managed checkout so the evolve loops work by default without touching your checkout. 0=disable: falls back to in-place on an editable install (pre-isolation behaviour), else needs EVOLVE_REPO_ROOT
 # THREADKEEPER_EVOLVE_REPO_URL=https://github.com/po4erk91/thread-keeper   # git URL the managed checkout is cloned from
 # THREADKEEPER_EVOLVE_REPO_BRANCH=main         # branch the managed checkout tracks
+# THREADKEEPER_EVOLVE_REPO_MIN_FREE_BYTES=5368709120  # reserve 5 GiB before managed clone/.venv creation; 0=disable the disk preflight
+# THREADKEEPER_EVOLVE_REPO_PROVISION_LOCK_TIMEOUT_S=5  # bounded wait for another clone/venv install; returns retry_later when held longer
 # THREADKEEPER_ROADMAP_CLAIM_RACE_WINDOW_S=3   # multi-host TOCTOU window: after posting a claim, wait this long before re-fetching to detect a competing claim. 0=skip race detection (single-host setups)
 # THREADKEEPER_ROADMAP_ISSUE_MAX_ATTEMPTS=3    # poison-issue dead-letter cap: after this many implementer spawns with no PR, the roadmap issue gets a `blocked` label + one summary comment and drops out of the auto-drain until a human intervenes
 # THREADKEEPER_ROADMAP_ISSUE_BACKOFF_BASE_S=172800  # base failure-backoff window (s); doubles per attempt (base*2^(n-1), capped 30d). Defers re-selecting a repeatedly-aborting issue beyond the 24h claim TTL

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ version bumps follow semver per the policy in
 [CONTRIBUTING.md → Releases](CONTRIBUTING.md#releases).
 
 ## [Unreleased]
+- **Fixed: managed Evolve checkouts no longer branch from a stale base (#128).**
+  The default disposable clone now fetches, checks out, and hard-resets to the
+  configured `origin/<EVOLVE_REPO_BRANCH>` before a code-producing pass, after
+  clean-tree and live-writer guards; explicit operator checkouts remain
+  untouched. Managed clone/venv creation reserves 5 GiB by default
+  (`THREADKEEPER_EVOLVE_REPO_MIN_FREE_BYTES`, `0` disables), and the bounded
+  provisioning flock returns a retryable in-progress error after 5 seconds
+  instead of blocking foreground tools behind a long `pip install`.
+  `mp_dashboard()` now reports managed repo/venv/total/free-disk footprint, and
+  `evolve_prune_managed_venv(confirm=True)` explicitly reclaims the managed
+  virtualenv without deleting its clone.
 - **Fixed: evolve reviewer backlog is mechanically bounded (#115).** Before
   dispatching its privileged issue-creating audit phase, the reviewer now
   counts open, not-yet-applied roadmap issues and records

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ version bumps follow semver per the policy in
 [CONTRIBUTING.md → Releases](CONTRIBUTING.md#releases).
 
 ## [Unreleased]
+- **Fixed: pinned the MCP SDK below 2.0.** `mcp` 2.0.0 (2026-07-28) renamed
+  `mcp.server.fastmcp` to `mcp.server.mcpserver` (`FastMCP` → `MCPServer`) with
+  no compatibility shim, so every fresh install resolving the unbounded
+  `mcp>=1.10.0` floor died at import with
+  `ModuleNotFoundError: No module named 'mcp.server.fastmcp'`. The requirement
+  is now `mcp>=1.10.0,<2` (resolves to 1.29.0, which still ships the 1.x import
+  path). Porting the server to the 2.x API remains open; the cap is only safe to
+  lift together with that port.
 - **Fixed: managed Evolve checkouts no longer branch from a stale base (#128).**
   The default disposable clone now fetches, checks out, and hard-resets to the
   configured `origin/<EVOLVE_REPO_BRANCH>` before a code-producing pass, after

--- a/README.md
+++ b/README.md
@@ -855,6 +855,19 @@ diff under
 unreadable PR state remains fail-closed. An explicit
 `THREADKEEPER_EVOLVE_REPO_ROOT` is never auto-reset.
 
+The default managed checkout is refreshed before every code-producing pass:
+after checking that no Evolve git writer is live and that tracked files are
+clean, it fetches the configured branch, checks out that branch, and resets to
+`origin/<THREADKEEPER_EVOLVE_REPO_BRANCH>`. Explicit
+`THREADKEEPER_EVOLVE_REPO_ROOT` checkouts are never refreshed or reset by this
+path. Provisioning reserves 5 GiB by default before clone or `.venv` creation
+(`THREADKEEPER_EVOLVE_REPO_MIN_FREE_BYTES=0` disables that preflight), and a
+contended provisioning lock returns a retryable error after 5 seconds rather
+than holding a foreground tool call behind `pip install`. `mp_dashboard()`
+reports the managed repository, virtualenv, total, and free-disk sizes. To
+reclaim the optional heavyweight virtualenv while retaining the clone, call
+`evolve_prune_managed_venv(confirm=True)`; the next managed pass rebuilds it.
+
 **Skip-label gate.** Autonomous issue pickup refuses issues with labels listed
 in `THREADKEEPER_EVOLVE_APPLY_SKIP_LABELS` (default
 `blocked,needs-design,wontfix,question,discussion,help wanted`). These labels
@@ -1156,6 +1169,8 @@ The most-used env knobs (full list in `threadkeeper/config.py`):
 | `THREADKEEPER_EVOLVE_AUTO_CLONE` | true | auto-provision (git clone + `.venv` with `[semantic,dev]`) a managed checkout when installed without a source tree (PyPI/site-packages), so the evolve loops work by default. Set `0`/`false` to disable — then a non-checkout install requires an editable install or an explicit `EVOLVE_REPO_ROOT`, otherwise the loops return `ERR evolve_repo_unavailable` |
 | `THREADKEEPER_EVOLVE_REPO_URL` | upstream repo | git URL the managed checkout is cloned from |
 | `THREADKEEPER_EVOLVE_REPO_BRANCH` | `main` | branch the managed checkout tracks |
+| `THREADKEEPER_EVOLVE_REPO_MIN_FREE_BYTES` | 5368709120 (5 GiB) | minimum free space required before a managed clone or managed `.venv` is created; `0` disables the preflight |
+| `THREADKEEPER_EVOLVE_REPO_PROVISION_LOCK_TIMEOUT_S` | 5 | maximum seconds to wait for another clone/venv provisioning operation before returning `ERR evolve_repo_provisioning_in_progress retry_later=1`; `0` is immediate |
 | `THREADKEEPER_EVOLVE_APPLY_SKIP_LABELS` | `blocked,needs-design,wontfix,question,discussion,help wanted` | comma-separated labels that exclude GitHub issues from autonomous Evolve applier pickup. Exact-number apply returns `skipped: label X`; set to `off` to clear |
 | `THREADKEEPER_EVOLVE_TRUSTED_AUTHOR_ASSOCIATIONS` | `OWNER,MEMBER,COLLABORATOR` | comma-separated GitHub author associations eligible for **autonomous** issue pickup on this public repo; issues from other authors are skipped unless promoted (trust label or exact-number invocation) |
 | `THREADKEEPER_EVOLVE_TRUST_LABELS` | (empty) | comma-separated labels that promote an untrusted-author issue into the autonomous queue; on a public repo only collaborators can apply labels, so a trust label is a maintainer endorsement |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -682,9 +682,20 @@ moving the high-water forward; `force=True` bypasses this due gate.
   non-checkout install with auto-clone off the loops report
   `ERR evolve_repo_unavailable=<path>` until an explicit `EVOLVE_REPO_ROOT` is
   provided. An explicit override that is not itself a checkout is never
-  auto-cloned into and reports `ERR repo_root_not_git`. Provisioning is
-  serialized by `evolve-repo-provision.lock`. Curator report apply needs no git
-  tree and runs regardless.
+  auto-cloned into and reports `ERR repo_root_not_git`. The disposable managed
+  checkout is refreshed before every code-producing pass: after a clean-tree
+  and no-live-writer check, the parent fetches the configured branch, checks it
+  out, and hard-resets to `origin/<EVOLVE_REPO_BRANCH>`. Explicit checkout
+  roots are never refreshed or reset. Before clone or heavyweight
+  `[semantic,dev]` virtualenv creation, a 5 GiB free-space reserve is checked
+  (`EVOLVE_REPO_MIN_FREE_BYTES=0` disables it); `mp_dashboard()` reports
+  managed repo/venv/total/free-disk sizes, and
+  `evolve_prune_managed_venv(confirm=True)` removes only the default managed
+  `.venv` for explicit disk reclamation. Provisioning is serialized by
+  `evolve-repo-provision.lock`, but acquisition waits at most
+  `EVOLVE_REPO_PROVISION_LOCK_TIMEOUT_S` (default 5 seconds) before returning
+  a retryable in-progress error. Curator report apply needs no git tree and
+  runs regardless.
 
   Before the privileged reviewer audit or any code/PR applier child is spawned,
   the parent enforces local git safety on that checkout: `git status

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -97,6 +97,11 @@ remains a live question.
   plus an applier-owned branch and an exact GitHub `MERGED` state, archives the
   tracked diff under `evolve-recovery/`, and returns the checkout to the fetched
   base. Explicit operator checkouts and uncertain PR states remain fail-closed.
+- Evolve managed-checkout lifecycle (#128): the disposable clone now refreshes
+  to the configured `origin/<EVOLVE_REPO_BRANCH>` base before each code pass,
+  without touching explicit checkouts. Clone/venv provisioning has a bounded
+  lock, a configurable free-disk reserve, visible footprint telemetry, and an
+  explicit managed-venv prune tool.
 - Evolve reviewer roadmap-doc PR dedup (#54): before spawning the privileged
   audit child, the parent checks open PRs for automation-owned changes touching
   `docs/ROADMAP.md`; the prompt tells the reviewer to append/skip when one

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,11 @@ classifiers = [
 dependencies = [
     # >=1.10.0 for the MCP 2025-06-18 tool vocabulary: ToolAnnotations
     # (readOnly/destructive/idempotent hints) + structured outputSchema (#67).
-    "mcp>=1.10.0",
+    # <2 because mcp 2.0.0 renamed `mcp.server.fastmcp` -> `mcp.server.mcpserver`
+    # (FastMCP -> MCPServer) with no compatibility shim; _mcp.py, elicitation.py
+    # and tools/dialectic.py all import the 1.x path. Lift the cap only together
+    # with that migration — until then an unbounded floor breaks fresh installs.
+    "mcp>=1.10.0,<2",
     "pydantic>=2.13.4",
     "pydantic-settings>=2.14.2",
     "pyyaml>=6.0.3",

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import re
 import time
+from pathlib import Path
 
 
 def _tool(pkg, name):
@@ -54,6 +55,22 @@ def test_dashboard_empty_db_no_crash(fresh_mp):
     assert "high_volume:" in out, out
     for key in ("dialog_messages", "dialog_fts", "events", "signals", "tasks"):
         assert f"{key}=" in out, out
+
+
+def test_dashboard_reports_managed_checkout_and_venv_footprint(fresh_mp):
+    root = Path(fresh_mp["db"].DB_PATH).parent / "evolve-repo"
+    venv = root / ".venv"
+    root.mkdir(parents=True)
+    venv.mkdir()
+    (root / "tracked").write_bytes(b"repo-bytes")
+    (venv / "python").write_bytes(b"venv-bytes")
+
+    out = _tool(fresh_mp, "mp_dashboard")()
+
+    assert "managed_checkout: state=present" in out, out
+    assert "repo=10B" in out, out
+    assert "venv=10B" in out, out
+    assert "total=20B" in out, out
 
 
 def test_dashboard_counts_stores_delta(fresh_mp):

--- a/tests/test_evolve_applier.py
+++ b/tests/test_evolve_applier.py
@@ -120,6 +120,13 @@ def _bootstrap(tmp_path, monkeypatch, interval="0", pin_repo=True):
         _repo = tmp_path / "evolve-repo"
         monkeypatch.setattr(evolve_applier, "_resolve_repo_root", lambda: _repo)
         monkeypatch.setattr(evolve_applier, "_is_git_repo", lambda p: True)
+        # Dispatch tests use a logical ready checkout rather than a real git
+        # worktree; lifecycle tests opt out and exercise managed refresh for
+        # real. Keep the fake checkout outside the refresh-only path.
+        monkeypatch.setattr(
+            evolve_applier, "_managed_repo_auto_recovery_allowed",
+            lambda p: False,
+        )
     return {"mcp": _mcp.mcp, "db": db, "ea": evolve_applier,
             "identity": identity, "orig": orig}
 
@@ -2183,6 +2190,9 @@ def test_ensure_repo_ready_uses_existing_checkout(tmp_path, monkeypatch):
     tree (provisioned on a prior pass) → ready, no re-provisioning."""
     pkg = _bootstrap(tmp_path, monkeypatch)
     monkeypatch.setattr(pkg["ea"], "_is_git_repo", lambda path: True)
+    monkeypatch.setattr(
+        pkg["ea"], "_managed_repo_auto_recovery_allowed", lambda path: False,
+    )
 
     def _no_provision(dest):
         raise AssertionError("must not provision when a checkout exists")
@@ -2191,6 +2201,139 @@ def test_ensure_repo_ready_uses_existing_checkout(tmp_path, monkeypatch):
     root, err = pkg["ea"]._ensure_repo_ready()
     assert err == ""
     assert root == pkg["ea"]._repo_root()
+
+
+def test_managed_checkout_refreshes_to_latest_origin_base(tmp_path, monkeypatch):
+    """A later pass must branch from the current remote base, not clone day."""
+    pkg = _bootstrap(tmp_path, monkeypatch, pin_repo=False)
+    repo = pkg["ea"]._managed_repo_dir()
+    remote = tmp_path / "remote.git"
+    source = tmp_path / "source"
+
+    def run(*cmd, cwd=None):
+        proc = subprocess.run(
+            list(cmd), cwd=str(cwd) if cwd else None, text=True,
+            capture_output=True, check=False,
+        )
+        if proc.returncode != 0:
+            raise AssertionError(proc.stderr or proc.stdout)
+        return proc
+
+    run("git", "init", "--bare", str(remote))
+    run("git", "init", "-b", "main", str(source))
+    run("git", "config", "user.email", "test@example.com", cwd=source)
+    run("git", "config", "user.name", "Test", cwd=source)
+    (source / "base.txt").write_text("first\n", encoding="utf-8")
+    run("git", "add", "base.txt", cwd=source)
+    run("git", "commit", "-m", "base", cwd=source)
+    run("git", "remote", "add", "origin", str(remote), cwd=source)
+    run("git", "push", "-u", "origin", "main", cwd=source)
+    run("git", "clone", "--branch", "main", str(remote), str(repo))
+    old_head = run("git", "rev-parse", "HEAD", cwd=repo).stdout.strip()
+
+    (source / "upstream.txt").write_text("new base\n", encoding="utf-8")
+    run("git", "add", "upstream.txt", cwd=source)
+    run("git", "commit", "-m", "advance base", cwd=source)
+    run("git", "push", "origin", "main", cwd=source)
+    upstream_head = run("git", "rev-parse", "HEAD", cwd=source).stdout.strip()
+
+    root, err = pkg["ea"]._ensure_repo_ready()
+
+    assert err == ""
+    assert root == repo
+    assert (repo / "upstream.txt").read_text(encoding="utf-8") == "new base\n"
+    assert run("git", "rev-parse", "HEAD", cwd=repo).stdout.strip() == upstream_head
+    assert upstream_head != old_head
+
+
+def test_managed_provision_fails_before_clone_when_disk_is_low(
+    tmp_path, monkeypatch,
+):
+    pkg = _bootstrap(tmp_path, monkeypatch, pin_repo=False)
+    dest = tmp_path / "managed-repo"
+    monkeypatch.setattr(pkg["ea"], "EVOLVE_REPO_MIN_FREE_BYTES", 1024)
+    monkeypatch.setattr(pkg["ea"], "_disk_free_bytes", lambda path: (1023, ""))
+    monkeypatch.setattr(
+        pkg["ea"], "_run",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("must not clone with insufficient disk")
+        ),
+    )
+
+    out = pkg["ea"]._provision_managed_repo(dest)
+
+    assert out.startswith("ERR evolve_disk_low="), out
+    assert "free_bytes=1023" in out and "required_bytes=1024" in out
+
+
+def test_managed_venv_fails_before_install_when_disk_is_low(tmp_path, monkeypatch):
+    pkg = _bootstrap(tmp_path, monkeypatch, pin_repo=False)
+    dest = tmp_path / "managed-repo"
+    dest.mkdir()
+    monkeypatch.setattr(pkg["ea"], "EVOLVE_REPO_MIN_FREE_BYTES", 1024)
+    monkeypatch.setattr(pkg["ea"], "_disk_free_bytes", lambda path: (0, ""))
+    monkeypatch.setattr(
+        pkg["ea"], "_run",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("must not create or install a venv with insufficient disk")
+        ),
+    )
+
+    out = pkg["ea"]._ensure_managed_venv(dest)
+
+    assert out.startswith("ERR evolve_disk_low="), out
+
+
+def test_repo_provision_lock_returns_promptly_when_another_process_holds_it(
+    tmp_path, monkeypatch,
+):
+    pkg = _bootstrap(tmp_path, monkeypatch, pin_repo=False)
+    lock_path = pkg["ea"].DB_PATH.parent / "evolve-repo-provision.lock"
+    ready = tmp_path / "lock-ready"
+    holder = subprocess.Popen([
+        sys.executable,
+        "-c",
+        (
+            "import fcntl, pathlib, sys, time; "
+            "lock=open(sys.argv[1], 'w'); "
+            "fcntl.flock(lock, fcntl.LOCK_EX); "
+            "pathlib.Path(sys.argv[2]).write_text('ready'); "
+            "time.sleep(30)"
+        ),
+        str(lock_path), str(ready),
+    ])
+    try:
+        deadline = time.monotonic() + 5
+        while not ready.exists() and time.monotonic() < deadline:
+            time.sleep(0.01)
+        assert ready.exists(), "lock holder did not become ready"
+        monkeypatch.setattr(pkg["ea"], "EVOLVE_REPO_PROVISION_LOCK_TIMEOUT_S", 0)
+
+        started = time.monotonic()
+        with pkg["ea"]._repo_provision_lock() as err:
+            assert err == "ERR evolve_repo_provisioning_in_progress retry_later=1"
+        assert time.monotonic() - started < 0.5
+    finally:
+        holder.terminate()
+        holder.wait(timeout=5)
+
+
+def test_prune_managed_venv_only_removes_default_managed_environment(
+    tmp_path, monkeypatch,
+):
+    pkg = _bootstrap(tmp_path, monkeypatch, pin_repo=False)
+    venv = pkg["ea"]._managed_repo_dir() / ".venv"
+    venv.mkdir(parents=True)
+    (venv / "payload").write_bytes(b"heavy")
+    monkeypatch.setattr(pkg["ea"], "_running_git_writer_children", lambda conn: [])
+
+    out = pkg["ea"].prune_managed_venv()
+
+    assert out == "ok evolve_managed_venv_pruned freed_bytes=5"
+    assert not venv.exists()
+    assert _tool(pkg, "evolve_prune_managed_venv")(confirm=False).startswith(
+        "ERR confirmation_required"
+    )
 
 
 def test_ensure_repo_ready_auto_clones_when_missing(tmp_path, monkeypatch):

--- a/tests/test_release_workflows.py
+++ b/tests/test_release_workflows.py
@@ -94,3 +94,22 @@ def test_glama_dockerfile_pin_matches_the_project_release():
     version = tomllib.loads((ROOT / "pyproject.toml").read_text())["project"]["version"]
 
     assert f"threadkeeper=={version}" in DOCKERFILE.read_text()
+
+
+def test_mcp_requirement_is_capped_while_the_1x_import_path_is_used():
+    # mcp 2.0.0 renamed `mcp.server.fastmcp` -> `mcp.server.mcpserver`
+    # (FastMCP -> MCPServer) with no shim, so an unbounded `mcp>=1.10.0`
+    # made every fresh resolve die at import. Keep the cap and the import
+    # path in lockstep: whoever migrates to the 2.x API drops both.
+    importers = [
+        ROOT / "threadkeeper" / "_mcp.py",
+        ROOT / "threadkeeper" / "elicitation.py",
+        ROOT / "threadkeeper" / "tools" / "dialectic.py",
+    ]
+    if not any("mcp.server.fastmcp" in p.read_text() for p in importers):
+        return  # migrated to the 2.x API — the cap is free to go.
+
+    deps = tomllib.loads((ROOT / "pyproject.toml").read_text())["project"]["dependencies"]
+    mcp_req = next(d for d in deps if d.split(">")[0].split("<")[0].strip() == "mcp")
+
+    assert "<2" in mcp_req, f"mcp requirement must exclude 2.x, got {mcp_req!r}"

--- a/tests/test_tool_annotations.py
+++ b/tests/test_tool_annotations.py
@@ -42,7 +42,8 @@ READ_TOOLS = {
 DELETE_CLASS_TOOLS = {
     "agent_memory_cleanup", "concept_manage", "consolidate", "core_remove",
     "curator_restore", "curator_run", "forget", "lesson_remove",
-    "memory_guard_check", "mp_cleanup", "skill_manage", "unlink",
+    "evolve_prune_managed_venv", "memory_guard_check", "mp_cleanup",
+    "skill_manage", "unlink",
 }
 
 # --- non-destructive mutating tools ------------------------------------------

--- a/threadkeeper/config.py
+++ b/threadkeeper/config.py
@@ -410,6 +410,13 @@ class Settings(BaseSettings):
     # tracks. Defaults to the upstream thread-keeper project.
     evolve_repo_url: str = "https://github.com/po4erk91/thread-keeper"
     evolve_repo_branch: str = "main"
+    # Fail before a managed clone / its heavyweight semantic+dev venv can
+    # consume the last free space on a host. 0 deliberately disables the
+    # guard for constrained test or operator-managed environments.
+    evolve_repo_min_free_bytes: int = Field(default=5 * 1024 ** 3, ge=0)
+    # A provisioning winner can spend many minutes in pip. Never leave a
+    # foreground MCP call blocked behind that work indefinitely.
+    evolve_repo_provision_lock_timeout_s: float = Field(default=5.0, ge=0)
     # After posting a roadmap-issue claim comment, wait this long, re-fetch
     # comments, and retract our claim if another host raced us. Cross-host
     # TOCTOU guard. Set to 0 in tests to skip the wait.
@@ -844,6 +851,10 @@ def _derive_constants(s: "Settings") -> dict:
         "EVOLVE_AUTO_CLONE": s.evolve_auto_clone,
         "EVOLVE_REPO_URL": s.evolve_repo_url,
         "EVOLVE_REPO_BRANCH": s.evolve_repo_branch,
+        "EVOLVE_REPO_MIN_FREE_BYTES": s.evolve_repo_min_free_bytes,
+        "EVOLVE_REPO_PROVISION_LOCK_TIMEOUT_S": (
+            s.evolve_repo_provision_lock_timeout_s
+        ),
         "ROADMAP_CLAIM_RACE_WINDOW_S": s.roadmap_claim_race_window_s,
         "EVOLVE_TRUSTED_AUTHOR_ASSOCIATIONS": (
             s.evolve_trusted_author_associations

--- a/threadkeeper/evolve_applier.py
+++ b/threadkeeper/evolve_applier.py
@@ -48,15 +48,18 @@ from __future__ import annotations
 
 from contextlib import contextmanager
 from datetime import datetime, timezone
+import errno
 import json
 import logging
+import os
 import re
+import shutil
 import sqlite3
 import subprocess
 import threading
 import time
 from pathlib import Path
-from typing import Optional
+from typing import Iterator, Optional
 
 from .config import (
     CURATOR_REPORTS_DIR,
@@ -65,6 +68,8 @@ from .config import (
     EVOLVE_AUTO_CLONE,
     EVOLVE_APPLY_SKIP_LABELS,
     EVOLVE_REPO_BRANCH,
+    EVOLVE_REPO_MIN_FREE_BYTES,
+    EVOLVE_REPO_PROVISION_LOCK_TIMEOUT_S,
     EVOLVE_REPO_ROOT,
     EVOLVE_REPO_URL,
     EVOLVE_TRUST_LABELS,
@@ -465,6 +470,7 @@ or:
 
 EVOLVE_CLONE_TIMEOUT_S = 600
 EVOLVE_VENV_TIMEOUT_S = 1800
+EVOLVE_REPO_PROVISION_LOCK_POLL_S = 0.05
 
 
 def _managed_repo_dir() -> Path:
@@ -540,21 +546,44 @@ def _autoclone_disabled_error(root: Path) -> str:
 
 
 @contextmanager
-def _repo_provision_lock():
-    """Serialize clone/venv provisioning across foreground servers so two ticks
-    don't race a half-finished clone into the same managed dir. Blocking: the
-    loser waits, then re-checks under the lock and reuses the finished clone."""
+def _repo_provision_lock() -> Iterator[str]:
+    """Acquire the managed-checkout lock, with a bounded wait.
+
+    Clone and pip-install work can take many minutes. A competing foreground
+    tool gets a retryable ERR instead of waiting behind that entire operation.
+    The yielded string is empty when this caller owns the lock.
+    """
     try:
         import fcntl
     except ImportError:  # pragma: no cover - thread-keeper runs on Unix CLIs.
-        yield
+        yield ""
         return
     lock_path = DB_PATH.parent / "evolve-repo-provision.lock"
-    lock_path.parent.mkdir(parents=True, exist_ok=True)
-    with lock_path.open("w") as lock:
-        fcntl.flock(lock.fileno(), fcntl.LOCK_EX)
+    try:
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+        lock = lock_path.open("w")
+    except OSError as e:
+        yield f"ERR evolve_repo_provision_lock_failed={_short(str(e))}"
+        return
+    with lock:
+        deadline = time.monotonic() + max(
+            0.0, float(EVOLVE_REPO_PROVISION_LOCK_TIMEOUT_S)
+        )
+        while True:
+            try:
+                fcntl.flock(lock.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+                break
+            except OSError as e:
+                if e.errno not in (errno.EACCES, errno.EAGAIN):
+                    yield f"ERR evolve_repo_provision_lock_failed={_short(str(e))}"
+                    return
+                if time.monotonic() >= deadline:
+                    yield "ERR evolve_repo_provisioning_in_progress retry_later=1"
+                    return
+                time.sleep(min(EVOLVE_REPO_PROVISION_LOCK_POLL_S,
+                               max(0.0, deadline - time.monotonic())))
         try:
-            yield
+            yield ""
         finally:
             fcntl.flock(lock.fileno(), fcntl.LOCK_UN)
 
@@ -589,6 +618,85 @@ def _base_branch_name() -> str:
 
 def _base_ref() -> str:
     return f"origin/{_base_branch_name()}"
+
+
+def _disk_free_bytes(path: Path) -> tuple[int, str]:
+    """Return free bytes on the nearest existing parent of ``path``."""
+    probe = path.expanduser()
+    while not probe.exists() and probe != probe.parent:
+        probe = probe.parent
+    try:
+        return int(shutil.disk_usage(probe).free), ""
+    except OSError as e:
+        return 0, _short(str(e))
+
+
+def _managed_disk_preflight(path: Path) -> str:
+    """Fail before clone/venv work when the configured disk reserve is absent."""
+    required = max(0, int(EVOLVE_REPO_MIN_FREE_BYTES))
+    if required == 0:
+        return ""
+    free, err = _disk_free_bytes(path)
+    if err:
+        return f"ERR evolve_disk_preflight_failed={path}: {err}"
+    if free < required:
+        return (
+            f"ERR evolve_disk_low={path} free_bytes={free} "
+            f"required_bytes={required} (set "
+            "THREADKEEPER_EVOLVE_REPO_MIN_FREE_BYTES=0 to disable)"
+        )
+    return ""
+
+
+def _tree_size(path: Path, *, skip_top_level: set[str] | None = None) -> int:
+    """Best-effort allocated-file estimate without following symlinks."""
+    skip_top_level = skip_top_level or set()
+
+    def walk(current: Path, *, top: bool = False) -> int:
+        try:
+            with os.scandir(current) as entries:
+                total = 0
+                for entry in entries:
+                    if top and entry.name in skip_top_level:
+                        continue
+                    try:
+                        if entry.is_symlink():
+                            continue
+                        if entry.is_dir(follow_symlinks=False):
+                            total += walk(Path(entry.path))
+                        else:
+                            total += int(entry.stat(follow_symlinks=False).st_size)
+                    except OSError:
+                        continue
+                return total
+        except OSError:
+            return 0
+
+    if path.is_symlink():
+        return 0
+    if path.is_dir():
+        return walk(path, top=True)
+    try:
+        return int(path.stat().st_size)
+    except OSError:
+        return 0
+
+
+def managed_repo_storage_status() -> dict[str, int | str]:
+    """Best-effort default managed-checkout footprint for status surfaces."""
+    root = _managed_repo_dir()
+    venv = root / ".venv"
+    free, free_err = _disk_free_bytes(root.parent)
+    repo_bytes = _tree_size(root, skip_top_level={".venv"})
+    venv_bytes = _tree_size(venv)
+    return {
+        "state": "present" if root.exists() else "absent",
+        "repo_bytes": repo_bytes,
+        "venv_bytes": venv_bytes,
+        "total_bytes": repo_bytes + venv_bytes,
+        "free_bytes": free,
+        "free_error": free_err,
+    }
 
 
 def _tracked_worktree_status(repo_root: Path) -> tuple[str, str]:
@@ -1058,6 +1166,9 @@ def _ensure_managed_venv(dest: Path) -> str:
     venv_py = dest / ".venv" / "bin" / "python"
     if venv_py.exists():
         return ""
+    space_err = _managed_disk_preflight(dest)
+    if space_err:
+        return space_err
     err = _run([sys.executable, "-m", "venv", str(dest / ".venv")],
                EVOLVE_VENV_TIMEOUT_S)
     if err:
@@ -1074,7 +1185,9 @@ def _provision_managed_repo(dest: Path) -> str:
     """Clone the canonical repo into `dest` and provision its venv. Serialized
     and idempotent: re-checks under the lock so a concurrent winner's clone is
     reused. Returns '' on success or an ERR string."""
-    with _repo_provision_lock():
+    with _repo_provision_lock() as lock_err:
+        if lock_err:
+            return lock_err
         if _is_git_repo(dest):
             return _ensure_managed_venv(dest)
         if dest.exists() and any(dest.iterdir()):
@@ -1083,6 +1196,9 @@ def _provision_managed_repo(dest: Path) -> str:
                 "non-empty non-git directory; clear it or set "
                 "THREADKEEPER_EVOLVE_REPO_ROOT)"
             )
+        space_err = _managed_disk_preflight(dest.parent)
+        if space_err:
+            return space_err
         dest.parent.mkdir(parents=True, exist_ok=True)
         err = _run(
             ["git", "clone", "--quiet", "--branch", str(EVOLVE_REPO_BRANCH),
@@ -1094,12 +1210,57 @@ def _provision_managed_repo(dest: Path) -> str:
         return _ensure_managed_venv(dest)
 
 
+def _refresh_managed_repo(dest: Path) -> str:
+    """Fast-forward only the disposable managed checkout to its base branch.
+
+    Explicit checkout roots are never routed here. A clean but old applier
+    branch is safe to replace after its child has ended; tracked edits and live
+    writers fail closed instead of being reset underneath their owner.
+    """
+    with _repo_provision_lock() as lock_err:
+        if lock_err:
+            return lock_err
+        if not _is_git_repo(dest):
+            return "ERR evolve_repo_refresh_missing_checkout"
+        dirty, status_err = _tracked_worktree_status(dest)
+        if status_err:
+            return f"ERR evolve_repo_refresh_status_failed={_short(status_err)}"
+        if dirty:
+            return "ERR evolve_repo_refresh_blocked_dirty"
+        try:
+            running = _running_git_writer_children(get_db())
+        except Exception as e:  # noqa: BLE001 — fail closed before a reset.
+            return f"ERR evolve_repo_refresh_running_check_failed={_short(str(e))}"
+        if running:
+            return f"ERR evolve_repo_refresh_in_use n={len(running)}"
+        branch = _base_branch_name()
+        fetch_err = _run(["git", "fetch", "origin", branch], 60, cwd=dest)
+        if fetch_err:
+            return f"ERR evolve_repo_refresh_fetch_failed={_short(fetch_err)}"
+        checkout_err = _run(["git", "checkout", "-f", branch], 30, cwd=dest)
+        if checkout_err:
+            return f"ERR evolve_repo_refresh_checkout_failed={_short(checkout_err)}"
+        reset_err = _run(
+            ["git", "reset", "--hard", _base_ref()], 30, cwd=dest
+        )
+        if reset_err:
+            return f"ERR evolve_repo_refresh_reset_failed={_short(reset_err)}"
+    return ""
+
+
 def _ensure_repo_ready() -> tuple[Path, str]:
     """Resolve the repo root and make sure it is a usable git checkout, cloning
     a managed one on first use when needed. Returns (root, error); error is ''
     on success. This is the gate every code/PR path and the reviewer call."""
     root = _resolve_repo_root()
     if _is_git_repo(root):
+        # A real git probe necessarily implies an extant directory. The extra
+        # existence check keeps this best-effort gate tolerant of a checkout
+        # disappearing between probes (and of lightweight test doubles).
+        if root.exists() and _managed_repo_auto_recovery_allowed(root):
+            refresh_err = _refresh_managed_repo(root)
+            if refresh_err:
+                return root, refresh_err
         return root, ""
     if (EVOLVE_REPO_ROOT or "").strip():
         # Explicit override that isn't a checkout — never auto-clone there.
@@ -1110,6 +1271,40 @@ def _ensure_repo_ready() -> tuple[Path, str]:
     if err:
         return root, err
     return root, ""
+
+
+def prune_managed_venv() -> str:
+    """Delete only the default managed `.venv` after an explicit GC request.
+
+    The next managed pass recreates it. Explicit operator checkouts and
+    auto-clone-disabled installations are rejected so this cannot target a
+    developer's chosen checkout.
+    """
+    root = _managed_repo_dir()
+    if not _managed_repo_auto_recovery_allowed(root):
+        return "ERR evolve_managed_venv_prune_unavailable"
+    venv = root / ".venv"
+    if venv.is_symlink():
+        return "ERR evolve_managed_venv_prune_refused_symlink"
+    with _repo_provision_lock() as lock_err:
+        if lock_err:
+            return lock_err
+        if not venv.exists():
+            return "ok evolve_managed_venv_absent"
+        if not venv.is_dir() or venv.is_symlink():
+            return "ERR evolve_managed_venv_prune_refused_invalid_path"
+        try:
+            running = _running_git_writer_children(get_db())
+        except Exception as e:  # noqa: BLE001 — do not prune on uncertainty.
+            return f"ERR evolve_managed_venv_prune_running_check_failed={_short(str(e))}"
+        if running:
+            return f"ERR evolve_managed_venv_prune_in_use n={len(running)}"
+        freed = _tree_size(venv)
+        try:
+            shutil.rmtree(venv)
+        except OSError as e:
+            return f"ERR evolve_managed_venv_prune_failed={_short(str(e))}"
+    return f"ok evolve_managed_venv_pruned freed_bytes={freed}"
 
 
 def _slug(text: str, maxlen: int = 32) -> str:

--- a/threadkeeper/tools/dashboard.py
+++ b/threadkeeper/tools/dashboard.py
@@ -32,6 +32,7 @@ from ..agent_status import _LOOP_DEFS
 from ..agent_status import daemon_liveness_statuses
 from ..config import DB_PATH
 from ..db import get_db
+from ..evolve_applier import managed_repo_storage_status
 from ..helpers import fmt_age
 from ..identity import _ensure_session
 
@@ -300,6 +301,19 @@ def mp_dashboard(window_days: int = 7) -> str:
         f"  db_size={_fmt_bytes(db_total)} "
         f"main={_fmt_bytes(db_main)} wal={_fmt_bytes(db_wal)} "
         f"shm={_fmt_bytes(db_shm)}"
+    )
+    managed = managed_repo_storage_status()
+    free = (
+        _fmt_bytes(int(managed["free_bytes"]))
+        if not managed["free_error"] else "unavailable"
+    )
+    out.append(
+        "  managed_checkout: "
+        f"state={managed['state']} "
+        f"repo={_fmt_bytes(int(managed['repo_bytes']))} "
+        f"venv={_fmt_bytes(int(managed['venv_bytes']))} "
+        f"total={_fmt_bytes(int(managed['total_bytes']))} "
+        f"free={free}"
     )
     out.append(
         f"  threads: {_fmt_group(threads, ('active','idle','closed'))} "

--- a/threadkeeper/tools/evolve_applier.py
+++ b/threadkeeper/tools/evolve_applier.py
@@ -29,6 +29,11 @@
   evolve_apply_status()
     Diagnostic: interval knob, promoted+unapplied queue, running applier, and
     the last few apply/recovery passes.
+
+  evolve_prune_managed_venv(confirm=True)
+    Explicitly delete the default managed checkout's heavyweight virtualenv.
+    The next managed pass recreates it; operator-specified checkouts are never
+    eligible.
 """
 
 from __future__ import annotations
@@ -49,6 +54,7 @@ from ..evolve_applier import (
     mark_curator_report_applied,
     mark_applied,
     mark_roadmap_issue_applied,
+    prune_managed_venv,
     roadmap_attempt_ledger,
     _conflicted_applier_prs,
     _format_label_skip,
@@ -122,6 +128,22 @@ def evolve_apply_conflicted_pr(pr_number: int = 0) -> str:
     conn = get_db()
     _ensure_session(conn)
     return apply_conflicted_pr(int(pr_number or 0))
+
+
+@write_tool(destructive=True, idempotent=True)
+def evolve_prune_managed_venv(confirm: bool = False) -> str:
+    """Free the default managed checkout's `.venv` after explicit confirmation.
+
+    Pass `confirm=True` to delete only that auto-managed virtualenv. Its clone
+    remains intact and the next Evolve pass rebuilds the environment. This
+    refuses `THREADKEEPER_EVOLVE_REPO_ROOT` and auto-clone-disabled setups, so
+    it never prunes an operator-selected checkout.
+    """
+    if not confirm:
+        return "ERR confirmation_required pass confirm=true to prune managed .venv"
+    conn = get_db()
+    _ensure_session(conn)
+    return prune_managed_venv()
 
 
 @write_tool(idempotent=True)


### PR DESCRIPTION
Refreshes the default managed checkout to its configured origin base before code-producing passes, while preserving explicit checkout safety.\n\nAdds low-disk preflight, bounded provisioning-lock retries, dashboard footprint telemetry, and an explicit managed-venv prune tool.\n\nTests: env -u THREADKEEPER_NO_EMBEDDINGS .venv/bin/python -m pytest -q\n\nCloses #128