### PR TITLE
fix: parse Copilot timestamps as UTC

### DIFF
--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -8,8 +8,11 @@ For each adapter we verify:
 from __future__ import annotations
 
 import json
+import os
 import sqlite3
 import sys
+import time
+from datetime import datetime, timezone
 from pathlib import Path
 
 import pytest
@@ -738,3 +741,24 @@ def test_copilot_iter_messages_splits_turns(tmp_path, monkeypatch):
     assert msgs[1].role == "assistant" and msgs[1].content == "hi there"
     assert msgs[2].role == "user" and msgs[2].content == "do X"
     assert msgs[3].role == "assistant" and msgs[3].content == "done"
+
+
+@pytest.mark.skipif(not hasattr(time, "tzset"), reason="requires POSIX TZ support")
+@pytest.mark.parametrize("local_tz", ["UTC", "America/Los_Angeles"])
+def test_copilot_naive_utc_timestamp_is_independent_of_local_tz(
+    tmp_path, monkeypatch, local_tz,
+):
+    _bootstrap(tmp_path, monkeypatch)
+    copilot_module = sys.modules["threadkeeper.adapters.copilot"]
+    expected = int(datetime(2026, 6, 17, 12, tzinfo=timezone.utc).timestamp())
+    original_tz = os.environ.get("TZ")
+    try:
+        monkeypatch.setenv("TZ", local_tz)
+        time.tzset()
+        assert copilot_module._ts("2026-06-17 12:00:00") == expected
+    finally:
+        if original_tz is None:
+            monkeypatch.delenv("TZ", raising=False)
+        else:
+            monkeypatch.setenv("TZ", original_tz)
+        time.tzset()

--- a/threadkeeper/adapters/copilot.py
+++ b/threadkeeper/adapters/copilot.py
@@ -33,7 +33,7 @@ import shutil
 import sqlite3
 import subprocess
 import re
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Iterator
 
@@ -42,12 +42,18 @@ from .base import CLIAdapter, NormalizedMessage, find_cli_executable
 
 def _ts(s: str) -> int:
     try:
-        return int(datetime.fromisoformat(s.replace("Z", "+00:00")).timestamp())
+        dt = datetime.fromisoformat(s.replace("Z", "+00:00"))
+        if dt.tzinfo is None:
+            # Copilot's SQLite timestamps omit a timezone but are UTC.
+            dt = dt.replace(tzinfo=timezone.utc)
+        return int(dt.timestamp())
     except Exception:
         try:
             # Copilot stores timestamps via sqlite's datetime('now')
             # which yields 'YYYY-MM-DD HH:MM:SS' (no T, no tz).
-            return int(datetime.strptime(s, "%Y-%m-%d %H:%M:%S").timestamp())
+            return int(datetime.strptime(
+                s, "%Y-%m-%d %H:%M:%S"
+            ).replace(tzinfo=timezone.utc).timestamp())
         except Exception:
             import time
             return int(time.time())


### PR DESCRIPTION
## Summary
- Treat timezone-less Copilot SQLite transcript timestamps as UTC.
- Add regression coverage under UTC and America/Los_Angeles.

## Tests
- `env -u THREADKEEPER_NO_EMBEDDINGS .venv/bin/python -m pytest -q` (1401 passed, 3 skipped)

Closes #140