### PR TITLE
fix: atomically update CLI configuration

### DIFF
--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -100,6 +100,36 @@ def test_claude_register_mcp_writes_config(tmp_path, monkeypatch):
     assert "already current" in result2
 
 
+def test_claude_config_write_failure_preserves_existing_json(tmp_path, monkeypatch):
+    """A failed replacement must leave Claude Code's shared state untouched."""
+    pkg = _bootstrap(tmp_path, monkeypatch)
+    cfg = tmp_path / ".claude.json"
+    original = json.dumps({
+        "mcpServers": {"other": {"command": "other-cli"}},
+        "projects": {"/workspace": {"history": ["session-1"]}},
+    })
+    cfg.write_text(original)
+    monkeypatch.setattr(pkg["claude"], "config_path", cfg)
+
+    from threadkeeper import config_io
+
+    def fail_sync(fd):
+        raise OSError("injected config write failure")
+
+    monkeypatch.setattr(config_io.os, "fsync", fail_sync)
+    with pytest.raises(OSError, match="injected config write failure"):
+        pkg["claude"].register_mcp_server(
+            name="thread-keeper",
+            command="/opt/python",
+            args=["-m", "threadkeeper.server"],
+            env={"PYTHONPATH": "/repo"},
+        )
+
+    assert cfg.read_text() == original
+    assert json.loads(cfg.read_text()) == json.loads(original)
+    assert not list(cfg.parent.glob(f".{cfg.name}.tmp.*"))
+
+
 def test_claude_iter_messages_parses_jsonl(tmp_path, monkeypatch):
     pkg = _bootstrap(tmp_path, monkeypatch)
     fp = tmp_path / "claude_session.jsonl"

--- a/threadkeeper/_setup.py
+++ b/threadkeeper/_setup.py
@@ -27,6 +27,7 @@ import sys
 from pathlib import Path
 from typing import Any
 
+from .config_io import mutate_text_file
 from .permissions import chmod_private_dir
 
 # ----------------------------------------------------------------------
@@ -240,40 +241,41 @@ def _install_managed_block(fp: Path, dry_run: bool) -> str:
     block = f"{MARK_BEGIN}\n{CLAUDE_MD_BLOCK}{MARK_END}\n"
     label = fp.name
 
-    if not fp.exists():
-        if not dry_run:
-            fp.parent.mkdir(parents=True, exist_ok=True)
-            fp.write_text(block)
-        return f"{label}: created"
+    def update(body: str, exists: bool) -> tuple[str, str]:
+        if not exists:
+            return block, "created"
+        if MARK_BEGIN in body and MARK_END in body:
+            head, _, rest = body.partition(MARK_BEGIN)
+            _, _, tail = rest.partition(MARK_END)
+            head = head.rstrip()
+            tail = tail.lstrip()
+            if head and tail:
+                new_body = head + "\n\n" + block + "\n" + tail + "\n"
+            elif head:
+                new_body = head + "\n\n" + block
+            elif tail:
+                new_body = block + "\n" + tail + "\n"
+            else:
+                new_body = block
+            return new_body, "already" if new_body == body else "updated"
 
-    body = fp.read_text()
-    if MARK_BEGIN in body and MARK_END in body:
-        head, _, rest = body.partition(MARK_BEGIN)
-        _, _, tail = rest.partition(MARK_END)
-        head = head.rstrip()
-        tail = tail.lstrip()
-        if head and tail:
-            new_body = head + "\n\n" + block + "\n" + tail + "\n"
-        elif head:
-            new_body = head + "\n\n" + block
-        elif tail:
-            new_body = block + "\n" + tail + "\n"
-        else:
-            new_body = block
-        if new_body == body:
-            return f"{label}: managed block already current"
-        if not dry_run:
-            fp.write_text(new_body)
-        return f"{label}: {'would update' if dry_run else 'updated'} managed block"
+        # No markers yet → prepend (top placement → visible without scroll).
+        existing = body.strip()
+        new_body = block + "\n" + existing + "\n" if existing else block
+        return new_body, "prepended"
 
