### PR TITLE
fix: deduplicate roadmap issue claim checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ version bumps follow semver per the policy in
 [CONTRIBUTING.md → Releases](CONTRIBUTING.md#releases).
 
 ## [Unreleased]
+- **Fixed: evolve-applier roadmap dispatch no longer double-fetches and
+  claim-checks the whole backlog (#131).** A due pass now reuses one paginated
+  open-issue snapshot for selection and dispatch; roadmap-label/FIFO sorting
+  happens before the existing per-start claim/open-PR/race guards, so comment
+  requests are limited to candidates actually attempted.
 - **Fixed: pinned the MCP SDK below 2.0.** `mcp` 2.0.0 (2026-07-28) renamed
   `mcp.server.fastmcp` to `mcp.server.mcpserver` (`FastMCP` → `MCPServer`) with
   no compatibility shim, so every fresh install resolving the unbounded

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -572,7 +572,11 @@ moving the high-water forward; `force=True` bypasses this due gate.
   (`roadmap`-labeled issues first, then FIFO by issue number) applies across
   the open backlog rather than only the newest page. A generous local candidate
   window is retained as a runaway guard; if exceeded, a warning logs the number
-  of open issues outside the window. The applier then spawns one
+  of open issues outside the window. Each pass reuses that one candidate
+  snapshot for dispatch, then reads claim comments lazily only for candidates
+  it actually tries (normally the selected issue's initial claim check and
+  post-claim race check). This avoids a second open-issue fetch and a
+  per-backlog-item claim-comment fan-out before the applier spawns one
   `evolve_applier` child to implement exactly one issue.
   **Shared GitHub budget (#38):** parent `gh` calls and the privileged child
   PATH `gh` wrapper consult `github_rate_budget` before every request. Included

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -669,6 +669,9 @@ Follow-up gaps from the 2026-06-17 audit:
 - Transcript secret scrubbing before persistence into `dialog_messages` /
   `dialog_fts` (#37).
 - ✅ DONE (#38). Shared GitHub API budget/backoff across roadmap automation.
+- ✅ DONE (#131). Evolve applier roadmap selection now reuses one issue-list
+  snapshot per pass and checks active claims lazily in priority order, avoiding
+  duplicate full-backlog reads and per-candidate comment fan-out.
 - ✅ DONE (#40). Curator went **destructive-by-default**
   (`THREADKEEPER_CURATOR_DESTRUCTIVE=1`), so the autonomous child needed a
   recovery path before pruning/consolidating lessons + skills in place. A

--- a/tests/test_evolve_applier.py
+++ b/tests/test_evolve_applier.py
@@ -54,6 +54,7 @@ def _bootstrap(tmp_path, monkeypatch, interval="0", pin_repo=True):
     # exercise the unstubbed gh/REST paths can restore them.
     orig = {
         "_fetch_open_issues": evolve_applier._fetch_open_issues,
+        "_fetch_issue_comments": evolve_applier._fetch_issue_comments,
         "_fetch_open_prs": evolve_applier._fetch_open_prs,
         "_comment_issue_claim": evolve_applier._comment_issue_claim,
         "_git_worktree_precondition": evolve_applier._git_worktree_precondition,
@@ -604,7 +605,7 @@ def test_open_roadmap_issues_requeued_marker_obeys_attempt_cap(
     assert (state, attempts) == ("dead_letter", 1)
 
 
-def test_open_roadmap_issues_skips_active_issue_claim(
+def test_open_roadmap_issues_defers_claim_reads_until_dispatch(
     tmp_path, monkeypatch,
 ):
     pkg = _bootstrap(tmp_path, monkeypatch)
@@ -621,24 +622,20 @@ def test_open_roadmap_issues_skips_active_issue_claim(
     )
 
     def _comments(issue_number, repo_root=None):
-        if int(issue_number) == 1:
-            return ([_claim_comment()], "")
-        return ([], "")
+        raise AssertionError("candidate collection must not read claim comments")
 
     monkeypatch.setattr(pkg["ea"], "_fetch_issue_comments", _comments)
-    monkeypatch.setattr(pkg["ea"].time, "time", lambda: 1781438400.0)
 
     issues, err = pkg["ea"]._open_roadmap_issues(conn)
 
     assert err == ""
-    assert [int(i["number"]) for i in issues] == [2]
+    assert [int(i["number"]) for i in issues] == [1, 2]
 
 
-def test_open_roadmap_issues_allows_stale_issue_claim(
+def test_apply_roadmap_issue_allows_stale_claim(
     tmp_path, monkeypatch,
 ):
     pkg = _bootstrap(tmp_path, monkeypatch)
-    conn = pkg["db"].get_db()
     monkeypatch.setattr(
         pkg["ea"], "_fetch_open_issues",
         lambda repo_root=None: ([_issue(1, "stale claim")], ""),
@@ -651,11 +648,13 @@ def test_open_roadmap_issues_allows_stale_issue_claim(
         ),
     )
     monkeypatch.setattr(pkg["ea"].time, "time", lambda: 1781438400.0)
+    calls = {}
+    _mock_spawn(monkeypatch, calls)
 
-    issues, err = pkg["ea"]._open_roadmap_issues(conn)
+    out = pkg["ea"].apply_roadmap_issue()
 
-    assert err == ""
-    assert [int(i["number"]) for i in issues] == [1]
+    assert out.startswith("spawned roadmap_issue=#1"), out
+    assert "ISSUE #1: stale claim" in calls["prompt"]
 
 
 def test_open_roadmap_issues_skips_untrusted_author(tmp_path, monkeypatch):
@@ -731,7 +730,7 @@ def test_open_roadmap_issues_exact_mode_bypasses_author_gate(
     assert [int(i["number"]) for i in gated] == []
 
     promoted, err = pkg["ea"]._open_roadmap_issues(
-        conn, skip_claimed=False, enforce_author_trust=False,
+        conn, enforce_author_trust=False,
     )
     assert err == ""
     assert [int(i["number"]) for i in promoted] == [7]
@@ -2001,6 +2000,68 @@ def test_run_apply_pass_picks_roadmap_issue_before_curator_and_evolve(
     assert out.startswith("spawned roadmap_issue=#2"), out
     assert "ISSUE #2: Hot config" in calls["prompt"]
     assert "Curator REPORT" not in calls["prompt"]
+
+
+def test_run_apply_pass_reuses_issue_snapshot_and_checks_claims_lazily(
+    tmp_path, monkeypatch,
+):
+    """One due pass reads the backlog once and only claim-checks its pick."""
+    pkg = _bootstrap(tmp_path, monkeypatch)
+    monkeypatch.setattr(
+        pkg["ea"], "_fetch_open_issues", pkg["orig"]["_fetch_open_issues"],
+    )
+    monkeypatch.setattr(
+        pkg["ea"], "_fetch_issue_comments",
+        pkg["orig"]["_fetch_issue_comments"],
+    )
+    calls = []
+
+    def _run_gh(cmd, **kwargs):
+        calls.append(cmd)
+        if cmd[:2] == ["gh", "api"]:
+            return subprocess.CompletedProcess(
+                cmd, 0,
+                stdout=json.dumps([
+                    _rest_issue(3, "ordinary issue", labels=("enhancement",)),
+                    _rest_issue(2, "later roadmap issue"),
+                    _rest_issue(1, "first roadmap issue"),
+                ]),
+                stderr="",
+            )
+        if cmd[:3] == ["gh", "issue", "view"]:
+            return subprocess.CompletedProcess(
+                cmd, 0, stdout=json.dumps({"comments": []}), stderr="",
+            )
+        if cmd[:3] == ["gh", "issue", "comment"]:
+            return subprocess.CompletedProcess(
+                cmd, 0,
+                stdout="https://github.com/o/r/issues/1#issuecomment-1\n",
+                stderr="",
+            )
+        if cmd[:3] == ["gh", "pr", "list"]:
+            return subprocess.CompletedProcess(cmd, 0, stdout="[]", stderr="")
+        raise AssertionError(f"unexpected gh command: {cmd}")
+
+    monkeypatch.setattr(pkg["ea"], "_run_gh", _run_gh)
+    spawn_calls = {}
+    _mock_spawn(monkeypatch, spawn_calls)
+
+    out = pkg["ea"].run_evolve_apply_pass(force=True)
+
+    assert out.startswith("spawned roadmap_issue=#1"), out
+    assert "ISSUE #1: first roadmap issue" in spawn_calls["prompt"]
+    issue_list_calls = [
+        cmd for cmd in calls
+        if cmd[:2] == ["gh", "api"] and "/issues?state=open" in cmd[-1]
+    ]
+    claim_view_calls = [
+        cmd for cmd in calls if cmd[:3] == ["gh", "issue", "view"]
+    ]
+    assert len(issue_list_calls) == 1
+    # The selected issue gets its initial and post-claim race checks; no other
+    # backlog candidate has its comments read.
+    assert len(claim_view_calls) == 2
+    assert {cmd[3] for cmd in claim_view_calls} == {"1"}
 
 
 def test_run_apply_pass_repairs_conflicted_pr_before_new_work(

--- a/threadkeeper/evolve_applier.py
+++ b/threadkeeper/evolve_applier.py
@@ -2417,14 +2417,12 @@ def _open_roadmap_issues(
     conn: sqlite3.Connection,
     repo_root: Optional[Path] = None,
     *,
-    skip_claimed: bool = True,
     enforce_author_trust: bool = True,
     skip_backoff: bool = True,
     flag_dead_letter: bool = False,
 ) -> tuple[list[dict], str]:
     issues, err, _ = _open_roadmap_issue_candidates(
         conn, repo_root,
-        skip_claimed=skip_claimed,
         enforce_author_trust=enforce_author_trust,
         skip_backoff=skip_backoff,
         flag_dead_letter=flag_dead_letter,
@@ -2436,7 +2434,6 @@ def _open_roadmap_issue_candidates(
     conn: sqlite3.Connection,
     repo_root: Optional[Path] = None,
     *,
-    skip_claimed: bool = True,
     enforce_author_trust: bool = True,
     skip_backoff: bool = True,
     flag_dead_letter: bool = False,
@@ -2444,11 +2441,12 @@ def _open_roadmap_issue_candidates(
     """Open GitHub issues not already handed off by evolve_applier.
 
     The user treats all open issues as roadmap backlog; issues with the
-    explicit `roadmap` label are prioritized first, then FIFO by number. Active
-    issue-claim comments are skipped so multiple appliers do not start the same
-    item in parallel. The upstream issue fetch is paginated oldest-first before
-    this sort, so FIFO applies across the whole visible backlog rather than a
-    newest-first GitHub CLI window.
+    explicit `roadmap` label are prioritized first, then FIFO by number. Claim
+    comments are deliberately not read here: the per-start guard checks each
+    candidate lazily, after sorting, so a pass does not fan out one GitHub
+    comment request across the full backlog. The upstream issue fetch is
+    paginated oldest-first before this sort, so FIFO applies across the whole
+    visible backlog rather than a newest-first GitHub CLI window.
 
     When `enforce_author_trust` is set (the autonomous-drain default), issues
     whose author is not trusted (`_issue_author_trusted`) are skipped — this
@@ -2470,7 +2468,6 @@ def _open_roadmap_issue_candidates(
     if err:
         return [], err, []
     out: list[dict] = []
-    claim_errors: list[str] = []
     applied_errors: list[str] = []
     untrusted: list[int] = []
     label_skipped: list[tuple[int, str]] = []
@@ -2502,15 +2499,6 @@ def _open_roadmap_issue_candidates(
                 continue
             if state == "backoff":
                 continue
-        if skip_claimed:
-            claimed, claim_err = _issue_has_active_claim(
-                num, repo_root, now_t
-            )
-            if claim_err:
-                claim_errors.append(f"#{num}: {claim_err}")
-                continue
-            if claimed:
-                continue
         out.append(issue)
     out.sort(
         key=lambda issue: (
@@ -2525,14 +2513,11 @@ def _open_roadmap_issue_candidates(
             len(untrusted),
             ", ".join(f"#{n}" for n in untrusted[:20]),
         )
-    if not out and (claim_errors or applied_errors):
+    if not out and applied_errors:
         parts = []
         if applied_errors:
             parts.append("roadmap_issue_applied_check_failed: "
                          + "; ".join(applied_errors)[:240])
-        if claim_errors:
-            parts.append("roadmap_issue_claim_check_failed: "
-                         + "; ".join(claim_errors)[:240])
         return [], " | ".join(parts), label_skipped
     return out, "", label_skipped
 
@@ -2962,7 +2947,12 @@ def _roadmap_dispatch_can_try_next(status: str) -> bool:
     ))
 
 
-def apply_roadmap_issue(issue_number: int = 0) -> str:
+def apply_roadmap_issue(
+    issue_number: int = 0,
+    *,
+    queued_issues: Optional[list[dict]] = None,
+    queued_label_skipped: Optional[list[tuple[int, str]]] = None,
+) -> str:
     """Spawn an evolve_applier child to implement one open GitHub issue.
 
     With issue_number=0, this is queue mode: try candidates in roadmap/FIFO
@@ -2988,16 +2978,21 @@ def apply_roadmap_issue(issue_number: int = 0) -> str:
         # Queue mode honours the backoff/dead-letter gate and flags poison
         # issues; exact mode is a deliberate human override that ignores it.
         # Label-denylisted issues are skipped in both modes; exact mode reports
-        # that skip explicitly instead of switching tasks.
-        issues, err, label_skipped = _open_roadmap_issue_candidates(
-            conn, repo_root,
-            skip_claimed=not exact,
-            enforce_author_trust=not exact,
-            skip_backoff=not exact,
-            flag_dead_letter=not exact,
-        )
-        if err:
-            return f"ERR roadmap_issue_fetch_failed: {err}"
+        # that skip explicitly instead of switching tasks. A daemon pass can
+        # provide its single already-fetched snapshot, avoiding a second full
+        # GitHub issue sweep before dispatch.
+        if queued_issues is None:
+            issues, err, label_skipped = _open_roadmap_issue_candidates(
+                conn, repo_root,
+                enforce_author_trust=not exact,
+                skip_backoff=not exact,
+                flag_dead_letter=not exact,
+            )
+            if err:
+                return f"ERR roadmap_issue_fetch_failed: {err}"
+        else:
+            issues = list(queued_issues)
+            label_skipped = list(queued_label_skipped or [])
         if exact:
             if _roadmap_issue_applied(conn, int(issue_number)):
                 return f"ERR roadmap_issue_already_applied={int(issue_number)}"
@@ -3295,7 +3290,10 @@ def run_evolve_apply_pass(force: bool = False) -> str:
     if label_skipped and not issues:
         _record_roadmap_issue_skipped(conn, label_skipped)
     if issues:
-        out = apply_roadmap_issue()
+        out = apply_roadmap_issue(
+            queued_issues=issues,
+            queued_label_skipped=label_skipped,
+        )
         if out.startswith("spawned roadmap_issue=") or out.startswith(
             "applier_running"
         ):


### PR DESCRIPTION
## Summary
- reuse a due pass's single roadmap-issue snapshot for dispatch
- defer claim comment reads until each priority candidate is attempted
- cover the GitHub call profile and document it

## Tests
- env -u THREADKEEPER_NO_EMBEDDINGS THREADKEEPER_BRIEF_LEAN=0 THREADKEEPER_BRIEF_NO_THREAD_NUDGE=0 .venv/bin/python -m pytest -q

Closes #131