### PR TITLE
fix: verify curator report provenance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ version bumps follow semver per the policy in
 [CONTRIBUTING.md → Releases](CONTRIBUTING.md#releases).
 
 ## [Unreleased]
+- **Fixed: curator report application now requires pass provenance (#143).**
+  Before a Curator child is dispatched, its parent authorizes each exact report
+  destination in a `curator_pass` event. The spawned Curator report writer
+  requires that authorization and its matching pass ID, then records the final
+  report SHA-256 in a `curator_report_provenance` event. The Evolve applier
+  accepts only a complete report whose current path/hash match that event and
+  rechecks the hash before marking it applied, rejecting forged, swapped, and
+  replayed report files.
 - **Fixed: pinned the MCP SDK below 2.0.** `mcp` 2.0.0 (2026-07-28) renamed
   `mcp.server.fastmcp` to `mcp.server.mcpserver` (`FastMCP` → `MCPServer`) with
   no compatibility shim, so every fresh install resolving the unbounded

--- a/README.md
+++ b/README.md
@@ -668,6 +668,13 @@ latest report, deterministic audit manifest, recovery snapshot, last endorsed
 `entries`, `batches`, `batch_entries`, and `max_batch_chars`, making partial or
 large reviews visible in the normal `curator_pass` trail.
 
+Each report path is explicitly authorized in a parent-authored `curator_pass`
+event before its child is launched. `curator_report_write` only accepts that
+exact path from the spawned Curator carrying the matching pass ID, then records
+the persisted report's SHA-256 in `curator_report_provenance`. This makes the
+report directory an untrusted transport: a stray or forged `REPORT-*.md` file
+cannot acquire the provenance needed by the applier.
+
 Curator applies its own PATCH / PRUNE / CONSOLIDATE directly by default (it
 writes the REPORT first, then mutates — `lesson_remove` is in its toolset so it
 can actually prune and consolidate duplicate lessons). Set
@@ -708,13 +715,14 @@ or `skill_manage(action='restore', name=...)`. Trash retention is bounded by
 trash writes. Advisory mode does not write snapshots. The existing Evolve
 applier is
 also the Curator apply worker: after the roadmap issue queue is empty, it looks
-for the latest complete Curator report (`CURATOR_PASS_COMPLETE`) that has not
-been marked applied, then spawns an `evolve_applier` child to apply only safe,
-still-current memory maintenance through `lesson_append` / `lesson_remove` /
-`skill_manage` / `concept_manage`. It never touches `[PROTECTED]`,
+for the latest complete Curator report (`CURATOR_PASS_COMPLETE`) whose path and
+current SHA-256 match an unapplied `curator_report_provenance` event, then
+spawns an `evolve_applier` child to apply only safe, still-current memory
+maintenance through `lesson_append` / `lesson_remove` / `skill_manage` /
+`concept_manage`. It never touches `[PROTECTED]`,
 foreground/user, pinned, or validated entries. Only after the child finishes
-does it call `evolve_mark_curator_report_applied(...)`, which prevents replaying
-the same report.
+does it call `evolve_mark_curator_report_applied(...)` with the verified hash;
+the mark rechecks that hash and prevents replaying the same report.
 
 The shared lesson file has its own write serialization: `lesson_append`,
 `lesson_remove`, and `lesson_restore` hold a blocking `fcntl.flock` on

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -500,6 +500,11 @@ moving the high-water forward; `force=True` bypasses this due gate.
   endorsed `inventory_sha256` and the current inventory hash. Spawned
   `curator_pass` events record total entries, batch count, compressed
   `batch_entries`, and max rendered batch chars.
+  Before dispatching each child, the parent also authorizes that exact
+  `REPORT-*.md` destination in a `curator_pass` event. The spawned Curator's
+  path-scoped writer requires that authorization plus its matching pass ID and
+  records the final SHA-256 in `curator_report_provenance`; a file appearing in
+  the report directory alone is therefore never trusted as Curator output.
   Destructive lesson removals and skill deletes reserve from one atomic,
   pass-ID-scoped server-side budget before touching disk. The default
   `CURATOR_MAX_DESTRUCTIVE_PER_PASS=10` is shared across child batches and
@@ -651,11 +656,13 @@ moving the high-water forward; `force=True` bypasses this due gate.
   common token shapes before the real GitHub CLI receives the body, refusing if
   a known unsafe pattern remains. Parent-authored claim/dead-letter comments use
   the same scrubber before spawning `gh`. If no issue is pending,
-  it falls back to the latest complete Curator `REPORT-*.md`, then to the oldest
+  it falls back to the latest complete Curator `REPORT-*.md` whose current
+  SHA-256 matches a `curator_report_provenance` event, then to the oldest
   promoted + unapplied legacy `evolve_format` suggestion. Curator report apply
   uses memory MCP tools only (`lesson_append`, `lesson_remove`, `skill_manage`)
-  and records `curator_report_applied`; no code edit or PR. Legacy code-evolve
-  apply still opens a PR and calls `evolve_mark_applied(evolve_id, pr_url)`.
+  and records `curator_report_applied` only after the child supplies the same
+  verified hash; no code edit or PR. Legacy code-evolve apply still opens a PR
+  and calls `evolve_mark_applied(evolve_id, pr_url)`.
   Machine-wide single-flight uses `evolve-applier.lock` plus the `"You are an
   EVOLVE APPLIER"` prompt prefix. Automatic apply passes respect the configured
   interval to avoid duplicate issue workers across foreground server startups;

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -509,6 +509,13 @@ applier drains them. Listed here so the roadmap reflects the live backlog.
   `~/.threadkeeper` is `0700`; `db.sqlite`, SQLite `-wal`/`-shm` sidecars,
   `.env`, and curator `REPORT-*.md` files are `0600`; headless spawn logs are
   created `0600`.
+- ✅ DONE (#143). Curator advisory reports are provenance-gated before the
+  destructive-memory applier can consume them: the parent records each
+  authorized report destination in a `curator_pass` event, the matching
+  spawned Curator records the final content SHA-256 in
+  `curator_report_provenance`, and the applier rechecks that path/hash both
+  before spawning and before it marks the report applied. Forged, swapped, or
+  replayed `REPORT-*.md` files are refused.
 - ✅ DONE (#22). The autonomous GitHub-writing daemons run privileged evolve
   children, but the dangerous pieces are now bounded: `spawn()` refuses
   `permission_mode="bypassPermissions"` outside the evolve role/write-origin

--- a/tests/test_agent_status.py
+++ b/tests/test_agent_status.py
@@ -202,10 +202,26 @@ def test_agent_status_evolve_applier_ready_when_curator_report_exists(
     reports_dir = pkg["tmp"] / "curator"
     reports_dir.mkdir()
     pkg["config"].CURATOR_REPORTS_DIR = reports_dir
-    (reports_dir / "REPORT-20260611T120000.md").write_text(
+    report = reports_dir / "REPORT-20260611T120000.md"
+    report.write_text(
         "# report\n\nPATCH: stale-skill\n\nCURATOR_PASS_COMPLETE\n",
         encoding="utf-8",
     )
+    conn = pkg["db"].get_db()
+    sid = pkg["identity"]._ensure_session(conn)
+    conn.execute(
+        "INSERT INTO events (session_id, kind, target, summary, created_at) "
+        "VALUES (?, ?, ?, ?, ?)",
+        (
+            sid,
+            applier_mod.CURATOR_REPORT_PROVENANCE_KIND,
+            str(report.resolve()),
+            "pass_id=test sha256="
+            + applier_mod.curator_report_sha256(report.read_text()),
+            int(time.time()),
+        ),
+    )
+    conn.commit()
 
     from threadkeeper.agent_status import agent_status_snapshot
 

--- a/tests/test_curator.py
+++ b/tests/test_curator.py
@@ -55,6 +55,7 @@ def _bootstrap(
     retention=None,
     max_destructive=None,
     write_origin="foreground",
+    spawned_child="0",
 ):
     env = {
         "THREADKEEPER_DB": str(tmp_path / "db.sqlite"),
@@ -75,6 +76,7 @@ def _bootstrap(
         "THREADKEEPER_CLIENT": "pytest",
         "THREADKEEPER_FORCE_CID": _FAKE_CID,
         "THREADKEEPER_WRITE_ORIGIN": write_origin,
+        "THREADKEEPER_SPAWNED_CHILD": spawned_child,
     }
     if destructive is not None:
         env["THREADKEEPER_CURATOR_DESTRUCTIVE"] = destructive
@@ -466,7 +468,10 @@ def test_run_curator_pass_advisory_writes_no_snapshot(tmp_path, monkeypatch):
     captured: list[dict] = []
 
     def fake_spawn(**kwargs):
-        assert "THREADKEEPER_CURATOR_PASS_ID" not in os.environ
+        # Advisory children now carry the parent-authorized pass id so their
+        # report writer can emit verifiable provenance, but still receive no
+        # destructive snapshot context.
+        assert os.environ["THREADKEEPER_CURATOR_PASS_ID"]
         assert "THREADKEEPER_CURATOR_SNAPSHOT_DIR" not in os.environ
         captured.append(kwargs)
         return "spawn task_id=fake-curator-task pid=0"
@@ -775,41 +780,79 @@ def test_skill_validate_tool_returns_post_change_contract(tmp_path, monkeypatch)
 def test_curator_report_write_is_path_scoped_and_replaceable(
     tmp_path, monkeypatch,
 ):
-    pkg = _bootstrap(tmp_path, monkeypatch)
+    pkg = _bootstrap(
+        tmp_path, monkeypatch, write_origin="curator", spawned_child="1",
+    )
     from threadkeeper._mcp import mcp
+    from threadkeeper.curator_snapshots import PASS_ID_ENV
     write_report = mcp._tool_manager._tools["curator_report_write"].fn
+    pass_id = "20260719T120000"
+    monkeypatch.setenv(PASS_ID_ENV, pass_id)
+    conn = pkg["db"].get_db()
+    pkg["curator"]._authorize_curator_report(
+        conn, int(time.time()), pass_id, f"REPORT-{pass_id}.md",
+    )
+    pkg["curator"]._authorize_curator_report(
+        conn,
+        int(time.time()),
+        pass_id,
+        f"REPORT-{pass_id}-batch-002-of-003.md",
+    )
 
     assert write_report(pass_id="../escape", content="x") == (
         "ERR invalid_pass_id"
     )
-    first = write_report(pass_id="20260719T120000", content="# Plan")
+    first = write_report(pass_id=pass_id, content="# Plan")
     second = write_report(
-        pass_id="20260719T120000",
+        pass_id=pass_id,
         content="# Results\n\nCURATOR_PASS_COMPLETE",
     )
     batch = write_report(
-        pass_id="20260719T120000",
+        pass_id=pass_id,
         batch_index=2,
         batch_total=3,
         content="# Batch two\n\nCURATOR_PASS_COMPLETE",
     )
 
-    report = pkg["reports_dir"] / "REPORT-20260719T120000.md"
+    report = pkg["reports_dir"] / f"REPORT-{pass_id}.md"
     batch_report = (
         pkg["reports_dir"]
-        / "REPORT-20260719T120000-batch-002-of-003.md"
+        / f"REPORT-{pass_id}-batch-002-of-003.md"
     )
     assert first.startswith("ok path=")
     assert second.startswith("ok path=")
     assert batch.startswith("ok path=")
     assert report.read_text() == "# Results\n\nCURATOR_PASS_COMPLETE\n"
     assert batch_report.read_text() == "# Batch two\n\nCURATOR_PASS_COMPLETE\n"
+    rows = conn.execute(
+        "SELECT target, summary FROM events "
+        "WHERE kind='curator_report_provenance' ORDER BY id"
+    ).fetchall()
+    assert rows[-1]["target"] == str(batch_report.resolve())
+    assert "sha256=" in rows[-1]["summary"]
     assert write_report(
-        pass_id="20260719T120000",
+        pass_id=pass_id,
         batch_index=2,
         content="x",
     ) == "ERR invalid_batch"
     assert not (tmp_path / "escape").exists()
+
+
+def test_curator_report_write_requires_parent_pass_authorization(
+    tmp_path, monkeypatch,
+):
+    pkg = _bootstrap(
+        tmp_path, monkeypatch, write_origin="curator", spawned_child="1",
+    )
+    from threadkeeper._mcp import mcp
+    from threadkeeper.curator_snapshots import PASS_ID_ENV
+
+    monkeypatch.setenv(PASS_ID_ENV, "unauthorized-pass")
+    write_report = mcp._tool_manager._tools["curator_report_write"].fn
+    assert write_report(
+        pass_id="unauthorized-pass",
+        content="# forged\n\nCURATOR_PASS_COMPLETE",
+    ) == "ERR report_write_not_authorized"
 
 
 def test_skill_validator_resolves_namespaced_external_plugin_skill(

--- a/tests/test_evolve_applier.py
+++ b/tests/test_evolve_applier.py
@@ -19,7 +19,14 @@ from pathlib import Path
 _FAKE_CID = "aaaa1111-2222-3333-4444-555566667777"
 
 
-def _bootstrap(tmp_path, monkeypatch, interval="0", pin_repo=True):
+def _bootstrap(
+    tmp_path,
+    monkeypatch,
+    interval="0",
+    pin_repo=True,
+    write_origin="foreground",
+    spawned_child="0",
+):
     env = {
         "THREADKEEPER_DB": str(tmp_path / "db.sqlite"),
         "CLAUDE_PROJECTS_DIR": str(tmp_path / "fake_claude_projects"),
@@ -41,6 +48,8 @@ def _bootstrap(tmp_path, monkeypatch, interval="0", pin_repo=True):
         "THREADKEEPER_TASK_LOG_DIR": str(tmp_path / "tasks"),
         "THREADKEEPER_CLIENT": "pytest",
         "THREADKEEPER_FORCE_CID": _FAKE_CID,
+        "THREADKEEPER_WRITE_ORIGIN": write_origin,
+        "THREADKEEPER_SPAWNED_CHILD": spawned_child,
         "THREADKEEPER_NO_EMBEDDINGS": "1",
     }
     for k, v in env.items():
@@ -156,7 +165,12 @@ def _mock_spawn(monkeypatch, calls):
     )
 
 
-def _write_report(pkg, name="REPORT-20260611T120000.md", complete=True):
+def _write_report(
+    pkg,
+    name="REPORT-20260611T120000.md",
+    complete=True,
+    provenanced=True,
+):
     import threadkeeper.config as cfg
 
     cfg.CURATOR_REPORTS_DIR.mkdir(parents=True, exist_ok=True)
@@ -166,6 +180,22 @@ def _write_report(pkg, name="REPORT-20260611T120000.md", complete=True):
         "# Curator report\n\nPATCH: stale-skill\n  reason: compact it\n" + tail,
         encoding="utf-8",
     )
+    if complete and provenanced:
+        conn = pkg["db"].get_db()
+        sid = pkg["identity"]._ensure_session(conn)
+        digest = pkg["ea"].curator_report_sha256(path.read_text())
+        conn.execute(
+            "INSERT INTO events (session_id, kind, target, summary, created_at) "
+            "VALUES (?, ?, ?, ?, ?)",
+            (
+                sid,
+                pkg["ea"].CURATOR_REPORT_PROVENANCE_KIND,
+                str(path.resolve()),
+                f"pass_id=test sha256={digest}",
+                int(time.time()),
+            ),
+        )
+        conn.commit()
     return path
 
 
@@ -344,6 +374,45 @@ def test_apply_curator_report_builds_evolve_applier_spawn(
     assert "gh pr create" not in prompt
 
 
+def test_authorized_curator_report_writer_is_applied_once(
+    tmp_path, monkeypatch,
+):
+    pkg = _bootstrap(
+        tmp_path,
+        monkeypatch,
+        write_origin="curator",
+        spawned_child="1",
+    )
+    from threadkeeper import curator
+    from threadkeeper.curator_snapshots import PASS_ID_ENV
+
+    pass_id = "20260804T120000"
+    report_name = f"REPORT-{pass_id}.md"
+    monkeypatch.setenv(PASS_ID_ENV, pass_id)
+    conn = pkg["db"].get_db()
+    curator._authorize_curator_report(conn, int(time.time()), pass_id, report_name)
+    write_report = _tool(pkg, "curator_report_write")
+    assert write_report(
+        pass_id=pass_id,
+        content="# Curator report\n\nPATCH: stale-skill\n\nCURATOR_PASS_COMPLETE",
+    ).startswith("ok path=")
+    report = tmp_path / "curator" / report_name
+    calls = {}
+    _mock_spawn(monkeypatch, calls)
+
+    assert pkg["ea"].apply_curator_report(str(report)).startswith(
+        f"spawned curator_report={report_name}"
+    )
+    digest = pkg["ea"].curator_report_sha256(report.read_text())
+    assert pkg["ea"].mark_curator_report_applied(
+        conn, str(report), digest, "no changes needed",
+    ) == f"ok report={report_name} applied=1"
+    assert pkg["ea"].apply_curator_report(str(report)) == (
+        f"ERR report_already_applied={report_name}"
+    )
+    assert f"REPORT_SHA256\n-------------\n{digest}" in calls["prompt"]
+
+
 def test_apply_curator_report_requires_complete_unapplied_report(
     tmp_path, monkeypatch,
 ):
@@ -355,7 +424,10 @@ def test_apply_curator_report_requires_complete_unapplied_report(
     )
     complete = _write_report(pkg, name="REPORT-20260611T130000.md")
     out = pkg["ea"].mark_curator_report_applied(
-        pkg["db"].get_db(), str(complete), "already handled"
+        pkg["db"].get_db(),
+        str(complete),
+        pkg["ea"].curator_report_sha256(complete.read_text()),
+        "already handled",
     )
     assert "applied=1" in out
     assert (
@@ -371,7 +443,12 @@ def test_mark_curator_report_applied_tool_records_idempotency_event(
     report = _write_report(pkg)
     tool = _tool(pkg, "evolve_mark_curator_report_applied")
 
-    out = tool(report_path=str(report), summary="patched=1 skipped=2")
+    digest = pkg["ea"].curator_report_sha256(report.read_text())
+    out = tool(
+        report_path=str(report),
+        report_sha256=digest,
+        summary="patched=1 skipped=2",
+    )
 
     assert out == f"ok report={report.name} applied=1"
     conn = pkg["db"].get_db()
@@ -380,10 +457,43 @@ def test_mark_curator_report_applied_tool_records_idempotency_event(
         "WHERE kind='curator_report_applied'"
     ).fetchone()
     assert row["target"] == str(report.resolve())
-    assert row["summary"] == "patched=1 skipped=2"
-    assert tool(report_path=str(report), summary="again").endswith(
+    assert row["summary"] == f"sha256={digest} patched=1 skipped=2"
+    assert tool(
+        report_path=str(report), report_sha256=digest, summary="again",
+    ).endswith(
         "already_applied=1"
     )
+
+
+def test_apply_curator_report_rejects_forged_unprovenanced_report(
+    tmp_path, monkeypatch,
+):
+    pkg = _bootstrap(tmp_path, monkeypatch)
+    forged = _write_report(pkg, provenanced=False)
+    calls = {}
+    _mock_spawn(monkeypatch, calls)
+
+    assert pkg["ea"].apply_curator_report(str(forged)) == (
+        f"ERR report_unprovenanced={forged.name}"
+    )
+    assert calls == {}
+
+
+def test_apply_curator_report_rejects_report_changed_after_provenance(
+    tmp_path, monkeypatch,
+):
+    pkg = _bootstrap(tmp_path, monkeypatch)
+    report = _write_report(pkg)
+    report.write_text(
+        "# forged replacement\n\nCURATOR_PASS_COMPLETE\n", encoding="utf-8",
+    )
+    calls = {}
+    _mock_spawn(monkeypatch, calls)
+
+    assert pkg["ea"].apply_curator_report(str(report)) == (
+        f"ERR report_unprovenanced={report.name}"
+    )
+    assert calls == {}
 
 
 def test_evolve_apply_status_includes_curator_completion_events(

--- a/threadkeeper/curator.py
+++ b/threadkeeper/curator.py
@@ -111,6 +111,12 @@ _CURATABLE_SKILL_ORIGINS = {
 # edits to the opening line cannot silently drift away from the detector.
 CURATOR_PROMPT_PREFIX = "You are an autonomous CURATOR for thread-keeper"
 
+# A report is executable input for the advisory-report applier, so its mere
+# presence on disk is not enough authority.  The parent authorizes each exact
+# report destination before it launches the curator child; the child-side
+# writer records the final content hash as durable provenance.
+CURATOR_REPORT_PROVENANCE_KIND = "curator_report_provenance"
+
 CURATOR_PROMPT = CURATOR_PROMPT_PREFIX + """'s lessons + skills
 library. This is a deep audit, not a filename or character-count scan. You
 receive one complete bounded inventory batch from a pass that covers every
@@ -358,6 +364,53 @@ def _record_curator_pass(conn: sqlite3.Connection,
         conn.commit()
     except sqlite3.OperationalError:
         logger.debug("curator: failed to record pass", exc_info=True)
+
+
+def _authorize_curator_report(
+    conn: sqlite3.Connection,
+    ts: int,
+    pass_id: str,
+    report_name: str,
+) -> None:
+    """Record an exact report destination before dispatching its curator child.
+
+    ``curator_report_write`` requires this parent-authored ``curator_pass``
+    record in addition to its spawned-curator context.  A writer that merely
+    drops a matching filename into the reports directory cannot mint the
+    provenance event consumed by the Evolve applier.
+    """
+    _record_curator_pass(
+        conn,
+        ts,
+        f"report_authorized pass_id={pass_id} report_name={report_name}",
+    )
+
+
+def _curator_report_is_authorized(
+    conn: sqlite3.Connection,
+    pass_id: str,
+    report_name: str,
+) -> bool:
+    """Whether the curator parent authorized this exact report destination."""
+    required = {
+        "report_authorized",
+        f"pass_id={pass_id}",
+        f"report_name={report_name}",
+    }
+    try:
+        rows = conn.execute(
+            "SELECT summary FROM events WHERE kind='curator_pass' "
+            "ORDER BY id DESC LIMIT 200"
+        ).fetchall()
+    except sqlite3.OperationalError:
+        return False
+    return any(required.issubset(set((row["summary"] or "").split()))
+               for row in rows)
+
+
+def curator_report_sha256(content: str) -> str:
+    """Digest report text exactly as the report writer persists it."""
+    return hashlib.sha256(content.encode("utf-8")).hexdigest()
 
 
 def _pass_due(conn: sqlite3.Connection, now_t: int) -> bool:
@@ -1187,8 +1240,11 @@ def run_curator_pass(force: bool = False, *, scheduled: bool = False) -> str:
         from .tools.spawn import spawn  # type: ignore
         old_pass = os.environ.get(PASS_ID_ENV)
         old_snap = os.environ.get(SNAPSHOT_DIR_ENV)
+        # Every report writer, including advisory-mode children, must carry the
+        # pass identifier the parent authorized.  The writer rejects filenames
+        # that are not one of this pass's explicit report destinations.
+        os.environ[PASS_ID_ENV] = pass_id
         if CURATOR_DESTRUCTIVE:
-            os.environ[PASS_ID_ENV] = pass_id
             os.environ[SNAPSHOT_DIR_ENV] = str(snapshot_dir)
         results: list[str] = []
         try:
@@ -1201,6 +1257,9 @@ def run_curator_pass(force: bool = False, *, scheduled: bool = False) -> str:
                             f"REPORT-{pass_id}-batch-"
                             f"{batch.index:03d}-of-{batch.total:03d}.md"
                         )
+                    _authorize_curator_report(
+                        conn, now, pass_id, report_name,
+                    )
                     full_prompt = (
                         CURATOR_PROMPT.replace(
                             "{DESTRUCTIVE_CLAUSE}",

--- a/threadkeeper/evolve_applier.py
+++ b/threadkeeper/evolve_applier.py
@@ -78,6 +78,7 @@ from .config import (
     ROADMAP_ISSUE_BACKOFF_BASE_S,
     ROADMAP_ISSUE_MAX_ATTEMPTS,
 )
+from .curator import CURATOR_REPORT_PROVENANCE_KIND, curator_report_sha256
 from .db import get_db
 from .github_budget import run_gh, split_gh_api_output, strip_gh_api_headers
 from .github_safety import GithubBodySafetyError, sanitize_public_github_body
@@ -247,6 +248,10 @@ REPORT_TEXT
 -----------
 {report_text}
 
+REPORT_SHA256
+-------------
+{report_sha256}
+
 REPO: {repo}
 
 DO, strictly in order:
@@ -292,6 +297,7 @@ DO, strictly in order:
    call:
      evolve_mark_curator_report_applied(
        report_path="{report_path}",
+       report_sha256="{report_sha256}",
        summary="<one-line summary of applied/skipped counts>"
      )
    Do not call it before the checks and mutations above.
@@ -1360,6 +1366,34 @@ def _is_complete_curator_report(path: Path) -> bool:
     return CURATOR_REPORT_MARKER in _read_curator_report(path)
 
 
+def _curator_report_provenanced(
+    conn: sqlite3.Connection,
+    path: Path,
+    report_text: str,
+) -> bool:
+    """Whether a curator child recorded this exact report content.
+
+    The report directory is deliberately treated as an untrusted transport:
+    only the writer's parent-authorized curator-pass event can create the
+    matching content hash record.  Re-reading the file and checking the hash
+    at every use closes replacement/tampering between report generation and
+    applier dispatch.
+    """
+    digest = curator_report_sha256(report_text)
+    try:
+        rows = conn.execute(
+            "SELECT summary FROM events WHERE kind=? AND target=? "
+            "ORDER BY id DESC LIMIT 20",
+            (CURATOR_REPORT_PROVENANCE_KIND, _report_key(path)),
+        ).fetchall()
+    except sqlite3.OperationalError:
+        return False
+    return any(
+        f"sha256={digest}" in (row["summary"] or "").split()
+        for row in rows
+    )
+
+
 def _curator_report_applied(conn: sqlite3.Connection, path: Path) -> bool:
     try:
         row = conn.execute(
@@ -1388,8 +1422,13 @@ def _latest_complete_curator_report(
     except OSError:
         return None
     for path in reports:
-        if not _is_complete_curator_report(path):
+        report_text = _read_curator_report(path)
+        if CURATOR_REPORT_MARKER not in report_text:
             return None
+        # An unprovenanced file is not a curator pass and must not supersede a
+        # prior authentic report just because it has a newer mtime.
+        if not _curator_report_provenanced(conn, path, report_text):
+            continue
         return None if _curator_report_applied(conn, path) else path
     return None
 
@@ -2569,6 +2608,7 @@ def build_curator_report_apply_prompt(
         report_path=key,
         report_name=report_path.name,
         report_text=report_text,
+        report_sha256=curator_report_sha256(report_text),
         repo=repo,
     )
 
@@ -2724,16 +2764,25 @@ def mark_applied(conn: sqlite3.Connection, evolve_id: int,
 def mark_curator_report_applied(
     conn: sqlite3.Connection,
     report_path: str,
+    report_sha256: str,
     summary: str,
 ) -> str:
-    """Record that an evolve_applier child processed a Curator report."""
+    """Record that an evolve_applier child processed an unchanged report."""
     path = _resolve_curator_report_path(report_path)
     if path is None:
         return "ERR invalid_report_path"
     if not path.exists():
         return f"ERR report_not_found={path}"
-    if not _is_complete_curator_report(path):
+    report_text = _read_curator_report(path)
+    if CURATOR_REPORT_MARKER not in report_text:
         return f"ERR report_incomplete={path.name}"
+    expected = (report_sha256 or "").strip().lower()
+    if not re.fullmatch(r"[0-9a-f]{64}", expected):
+        return "ERR report_sha256_required"
+    if curator_report_sha256(report_text) != expected:
+        return f"ERR report_changed={path.name}"
+    if not _curator_report_provenanced(conn, path, report_text):
+        return f"ERR report_unprovenanced={path.name}"
     key = _report_key(path)
     if _curator_report_applied(conn, path):
         return f"ok report={path.name} already_applied=1"
@@ -2744,7 +2793,7 @@ def mark_curator_report_applied(
             identity._session_id or "",
             CURATOR_REPORT_APPLIED_KIND,
             key,
-            (summary or "")[:300],
+            f"sha256={expected} {(summary or '')}"[:300],
             int(time.time()),
         ),
     )
@@ -3070,6 +3119,9 @@ def apply_curator_report(report_path: str = "") -> str:
                 return f"ERR report_not_found={path}"
             if not _is_complete_curator_report(path):
                 return f"ERR report_incomplete={path.name}"
+            report_text = _read_curator_report(path)
+            if not _curator_report_provenanced(conn, path, report_text):
+                return f"ERR report_unprovenanced={path.name}"
             if _curator_report_applied(conn, path):
                 return f"ERR report_already_applied={path.name}"
         else:
@@ -3085,6 +3137,8 @@ def apply_curator_report(report_path: str = "") -> str:
         report_text = _read_curator_report(path)
         if not report_text:
             return f"ERR report_empty={path.name}"
+        if not _curator_report_provenanced(conn, path, report_text):
+            return f"ERR report_unprovenanced={path.name}"
         # Curator apply is memory-only — no git tree required. Use the resolved
         # repo root when it exists, else fall back to the DB dir so the child's
         # cwd is always valid even before a managed checkout is cloned.

--- a/threadkeeper/tools/curator.py
+++ b/threadkeeper/tools/curator.py
@@ -20,6 +20,7 @@ audit pass:
 from __future__ import annotations
 
 import json
+import logging
 import os
 import re
 import time
@@ -29,13 +30,22 @@ from ..db import get_db
 from ..identity import _ensure_session
 from ..curator import (
     CURATOR_PROMPT,
+    CURATOR_REPORT_PROVENANCE_KIND,
     _collect_inventory,
+    _curator_report_is_authorized,
     _current_inventory_fingerprint,
     _last_inventory_fingerprint,
     _last_curator_ts,
+    curator_report_sha256,
     run_curator_pass,
 )
-from ..curator_snapshots import restore_lesson, restore_skill, snapshots_root
+from ..curator_snapshots import (
+    current_pass_id,
+    restore_lesson,
+    restore_skill,
+    snapshots_root,
+)
+from ..permissions import chmod_private_file
 from ..skill_audit import build_skill_audit
 from ..config import (
     CURATOR_INTERVAL_S,
@@ -43,11 +53,14 @@ from ..config import (
     CURATOR_REPORTS_DIR,
     CURATOR_DESTRUCTIVE,
     CURATOR_MANAGE_FOREGROUND_SKILLS,
+    SPAWNED_CHILD,
+    WRITE_ORIGIN,
 )
 
 
 _PASS_ID_RE = re.compile(r"^[A-Za-z0-9_.:-]+$")
 _MAX_REPORT_CHARS = 2_000_000
+logger = logging.getLogger(__name__)
 
 
 @write_tool()
@@ -266,7 +279,9 @@ def curator_report_write(
     arbitrary path. A bounded multi-child pass supplies ``batch_index`` and
     ``batch_total`` so children cannot overwrite each other's reports. Repeated
     calls replace the same pass/batch report so the Curator can persist its
-    plan before mutation and then add actual validation/rollback results.
+    plan before mutation and then add actual validation/rollback results. Only
+    a parent-authorized spawned Curator carrying the matching pass ID may write
+    a report; the final content hash is recorded for the report applier.
     """
     clean_id = pass_id.strip()
     if not clean_id or not _PASS_ID_RE.fullmatch(clean_id):
@@ -284,6 +299,12 @@ def curator_report_write(
         return f"ERR report_too_large max_chars={_MAX_REPORT_CHARS}"
     if not content.strip():
         return "ERR empty_report"
+    if WRITE_ORIGIN != "curator" or not SPAWNED_CHILD:
+        return "ERR report_write_not_authorized"
+    if current_pass_id() != clean_id:
+        return "ERR report_write_pass_mismatch"
+    conn = get_db()
+    _ensure_session(conn)
     CURATOR_REPORTS_DIR.mkdir(parents=True, exist_ok=True)
     if batch_index:
         report_name = (
@@ -291,17 +312,38 @@ def curator_report_write(
         )
     else:
         report_name = f"REPORT-{clean_id}.md"
+    if not _curator_report_is_authorized(conn, clean_id, report_name):
+        return "ERR report_write_not_authorized"
     target = CURATOR_REPORTS_DIR / report_name
     temporary = target.with_name(f".{target.name}.{os.getpid()}.tmp")
+    persisted = content.rstrip() + "\n"
     try:
-        temporary.write_text(content.rstrip() + "\n", encoding="utf-8")
+        temporary.write_text(persisted, encoding="utf-8")
         temporary.replace(target)
+        chmod_private_file(target)
     except OSError as exc:
         try:
             temporary.unlink(missing_ok=True)
         except OSError:
             pass
         return f"ERR report_write_failed={exc}"
+    digest = curator_report_sha256(persisted)
+    try:
+        conn.execute(
+            "INSERT INTO events (session_id, kind, target, summary, created_at) "
+            "VALUES (?, ?, ?, ?, ?)",
+            (
+                _ensure_session(conn),
+                CURATOR_REPORT_PROVENANCE_KIND,
+                str(target.resolve()),
+                f"pass_id={clean_id} sha256={digest}",
+                int(time.time()),
+            ),
+        )
+        conn.commit()
+    except Exception as exc:
+        logger.warning("curator report provenance record failed", exc_info=True)
+        return f"ERR report_provenance_failed={exc}"
     return f"ok path={target} chars={len(content)}"
 
 

--- a/threadkeeper/tools/evolve_applier.py
+++ b/threadkeeper/tools/evolve_applier.py
@@ -22,9 +22,9 @@
     Called BY the applier child after `gh pr create` succeeds. Sets applied=1
     so the suggestion stops resurfacing. Requires a non-empty pr_url (the gate).
 
-  evolve_mark_curator_report_applied(report_path, summary)
-    Called BY the applier child after it processed a Curator report. Records an
-    idempotency event so the report is not replayed.
+  evolve_mark_curator_report_applied(report_path, report_sha256, summary)
+    Called BY the applier child after it processed an unchanged, provenanced
+    Curator report. Records an idempotency event so the report is not replayed.
 
   evolve_apply_status()
     Diagnostic: interval knob, promoted+unapplied queue, running applier, and
@@ -178,17 +178,24 @@ def evolve_mark_roadmap_issue_applied(issue_number: int, pr_url: str) -> str:
 
 
 @write_tool(idempotent=True)
-def evolve_mark_curator_report_applied(report_path: str, summary: str) -> str:
+def evolve_mark_curator_report_applied(
+    report_path: str,
+    report_sha256: str,
+    summary: str,
+) -> str:
     """Mark a Curator report as processed by the evolve_applier child.
 
     The report must live under `THREADKEEPER_CURATOR_REPORTS_DIR`, match
-    `REPORT-*.md`, and contain `CURATOR_PASS_COMPLETE`. This marker is the
-    idempotency gate that prevents replaying the same advisory report."""
+    `REPORT-*.md`, contain `CURATOR_PASS_COMPLETE`, and still match the
+    parent-verified content hash. The hash and applied event prevent a swapped
+    report or replay from being accepted."""
     if not (report_path or "").strip():
         return "ERR report_path_required"
     conn = get_db()
     _ensure_session(conn)
-    return mark_curator_report_applied(conn, report_path.strip(), summary)
+    return mark_curator_report_applied(
+        conn, report_path.strip(), report_sha256, summary,
+    )
 
 
 @read_tool()


### PR DESCRIPTION
## Summary
- Authorize each curator report destination before the child runs and record its final SHA-256.
- Refuse unprovenanced or swapped reports before dispatch and before marking applied.
- Cover forged, legitimate, and replayed reports; update the curator/applier architecture.

## Tests
- `env -u THREADKEEPER_NO_EMBEDDINGS .venv/bin/python -m pytest -q`

Closes #143