-    # No markers yet → prepend (top placement → visible without scroll).
-    existing = body.strip()
-    if existing:
-        new_body = block + "\n" + existing + "\n"
+    if dry_run:
+        exists = fp.exists()
+        body = fp.read_text() if exists else ""
+        _, result = update(body, exists)
     else:
-        new_body = block
-    if not dry_run:
-        fp.write_text(new_body)
+        result = mutate_text_file(fp, update)
+    if result == "created":
+        return f"{label}: created"
+    if result == "already":
+        return f"{label}: managed block already current"
+    if result == "updated":
+        return f"{label}: {'would update' if dry_run else 'updated'} managed block"
     return f"{label}: {'would prepend' if dry_run else 'prepended'} managed block"
 
 

--- a/threadkeeper/adapters/_hook_helpers.py
+++ b/threadkeeper/adapters/_hook_helpers.py
@@ -10,6 +10,8 @@ import json
 from pathlib import Path
 from typing import Iterable
 
+from ..config_io import mutate_json_file
+
 
 def install_claude_style_hooks(
     settings_path: Path,
@@ -25,48 +27,53 @@ def install_claude_style_hooks(
     command isn't already present. Other hooks (from the user or other
     plugins) are preserved.
     """
-    if settings_path.exists():
-        try:
-            settings = json.loads(settings_path.read_text())
-        except json.JSONDecodeError:
-            return f"{settings_path.name}: malformed JSON — refused"
-    else:
-        settings = {}
-    hooks = settings.setdefault("hooks", {})
-
-    changed = False
-    for spec in specs:
-        event = spec["event"]
-        command = spec["command"]
-        matcher = spec.get("matcher", "")
-        blocks = hooks.get(event, [])
-        # Look for an existing block whose first hook command matches.
-        found = False
-        for block in blocks:
-            inner = block.get("hooks") or []
-            for h in inner:
-                if h.get("command") == command:
-                    found = True
-                    if block.get("matcher", "") != matcher:
-                        block["matcher"] = matcher
-                        changed = True
+    def merge(settings: dict) -> bool:
+        hooks = settings.setdefault("hooks", {})
+        changed = False
+        for spec in specs:
+            event = spec["event"]
+            command = spec["command"]
+            matcher = spec.get("matcher", "")
+            blocks = hooks.get(event, [])
+            # Look for an existing block whose first hook command matches.
+            found = False
+            for block in blocks:
+                inner = block.get("hooks") or []
+                for hook in inner:
+                    if hook.get("command") == command:
+                        found = True
+                        if block.get("matcher", "") != matcher:
+                            block["matcher"] = matcher
+                            changed = True
+                        break
+                if found:
                     break
-            if found:
-                break
-        if not found:
-            new_block = {
-                "hooks": [{"type": "command", "command": command}],
-            }
-            if matcher:
-                new_block["matcher"] = matcher
-            blocks.append(new_block)
-            changed = True
-        hooks[event] = blocks
+            if not found:
+                new_block = {
+                    "hooks": [{"type": "command", "command": command}],
+                }
+                if matcher:
+                    new_block["matcher"] = matcher
+                blocks.append(new_block)
+                changed = True
+            hooks[event] = blocks
+        return changed
 
+    try:
+        if dry_run:
+            settings = (json.loads(settings_path.read_text())
+                        if settings_path.exists() else {})
+            changed = merge(settings)
+        else:
+            def update(settings: dict) -> tuple[bool, bool]:
+                changed = merge(settings)
+                return changed, changed
+
+            changed = mutate_json_file(settings_path, update)
+    except json.JSONDecodeError:
+        return f"{settings_path.name}: malformed JSON — refused"
     if not changed:
         return f"{settings_path.name}: hooks already current"
     if dry_run:
         return f"{settings_path.name}: would update hooks"
-    settings_path.parent.mkdir(parents=True, exist_ok=True)
-    settings_path.write_text(json.dumps(settings, indent=2))
     return f"{settings_path.name}: hooks updated"

--- a/threadkeeper/adapters/antigravity.py
+++ b/threadkeeper/adapters/antigravity.py
@@ -23,6 +23,7 @@ from pathlib import Path
 from typing import Iterator
 
 from .base import CLIAdapter, NormalizedMessage, find_cli_executable
+from ..config_io import mutate_json_file
 
 
 class AntigravityAdapter(CLIAdapter):
@@ -121,40 +122,59 @@ class AntigravityAdapter(CLIAdapter):
     def register_mcp_server(
         self, name, command, args, env, dry_run=False
     ) -> str:
-        try:
-            cfg = self._read_config()
-        except json.JSONDecodeError:
-            return "antigravity: malformed mcp_config.json — refused"
-        servers = cfg.setdefault("mcpServers", {})
         entry = {
             "command": command,
             "args": list(args),
         }
         if env:
             entry["env"] = dict(env)
-        existing = servers.get(name)
+
+        def update(cfg: dict) -> tuple[bool, object]:
+            servers = cfg.setdefault("mcpServers", {})
+            existing = servers.get(name)
+            if existing == entry:
+                return False, existing
+            servers[name] = entry
+            return True, existing
+
+        try:
+            if dry_run:
+                _, existing = update(self._read_config())
+            else:
+                existing = mutate_json_file(
+                    self.config_path, update, allow_empty=True,
+                )
+        except json.JSONDecodeError:
+            return "antigravity: malformed mcp_config.json — refused"
         if existing == entry:
             return "antigravity: already current"
-        servers[name] = entry
-        if not dry_run:
-            self.config_path.parent.mkdir(parents=True, exist_ok=True)
-            self.config_path.write_text(json.dumps(cfg, indent=2))
         return f"antigravity: {'would ' if dry_run else ''}{'update' if existing else 'add'}"
 
     def unregister_mcp_server(self, name, dry_run=False) -> str:
-        if not self.config_path.exists():
-            return "antigravity: nothing to remove"
+        def remove(cfg: dict) -> tuple[bool, bool]:
+            servers = cfg.get("mcpServers") or {}
+            if name not in servers:
+                return False, False
+            servers.pop(name)
+            return True, True
+
         try:
-            cfg = self._read_config()
+            if dry_run:
+                if not self.config_path.exists():
+                    return "antigravity: nothing to remove"
+                _, present = remove(self._read_config())
+            else:
+                if not self.config_path.exists():
+                    return "antigravity: nothing to remove"
+                present = mutate_json_file(
+                    self.config_path, remove, allow_empty=True,
+                )
         except json.JSONDecodeError:
             return "antigravity: malformed mcp_config.json — refused"
-        servers = (cfg.get("mcpServers") or {})
-        if name not in servers:
+        if not present:
             return "antigravity: not present"
         if dry_run:
             return f"antigravity: would remove {name}"
-        servers.pop(name)
-        self.config_path.write_text(json.dumps(cfg, indent=2))
         return f"antigravity: removed {name}"
 
     # ----- Transcript ingestion -----------------------------------------

--- a/threadkeeper/adapters/claude_code.py
+++ b/threadkeeper/adapters/claude_code.py
@@ -16,6 +16,7 @@ from pathlib import Path
 from typing import Iterator
 
 from .base import CLIAdapter, NormalizedMessage, find_cli_executable
+from ..config_io import mutate_json_file
 
 
 def _clean_discovered_model(value: str) -> str:
@@ -206,40 +207,57 @@ class ClaudeCodeAdapter(CLIAdapter):
     def register_mcp_server(
         self, name, command, args, env, dry_run=False
     ) -> str:
-        cfg: dict
-        if self.config_path.exists():
-            try:
-                cfg = json.loads(self.config_path.read_text())
-            except json.JSONDecodeError:
-                return "claude-code: malformed ~/.claude.json — refused"
-        else:
-            cfg = {}
-        servers = cfg.setdefault("mcpServers", {})
         entry = {
             "type": "stdio",
             "command": command,
             "args": list(args),
             "env": dict(env),
         }
-        existing = servers.get(name)
+
+        def update(cfg: dict) -> tuple[bool, object]:
+            servers = cfg.setdefault("mcpServers", {})
+            existing = servers.get(name)
+            if existing == entry:
+                return False, existing
+            servers[name] = entry
+            return True, existing
+
+        try:
+            if dry_run:
+                cfg = (json.loads(self.config_path.read_text())
+                       if self.config_path.exists() else {})
+                _, existing = update(cfg)
+            else:
+                existing = mutate_json_file(self.config_path, update)
+        except json.JSONDecodeError:
+            return "claude-code: malformed ~/.claude.json — refused"
         if existing == entry:
             return "claude-code: already current"
-        servers[name] = entry
-        if not dry_run:
-            self.config_path.write_text(json.dumps(cfg, indent=2))
         return f"claude-code: {'would ' if dry_run else ''}{'update' if existing else 'add'}"
 
     def unregister_mcp_server(self, name, dry_run=False) -> str:
-        if not self.config_path.exists():
-            return "claude-code: nothing to remove"
-        cfg = json.loads(self.config_path.read_text())
-        servers = (cfg.get("mcpServers") or {})
-        if name not in servers:
+        def remove(cfg: dict) -> tuple[bool, bool]:
+            servers = cfg.get("mcpServers") or {}
+            if name not in servers:
+                return False, False
+            servers.pop(name)
+            return True, True
+
+        try:
+            if dry_run:
+                if not self.config_path.exists():
+                    return "claude-code: nothing to remove"
+                _, present = remove(json.loads(self.config_path.read_text()))
+            else:
+                if not self.config_path.exists():
+                    return "claude-code: nothing to remove"
+                present = mutate_json_file(self.config_path, remove)
+        except json.JSONDecodeError:
+            return "claude-code: malformed ~/.claude.json — refused"
+        if not present:
             return "claude-code: not present"
         if dry_run:
             return f"claude-code: would remove {name}"
-        servers.pop(name)
-        self.config_path.write_text(json.dumps(cfg, indent=2))
         return f"claude-code: removed {name}"
 
     # ----------------------------- transcripts ---------------------------

--- a/threadkeeper/adapters/claude_desktop.py
+++ b/threadkeeper/adapters/claude_desktop.py
@@ -30,6 +30,7 @@ from pathlib import Path
 from typing import Iterator
 
 from .base import CLIAdapter, NormalizedMessage
+from ..config_io import mutate_json_file
 
 
 def _default_config_path() -> Path:
@@ -73,44 +74,57 @@ class ClaudeDesktopAdapter(CLIAdapter):
     def register_mcp_server(
         self, name, command, args, env, dry_run=False
     ) -> str:
-        cfg: dict
-        if self.config_path.exists():
-            try:
-                cfg = json.loads(self.config_path.read_text())
-            except json.JSONDecodeError:
-                return "claude-desktop: malformed config — refused"
-        else:
-            cfg = {}
-        servers = cfg.setdefault("mcpServers", {})
         entry: dict = {
             "command": command,
             "args": list(args),
         }
         if env:
             entry["env"] = dict(env)
-        existing = servers.get(name)
+
+        def update(cfg: dict) -> tuple[bool, object]:
+            servers = cfg.setdefault("mcpServers", {})
+            existing = servers.get(name)
+            if existing == entry:
+                return False, existing
+            servers[name] = entry
+            return True, existing
+
+        try:
+            if dry_run:
+                cfg = (json.loads(self.config_path.read_text())
+                       if self.config_path.exists() else {})
+                _, existing = update(cfg)
+            else:
+                existing = mutate_json_file(self.config_path, update)
+        except json.JSONDecodeError:
+            return "claude-desktop: malformed config — refused"
         if existing == entry:
             return "claude-desktop: already current"
-        servers[name] = entry
-        if not dry_run:
-            self.config_path.parent.mkdir(parents=True, exist_ok=True)
-            self.config_path.write_text(json.dumps(cfg, indent=2))
         return f"claude-desktop: {'would ' if dry_run else ''}{'update' if existing else 'add'}"
 
     def unregister_mcp_server(self, name, dry_run=False) -> str:
-        if not self.config_path.exists():
-            return "claude-desktop: nothing to remove"
+        def remove(cfg: dict) -> tuple[bool, bool]:
+            servers = cfg.get("mcpServers") or {}
+            if name not in servers:
+                return False, False
+            servers.pop(name)
+            return True, True
+
         try:
-            cfg = json.loads(self.config_path.read_text())
+            if dry_run:
+                if not self.config_path.exists():
+                    return "claude-desktop: nothing to remove"
+                _, present = remove(json.loads(self.config_path.read_text()))
+            else:
+                if not self.config_path.exists():
+                    return "claude-desktop: nothing to remove"
+                present = mutate_json_file(self.config_path, remove)
         except json.JSONDecodeError:
             return "claude-desktop: malformed config — refused"
-        servers = (cfg.get("mcpServers") or {})
-        if name not in servers:
+        if not present:
             return "claude-desktop: not present"
         if dry_run:
             return f"claude-desktop: would remove {name}"
-        servers.pop(name)
-        self.config_path.write_text(json.dumps(cfg, indent=2))
         return f"claude-desktop: removed {name}"
 
     # ----------------------------- transcripts ---------------------------

--- a/threadkeeper/adapters/codex.py
+++ b/threadkeeper/adapters/codex.py
@@ -22,6 +22,7 @@ from pathlib import Path
 from typing import Iterator
 
 from .base import CLIAdapter, NormalizedMessage, find_cli_executable
+from ..config_io import mutate_text_file
 
 _FORCED_CID_RE = re.compile(
     r"Your own cid is ([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-"
@@ -132,9 +133,7 @@ def _approval_blocks(name: str) -> str:
     return "\n".join(lines) + "\n"
 
 
-def _read_toml(fp: Path) -> dict:
-    if not fp.exists():
-        return {}
+def _parse_toml(body: str) -> dict:
     try:
         import tomllib  # py3.11+
     except ImportError:
@@ -142,9 +141,15 @@ def _read_toml(fp: Path) -> dict:
         # without tomllib. Returns empty (caller treats as "no MCP").
         return {}
     try:
-        return tomllib.loads(fp.read_text())
+        return tomllib.loads(body)
     except Exception:
         return {}
+
+
+def _read_toml(fp: Path) -> dict:
+    if not fp.exists():
+        return {}
+    return _parse_toml(fp.read_text())
 
 
 def _serialize_mcp_section(name: str, command: str,
@@ -355,41 +360,59 @@ class CodexAdapter(CLIAdapter):
         self, name, command, args, env, dry_run=False
     ) -> str:
         block = _serialize_mcp_section(name, command, list(args), dict(env))
-        if not self.config_path.exists():
-            if dry_run:
-                return "codex: would create config.toml with mcp section"
-            self.config_path.parent.mkdir(parents=True, exist_ok=True)
-            self.config_path.write_text(block)
-            return "codex: created config.toml"
-        body = self.config_path.read_text()
-        # Check if already current (cheap normalization compare)
-        already = _read_toml(self.config_path).get("mcp_servers", {}).get(name)
-        if isinstance(already, dict):
-            want = {"command": command, "args": list(args)}
-            if env:
-                want["env"] = dict(env)
-            if name == "thread-keeper":
-                want.update(_thread_keeper_tools_config())
-            if already == want:
-                return "codex: already current"
-        new_body = _replace_or_append_mcp_block(body, name, block)
-        if new_body == body:
-            return "codex: already current"
+
+        def update(body: str, exists: bool) -> tuple[str, str]:
+            if not exists:
+                return block, "created"
+            # Check if already current (cheap normalization compare).
+            already = _parse_toml(body).get("mcp_servers", {}).get(name)
+            if isinstance(already, dict):
+                want = {"command": command, "args": list(args)}
+                if env:
+                    want["env"] = dict(env)
+                if name == "thread-keeper":
+                    want.update(_thread_keeper_tools_config())
+                if already == want:
+                    return body, "already"
+            new_body = _replace_or_append_mcp_block(body, name, block)
+            if new_body == body:
+                return body, "already"
+            return new_body, "updated"
+
         if dry_run:
-            return "codex: would update config.toml"
-        self.config_path.write_text(new_body)
-        return "codex: updated config.toml"
+            exists = self.config_path.exists()
+            body = self.config_path.read_text() if exists else ""
+            _, result = update(body, exists)
+        else:
+            result = mutate_text_file(self.config_path, update)
+        if result == "created":
+            return ("codex: would create config.toml with mcp section"
+                    if dry_run else "codex: created config.toml")
+        if result == "already":
+            return "codex: already current"
+        return "codex: would update config.toml" if dry_run else "codex: updated config.toml"
 
     def unregister_mcp_server(self, name, dry_run=False) -> str:
-        if not self.config_path.exists():
+        def remove(body: str, exists: bool) -> tuple[str, str]:
+            if not exists:
+                return body, "nothing"
+            new_body = _replace_or_append_mcp_block(body, name, "").rstrip() + "\n"
+            if new_body.rstrip() == body.rstrip():
+                return body, "missing"
+            return new_body, "removed"
+
+        if dry_run:
+            exists = self.config_path.exists()
+            body = self.config_path.read_text() if exists else ""
+            _, result = remove(body, exists)
+        else:
+            result = mutate_text_file(self.config_path, remove)
+        if result == "nothing":
             return "codex: nothing to remove"
-        body = self.config_path.read_text()
-        new_body = _replace_or_append_mcp_block(body, name, "").rstrip() + "\n"
-        if new_body.rstrip() == body.rstrip():
+        if result == "missing":
             return "codex: not present"
         if dry_run:
             return f"codex: would remove {name}"
-        self.config_path.write_text(new_body)
         return f"codex: removed {name}"
 
     # ----- Transcript ingestion -----------------------------------------

--- a/threadkeeper/adapters/copilot.py
+++ b/threadkeeper/adapters/copilot.py
@@ -38,6 +38,7 @@ from pathlib import Path
 from typing import Iterator
 
 from .base import CLIAdapter, NormalizedMessage, find_cli_executable
+from ..config_io import mutate_json_file
 
 
 def _ts(s: str) -> int:
@@ -151,53 +152,66 @@ class CopilotAdapter(CLIAdapter):
     def register_mcp_server(
         self, name, command, args, env, dry_run=False
     ) -> str:
-        cfg: dict
-        if self.config_path.exists():
-            try:
-                cfg = json.loads(self.config_path.read_text())
-            except json.JSONDecodeError:
-                return "copilot: malformed mcp-config.json — refused"
-        else:
-            cfg = {}
-        # Copilot v1.0.43+ schema validates the top-level `mcpServers`
-        # key (same as Claude). Older bundles shipped with
-        # `servers` documented; the validator now rejects that file.
-        # If we see a legacy `servers` block, migrate its contents into
-        # `mcpServers` AND drop the legacy key so the file is valid.
-        legacy = cfg.pop("servers", None)
-        if isinstance(legacy, dict):
-            cfg.setdefault("mcpServers", {})
-            for k, v in legacy.items():
-                cfg["mcpServers"].setdefault(k, v)
-        servers = cfg.setdefault("mcpServers", {})
         entry = {
             "command": command,
             "args": list(args),
         }
         if env:
             entry["env"] = dict(env)
-        existing = servers.get(name)
+
+        def update(cfg: dict) -> tuple[bool, tuple[object, object]]:
+            # Copilot v1.0.43+ validates ``mcpServers``.  Migrate an older
+            # ``servers`` block while preserving its entries.
+            legacy = cfg.pop("servers", None)
+            if isinstance(legacy, dict):
+                cfg.setdefault("mcpServers", {})
+                for key, value in legacy.items():
+                    cfg["mcpServers"].setdefault(key, value)
+            servers = cfg.setdefault("mcpServers", {})
+            existing = servers.get(name)
+            if existing == entry and legacy is None:
+                return False, (existing, legacy)
+            servers[name] = entry
+            return True, (existing, legacy)
+
+        try:
+            if dry_run:
+                cfg = (json.loads(self.config_path.read_text())
+                       if self.config_path.exists() else {})
+                _, (existing, legacy) = update(cfg)
+            else:
+                existing, legacy = mutate_json_file(self.config_path, update)
+        except json.JSONDecodeError:
+            return "copilot: malformed mcp-config.json — refused"
         if existing == entry and legacy is None:
             return "copilot: already current"
-        servers[name] = entry
-        if not dry_run:
-            self.config_path.parent.mkdir(parents=True, exist_ok=True)
-            self.config_path.write_text(json.dumps(cfg, indent=2))
         if legacy is not None:
             return f"copilot: migrated legacy 'servers' → 'mcpServers' + {'added' if not existing else 'updated'} {name}"
         return f"copilot: {'would ' if dry_run else ''}{'update' if existing else 'add'}"
 
     def unregister_mcp_server(self, name, dry_run=False) -> str:
-        if not self.config_path.exists():
-            return "copilot: nothing to remove"
-        cfg = json.loads(self.config_path.read_text())
-        servers = (cfg.get("mcpServers") or cfg.get("servers") or {})
-        if name not in servers:
+        def remove(cfg: dict) -> tuple[bool, bool]:
+            servers = cfg.get("mcpServers") or cfg.get("servers") or {}
+            if name not in servers:
+                return False, False
+            servers.pop(name)
+            return True, True
+
+        try:
+            if dry_run:
+                if not self.config_path.exists():
+                    return "copilot: nothing to remove"
+                _, present = remove(json.loads(self.config_path.read_text()))
+            else:
+                if not self.config_path.exists():
+                    return "copilot: nothing to remove"
+                present = mutate_json_file(self.config_path, remove)
+        except json.JSONDecodeError:
+            return "copilot: malformed mcp-config.json — refused"
+        if not present:
             return "copilot: not present"
         if dry_run:
             return f"copilot: would remove {name}"
-        servers.pop(name)
-        self.config_path.write_text(json.dumps(cfg, indent=2))
         return f"copilot: removed {name}"
 
     # ----- Transcript ingestion -----------------------------------------

--- a/threadkeeper/adapters/vscode.py
+++ b/threadkeeper/adapters/vscode.py
@@ -40,6 +40,7 @@ from pathlib import Path
 from typing import Iterator
 
 from .base import CLIAdapter, NormalizedMessage
+from ..config_io import mutate_json_file
 
 
 def _default_config_path() -> Path:
@@ -87,15 +88,6 @@ class VSCodeAdapter(CLIAdapter):
     def register_mcp_server(
         self, name, command, args, env, dry_run=False
     ) -> str:
-        cfg: dict
-        if self.config_path.exists():
-            try:
-                cfg = json.loads(self.config_path.read_text())
-            except json.JSONDecodeError:
-                return "vscode: malformed mcp.json — refused"
-        else:
-            cfg = {}
-        servers = cfg.setdefault("servers", {})
         entry: dict = {
             "type": "stdio",
             "command": command,
@@ -103,29 +95,51 @@ class VSCodeAdapter(CLIAdapter):
         }
         if env:
             entry["env"] = dict(env)
-        existing = servers.get(name)
+
+        def update(cfg: dict) -> tuple[bool, object]:
+            servers = cfg.setdefault("servers", {})
+            existing = servers.get(name)
+            if existing == entry:
+                return False, existing
+            servers[name] = entry
+            return True, existing
+
+        try:
+            if dry_run:
+                cfg = (json.loads(self.config_path.read_text())
+                       if self.config_path.exists() else {})
+                _, existing = update(cfg)
+            else:
+                existing = mutate_json_file(self.config_path, update)
+        except json.JSONDecodeError:
+            return "vscode: malformed mcp.json — refused"
         if existing == entry:
             return "vscode: already current"
-        servers[name] = entry
-        if not dry_run:
-            self.config_path.parent.mkdir(parents=True, exist_ok=True)
-            self.config_path.write_text(json.dumps(cfg, indent=2))
         return f"vscode: {'would ' if dry_run else ''}{'update' if existing else 'add'}"
 
     def unregister_mcp_server(self, name, dry_run=False) -> str:
-        if not self.config_path.exists():
-            return "vscode: nothing to remove"
+        def remove(cfg: dict) -> tuple[bool, bool]:
+            servers = cfg.get("servers") or {}
+            if name not in servers:
+                return False, False
+            servers.pop(name)
+            return True, True
+
         try:
-            cfg = json.loads(self.config_path.read_text())
+            if dry_run:
+                if not self.config_path.exists():
+                    return "vscode: nothing to remove"
+                _, present = remove(json.loads(self.config_path.read_text()))
+            else:
+                if not self.config_path.exists():
+                    return "vscode: nothing to remove"
+                present = mutate_json_file(self.config_path, remove)
         except json.JSONDecodeError:
             return "vscode: malformed mcp.json — refused"
-        servers = (cfg.get("servers") or {})
-        if name not in servers:
+        if not present:
             return "vscode: not present"
         if dry_run:
             return f"vscode: would remove {name}"
-        servers.pop(name)
-        self.config_path.write_text(json.dumps(cfg, indent=2))
         return f"vscode: removed {name}"
 
     # ----------------------------- transcripts ---------------------------

--- a/threadkeeper/config_io.py
+++ b/threadkeeper/config_io.py
@@ -1,0 +1,99 @@
+"""Safe read-modify-write helpers for user-owned CLI configuration files.
+
+CLI configuration is shared with the host application, so a failed setup must
+never truncate it.  These helpers write a fully synced sibling temporary file
+and atomically replace the destination only after that succeeds.  A small
+advisory lock also keeps concurrent setup processes from applying mutations to
+stale snapshots of the same file.
+"""
+from __future__ import annotations
+
+from contextlib import contextmanager
+import json
+import os
+from pathlib import Path
+import tempfile
+from typing import Callable, Iterator, TypeVar
+
+
+T = TypeVar("T")
+
+
+def atomic_write_text(path: Path, content: str, *, encoding: str = "utf-8") -> None:
+    """Durably replace ``path`` without ever truncating its current contents."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(prefix=f".{path.name}.tmp.", dir=path.parent)
+    tmp_path = Path(tmp_name)
+    try:
+        with os.fdopen(fd, "w", encoding=encoding) as fp:
+            fp.write(content)
+            fp.flush()
+            os.fsync(fp.fileno())
+        os.replace(tmp_path, path)
+    except BaseException:
+        try:
+            tmp_path.unlink(missing_ok=True)
+        except OSError:
+            pass
+        raise
+
+
+def atomic_write_json(path: Path, value: dict, *, indent: int = 2) -> None:
+    """Atomically serialize a JSON config file."""
+    atomic_write_text(path, json.dumps(value, indent=indent))
+
+
+@contextmanager
+def locked_config_file(path: Path) -> Iterator[None]:
+    """Hold a POSIX advisory lock for one configuration mutation.
+
+    The lock file is separate from the config itself so replacing the config
+    inode does not release the lock mid-mutation.  Platforms without
+    ``fcntl`` retain atomic replacement but skip this best-effort race guard.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    lock_path = path.with_name(f".{path.name}.lock")
+    with lock_path.open("a+") as lock:
+        try:
+            import fcntl
+        except ImportError:
+            yield
+            return
+        fcntl.flock(lock.fileno(), fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(lock.fileno(), fcntl.LOCK_UN)
+
+
+def mutate_json_file(
+    path: Path,
+    mutate: Callable[[dict], tuple[bool, T]],
+    *,
+    allow_empty: bool = False,
+) -> T:
+    """Lock, read, mutate, and atomically replace a JSON config when changed."""
+    with locked_config_file(path):
+        if path.exists():
+            body = path.read_text()
+            config = {} if allow_empty and not body.strip() else json.loads(body)
+        else:
+            config = {}
+        changed, result = mutate(config)
+        if changed:
+            atomic_write_json(path, config)
+        return result
+
+
+def mutate_text_file(
+    path: Path,
+    mutate: Callable[[str, bool], tuple[str, T]],
+) -> T:
+    """Lock, transform, and atomically replace arbitrary text config content."""
+    with locked_config_file(path):
+        exists = path.exists()
+        body = path.read_text() if exists else ""
+        new_body, result = mutate(body, exists)
+        if new_body != body:
+            atomic_write_text(path, new_body)
+        return result


### PR DESCRIPTION
## Summary
- atomically replace adapter and setup-managed configuration files after flushing and syncing a sibling temporary file
- serialize read-modify-write config mutations with sibling advisory locks
- cover a forced write failure that preserves the original Claude configuration

## Testing
- env -u THREADKEEPER_NO_EMBEDDINGS .venv/bin/python -m pytest -q

Closes #142