### PR TITLE
fix: unblock dirty evolve checkouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ version bumps follow semver per the policy in
 [CONTRIBUTING.md → Releases](CONTRIBUTING.md#releases).
 
 ## [Unreleased]
+- **Fixed: one abandoned Evolve attempt can no longer deadlock the apply
+  scheduler.** Managed-checkout refresh used to reject a dirty tree before the
+  abandoned-WIP recovery gate ran, so a child that edited `main` and then hit a
+  deterministic branch-name collision made every later pass fail with
+  `evolve_repo_refresh_blocked_dirty`. Refresh now checks live writers first,
+  archives and recovers eligible orphaned WIP (including the disposable base
+  branch), and only then resets to the remote base. Applier prompts prepare or
+  resume the local/remote feature branch before reading or editing, and
+  `agent_status` no longer treats `ERR`/spawn-failure pass events as successful
+  health-clock updates.
 - **Fixed: curator report application now requires pass provenance (#143).**
   Before a Curator child is dispatched, its parent authorizes each exact report
   destination in a `curator_pass` event. The spawned Curator report writer

--- a/README.md
+++ b/README.md
@@ -847,26 +847,28 @@ throttling the roadmap loop.
 Before any PR-producing reviewer/audit or applier child is spawned, the parent
 checks the target checkout with `git status --porcelain --untracked-files=no`.
 Tracked-file WIP records `skipped_dirty_worktree` and no child is dispatched;
-untracked scratch files do not block. The child prompts also fetch the configured
-base branch and create feature branches from `origin/main` (or the configured
-`THREADKEEPER_EVOLVE_REPO_BRANCH`), not from whatever `HEAD` the daemon happens
-to have checked out. A shared git-writer running-task check prevents the
-privileged reviewer audit and code/PR applier from overlapping in the same
-checkout. If a killed conflict-repair child leaves an unresolved merge in the
-default auto-managed checkout, the next code-applying pass can recover it — but
-only when the current branch is `roadmap/…`/`evolve/…` and GitHub confirms that
-exact PR is already merged. Before returning the managed tree to fresh
-`origin/<THREADKEEPER_EVOLVE_REPO_BRANCH>`, thread-keeper archives the tracked
-diff under
-`~/.threadkeeper/evolve-recovery/stale-merge-pr-*.patch` and records
-`recovered_stale_merge` telemetry. Open, closed-unmerged, missing, or
-unreadable PR state remains fail-closed. An explicit
-`THREADKEEPER_EVOLVE_REPO_ROOT` is never auto-reset.
+untracked scratch files do not block. Each applier child fetches the configured
+base and prepares or resumes its deterministic local/remote feature branch
+before reading or editing; retries therefore validate prior branch work instead
+of discovering a branch-name collision after changing the base checkout. A
+shared git-writer running-task check prevents the privileged reviewer audit and
+code/PR applier from overlapping in the same checkout.
+
+If a killed child leaves an unresolved merge or plain tracked WIP in the default
+auto-managed checkout, the next code-producing pass archives the diff before
+recovering it. Merge recovery remains limited to `roadmap/…`/`evolve/…`
+branches whose exact PR is confirmed merged. Plain abandoned WIP is recoverable
+on those applier branches when PR state is readable, and also on the configured
+base branch: the disposable base can contain orphaned edits when an older child
+failed during late branch creation. Recovery patches are owner-only files under
+`~/.threadkeeper/evolve-recovery/`, and `evolve_git_safety` records the action.
+Unknown ownership, a live writer, or unreadable required PR state remains
+fail-closed. An explicit `THREADKEEPER_EVOLVE_REPO_ROOT` is never auto-reset.
 
 The default managed checkout is refreshed before every code-producing pass:
-after checking that no Evolve git writer is live and that tracked files are
-clean, it fetches the configured branch, checks out that branch, and resets to
-`origin/<THREADKEEPER_EVOLVE_REPO_BRANCH>`. Explicit
+after checking that no Evolve git writer is live, it archives and recovers any
+eligible orphaned tracked WIP, then fetches the configured branch, checks it out,
+and resets to `origin/<THREADKEEPER_EVOLVE_REPO_BRANCH>`. Explicit
 `THREADKEEPER_EVOLVE_REPO_ROOT` checkouts are never refreshed or reset by this
 path. Provisioning reserves 5 GiB by default before clone or `.venv` creation
 (`THREADKEEPER_EVOLVE_REPO_MIN_FREE_BYTES=0` disables that preflight), and a

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -694,10 +694,11 @@ moving the high-water forward; `force=True` bypasses this due gate.
   `ERR evolve_repo_unavailable=<path>` until an explicit `EVOLVE_REPO_ROOT` is
   provided. An explicit override that is not itself a checkout is never
   auto-cloned into and reports `ERR repo_root_not_git`. The disposable managed
-  checkout is refreshed before every code-producing pass: after a clean-tree
-  and no-live-writer check, the parent fetches the configured branch, checks it
-  out, and hard-resets to `origin/<EVOLVE_REPO_BRANCH>`. Explicit checkout
-  roots are never refreshed or reset. Before clone or heavyweight
+  checkout is refreshed before every code-producing pass: after the
+  no-live-writer check, the parent archives and recovers eligible orphaned
+  tracked WIP, fetches the configured branch, checks it out, and hard-resets to
+  `origin/<EVOLVE_REPO_BRANCH>`. Explicit checkout roots are never refreshed or
+  reset. Before clone or heavyweight
   `[semantic,dev]` virtualenv creation, a 5 GiB free-space reserve is checked
   (`EVOLVE_REPO_MIN_FREE_BYTES=0` disables it); `mp_dashboard()` reports
   managed repo/venv/total/free-disk sizes, and
@@ -714,12 +715,15 @@ moving the high-water forward; `force=True` bypasses this due gate.
   mode=git` is recorded on `events.kind='evolve_git_safety'` when tracked WIP is
   present), and no other PR-producing evolve reviewer/applier task may already
   be running. The guard intentionally ignores untracked scratch files, matching
-  `auto_update`'s dirty-check semantics. Child prompts then branch from a fetched
-  base ref (`origin/main` by default, or `origin/<EVOLVE_REPO_BRANCH>`) instead
-  of arbitrary current `HEAD`; reviewer roadmap-doc prompts additionally reuse
-  the daily `docs/roadmap-audit-YYYY-MM-DD` branch or an existing open
-  roadmap-doc PR branch so repeated audits do not collide. The running-writer
-  check precedes dirty-state recovery so active child WIP is never discarded.
+  `auto_update`'s dirty-check semantics. Applier prompts fetch the base and
+  prepare or resume their deterministic local/remote feature branch before any
+  reading or editing, then rebase it on `origin/main` by default (or
+  `origin/<EVOLVE_REPO_BRANCH>`). This makes retries validate previous branch
+  work instead of colliding with a stale local branch after editing the base.
+  Reviewer roadmap-doc prompts additionally reuse the daily
+  `docs/roadmap-audit-YYYY-MM-DD` branch or an existing open roadmap-doc PR
+  branch so repeated audits do not collide. The running-writer check precedes
+  dirty-state recovery so active child WIP is never discarded.
   For the default auto-managed checkout only, an in-progress merge on an
   applier-owned branch is treated as recoverable when GitHub proves the exact
   PR is already merged. The parent fetches the configured base, archives the
@@ -733,8 +737,11 @@ moving the high-water forward; `force=True` bypasses this due gate.
   implementer child — is likewise auto-recovered: with no PR-producing child
   running and the branch's PR state readable (any state, including none), the
   tracked diff is archived as `evolve-recovery/abandoned-wip-*.patch` and the
-  checkout is reset to the fresh base, so one dead child can no longer stall
-  the whole apply backlog behind the dirty gate.
+  checkout is reset to the fresh base. Plain abandoned WIP on the configured
+  base branch is also recoverable in the disposable managed checkout because a
+  pre-fix child could edit there before its late feature-branch creation failed;
+  base-branch recovery does not need a PR lookup. One dead child can therefore
+  no longer stall the whole apply backlog behind refresh's dirty gate.
 - **curator → evolve bridge** — the Curator's lessons/skills audit remains
   snapshot-first and report-first: destructive mode writes a recoverable
   snapshot before spawning the child, then the child writes its REPORT before

--- a/tests/test_agent_status.py
+++ b/tests/test_agent_status.py
@@ -388,6 +388,34 @@ def test_agent_status_evolve_applier_prefers_completion_event(mp_with_cid):
     assert loop["work"] == "Applied 4 lesson consolidations"
 
 
+def test_agent_status_err_pass_does_not_refresh_success_clock(mp_with_cid):
+    pkg = mp_with_cid(_FAKE_CID)
+    conn = pkg["db"].get_db()
+    now = int(time.time())
+    conn.executemany(
+        "INSERT INTO events (session_id, kind, target, summary, created_at) "
+        "VALUES (?, 'evolve_apply_pass', ?, ?, ?)",
+        [
+            (_FAKE_CID, str(now - 7200), "no_apply_work", now - 7200),
+            (
+                _FAKE_CID,
+                str(now - 60),
+                "ERR evolve_repo_refresh_blocked_dirty",
+                now - 60,
+            ),
+        ],
+    )
+    conn.commit()
+
+    from threadkeeper.agent_status import _last_successful_pass
+
+    success = _last_successful_pass(conn, "evolve_apply_pass", now)
+
+    assert success["summary"] == "no_apply_work"
+    assert success["at"] == now - 7200
+    assert success["age_s"] == 7200
+
+
 def test_agent_status_probe_backlog_counts_only_due_objective_probes(mp_with_cid):
     pkg = mp_with_cid(_FAKE_CID)
     pkg["config"].PROBE_INTERVAL_S = 1800

--- a/tests/test_evolve_applier.py
+++ b/tests/test_evolve_applier.py
@@ -316,11 +316,15 @@ def test_apply_evolve_builds_spawn_call(tmp_path, monkeypatch):
     assert "gh pr create" in p
     assert 'git commit -m "<type>: <short imperative summary>"' in p
     assert 'gh pr create --title "<type>: <short>"' in p
-    assert "git fetch origin main" in p
-    assert (
-        f"git checkout -b {pkg['ea'].branch_name(eid, 'add a failed_paths field per thread')} "
-        "origin/main"
-    ) in p
+    branch = pkg["ea"].branch_name(eid, "add a failed_paths field per thread")
+    assert "git fetch origin" in p
+    assert f"refs/heads/{branch}" in p
+    assert f"refs/remotes/origin/{branch}" in p
+    assert f"git checkout -b {branch} origin/main" in p
+    assert f"git rebase origin/main" in p
+    assert p.index("PREPARE OR RESUME THE FEATURE BRANCH") < p.index(
+        "READ threadkeeper/brief.py"
+    )
     assert 'git commit -m "evolve:' not in p
     assert 'gh pr create --title "evolve:' not in p
     assert "evolve_mark_applied" in p
@@ -1119,11 +1123,15 @@ def test_apply_roadmap_issue_builds_evolve_applier_spawn(
     assert "evolve_mark_roadmap_issue_applied" in prompt
     assert "THREADKEEPER_NO_EMBEDDINGS" in prompt
     assert "<!-- thread-keeper:evolve-applier-claim -->" in prompt
-    assert "git fetch origin main" in prompt
-    assert (
-        f"git checkout -b {pkg['ea'].roadmap_issue_branch_name(6, 'Telemetry dashboard')} "
-        "origin/main"
-    ) in prompt
+    branch = pkg["ea"].roadmap_issue_branch_name(6, "Telemetry dashboard")
+    assert "git fetch origin" in prompt
+    assert f"refs/heads/{branch}" in prompt
+    assert f"refs/remotes/origin/{branch}" in prompt
+    assert f"git checkout -b {branch} origin/main" in prompt
+    assert f"git rebase origin/main" in prompt
+    assert prompt.index("Prepare or resume the issue branch") < prompt.index(
+        "Read the relevant code and docs"
+    )
 
 
 def test_apply_roadmap_issue_skips_dirty_worktree_and_records_event(
@@ -2417,6 +2425,91 @@ def test_managed_checkout_refreshes_to_latest_origin_base(tmp_path, monkeypatch)
     assert upstream_head != old_head
 
 
+def test_ensure_repo_ready_recovers_dirty_managed_base_before_refresh(
+    tmp_path, monkeypatch,
+):
+    """A dead child can leave WIP on main if branch setup itself failed.
+
+    Managed refresh must archive and recover that WIP instead of returning
+    ``evolve_repo_refresh_blocked_dirty`` before the recovery gate is reached.
+    """
+    pkg = _bootstrap(tmp_path, monkeypatch, pin_repo=False)
+    repo = pkg["ea"]._managed_repo_dir()
+    remote = tmp_path / "remote.git"
+
+    def run(*cmd, cwd=None):
+        proc = subprocess.run(
+            list(cmd), cwd=str(cwd) if cwd else None, text=True,
+            capture_output=True, check=False,
+        )
+        if proc.returncode != 0:
+            raise AssertionError(proc.stderr or proc.stdout)
+        return proc
+
+    run("git", "init", "--bare", str(remote))
+    run("git", "init", "-b", "main", str(repo))
+    run("git", "config", "user.email", "test@example.com", cwd=repo)
+    run("git", "config", "user.name", "Test", cwd=repo)
+    (repo / "shared.txt").write_text("base\n", encoding="utf-8")
+    run("git", "add", "shared.txt", cwd=repo)
+    run("git", "commit", "-m", "base", cwd=repo)
+    run("git", "remote", "add", "origin", str(remote), cwd=repo)
+    run("git", "push", "-u", "origin", "main", cwd=repo)
+
+    (repo / "shared.txt").write_text(
+        "issue implementation left on main\n", encoding="utf-8"
+    )
+    monkeypatch.setattr(
+        pkg["ea"], "_prs_for_head_branch",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("base-branch recovery must not query PR state")
+        ),
+    )
+
+    root, err = pkg["ea"]._ensure_repo_ready()
+
+    assert root == repo
+    assert err == ""
+    assert run(
+        "git", "status", "--porcelain", "--untracked-files=no", cwd=repo
+    ).stdout == ""
+    assert (repo / "shared.txt").read_text(encoding="utf-8") == "base\n"
+    backups = list(
+        (tmp_path / "evolve-recovery").glob("abandoned-wip-main-*.patch")
+    )
+    assert len(backups) == 1
+    assert "issue implementation left on main" in backups[0].read_text(
+        encoding="utf-8"
+    )
+    row = pkg["db"].get_db().execute(
+        "SELECT target, summary FROM events WHERE kind=? ORDER BY id DESC",
+        (pkg["ea"].EVOLVE_GIT_SAFETY_KIND,),
+    ).fetchone()
+    assert row["target"] == "managed_repo_refresh"
+    assert "recovered_abandoned_wip branch=main" in row["summary"]
+
+
+def test_managed_refresh_checks_live_writer_before_dirty_recovery(
+    tmp_path, monkeypatch,
+):
+    pkg = _bootstrap(tmp_path, monkeypatch, pin_repo=False)
+    repo = pkg["ea"]._managed_repo_dir()
+    monkeypatch.setattr(pkg["ea"], "_is_git_repo", lambda path: True)
+    monkeypatch.setattr(
+        pkg["ea"], "_running_git_writer_children", lambda conn: ["tk_live"]
+    )
+    monkeypatch.setattr(
+        pkg["ea"], "_tracked_worktree_status",
+        lambda path: (_ for _ in ()).throw(
+            AssertionError("must not inspect/recover a live writer's WIP")
+        ),
+    )
+
+    err = pkg["ea"]._refresh_managed_repo(repo)
+
+    assert err == "ERR evolve_repo_refresh_in_use n=1"
+
+
 def test_managed_provision_fails_before_clone_when_disk_is_low(
     tmp_path, monkeypatch,
 ):
@@ -3010,11 +3103,13 @@ def test_abandoned_wip_ignores_non_applier_branch(tmp_path, monkeypatch):
     monkeypatch.setattr(
         pkg["ea"], "_merge_in_progress", lambda repo: (False, ""),
     )
-    monkeypatch.setattr(pkg["ea"], "_current_branch", lambda repo: ("main", ""))
+    monkeypatch.setattr(
+        pkg["ea"], "_current_branch", lambda repo: ("feature/operator-work", "")
+    )
 
     recovered, reason = pkg["ea"]._recover_abandoned_managed_wip(
         tmp_path / "repo"
     )
 
     assert recovered is False
-    assert reason == "abandoned_wip_non_applier_branch=main"
+    assert reason == "abandoned_wip_non_applier_branch=feature/operator-work"

--- a/threadkeeper/agent_status.py
+++ b/threadkeeper/agent_status.py
@@ -512,23 +512,29 @@ def _last_event(conn, kind: str | tuple[str, ...], now: int) -> dict[str, Any]:
 
 
 def _last_successful_pass(conn, kind: str | tuple[str, ...], now: int) -> dict[str, Any]:
-    """Latest completed pass, ignoring repeated single-flight ``*_running`` ticks.
+    """Latest non-failing completed pass.
 
-    The loop still records those ticks for diagnostics, but they only prove
-    that the scheduler woke up — not that the enabled loop completed work.
+    Running/lock rows only prove that the scheduler woke up. ``ERR`` and spawn
+    failures prove the opposite of health and must not refresh the success
+    clock; otherwise a permanently blocked loop reports ``verdict=ok`` forever.
     """
     kinds = (kind,) if isinstance(kind, str) else tuple(k for k in kind if k)
     if not kinds:
         kinds = ("",)
     placeholders = ",".join("?" for _ in kinds)
+    from .notify import classify_summary
     try:
-        row = conn.execute(
+        rows = conn.execute(
             f"SELECT summary, created_at FROM events WHERE kind IN ({placeholders}) "
             "AND lower(COALESCE(summary, '')) NOT LIKE '%_running%' "
             "AND lower(COALESCE(summary, '')) NOT LIKE '%single-flight lock%' "
-            "ORDER BY created_at DESC, id DESC LIMIT 1",
+            "ORDER BY created_at DESC, id DESC",
             kinds,
-        ).fetchone()
+        )
+        row = next(
+            (r for r in rows if classify_summary(r["summary"] or "") != "failure"),
+            None,
+        )
     except Exception:
         row = None
     if not row:

--- a/threadkeeper/evolve_applier.py
+++ b/threadkeeper/evolve_applier.py
@@ -111,16 +111,34 @@ REPO: {repo}   (run everything from here; the project venv is .venv/)
 
 DO, strictly in order:
 
-1. READ threadkeeper/brief.py — specifically render_brief() — and understand the
+1. PREPARE OR RESUME THE FEATURE BRANCH BEFORE READING OR EDITING. Never make
+   implementation changes on the managed checkout's base branch:
+       git fetch origin
+       if git show-ref --verify --quiet refs/heads/{branch}; then
+         git checkout {branch}
+         if git show-ref --verify --quiet refs/remotes/origin/{branch}; then
+           git merge --ff-only origin/{branch}
+         fi
+       elif git show-ref --verify --quiet refs/remotes/origin/{branch}; then
+         git checkout -b {branch} origin/{branch}
+       else
+         git checkout -b {branch} {base_ref}
+       fi
+       git rebase {base_ref}
+   If the branch already contains a previous implementation attempt, inspect
+   and validate that work instead of recreating it. If it cannot be resumed
+   safely, stop before editing and report the blocker.
+
+2. READ threadkeeper/brief.py — specifically render_brief() — and understand the
    sections it emits (core_memory, style, verbatim, open/idle/closed threads,
    evolve_pending, the trailing user-facing reminder, ...). Find exactly where
    the suggestion applies.
 
-2. IMPLEMENT the suggestion by editing render_brief() (and only the helper(s) it
+3. IMPLEMENT the suggestion by editing render_brief() (and only the helper(s) it
    needs). Keep the change surgical and in the existing house style — match the
    surrounding section idiom. Do NOT reformat or touch unrelated code.
 
-3. ADD or EXTEND A GOLDEN TEST under tests/ (extend tests/test_brief_sections.py
+4. ADD or EXTEND A GOLDEN TEST under tests/ (extend tests/test_brief_sections.py
    or add tests/test_evolve_apply_{evolve_id}.py). It MUST assert BOTH:
      (a) the NEW behavior/field the suggestion asks for actually appears in the
          rendered brief for a seeded fixture, AND
@@ -131,7 +149,7 @@ DO, strictly in order:
    Mirror the bootstrap/fixture style of tests/test_brief_sections.py and
    tests/test_evolve_daemon.py (env setup, module reload, render_brief(conn)).
 
-4. RUN THE FULL SUITE from the repo root and read the FINAL summary line.
+5. RUN THE FULL SUITE from the repo root and read the FINAL summary line.
    IMPORTANT: your spawned environment sets THREADKEEPER_NO_EMBEDDINGS=1 (the
    slim-child default). That makes the embedding/vector tests (test_vec_search,
    test_delegated_search, test_onnx_embeddings) fail SPURIOUSLY — they are NOT
@@ -142,10 +160,8 @@ DO, strictly in order:
    IS related to your brief change, FIX it (your change or your test) and re-run
    until green. Do NOT proceed while red.
 
-5. OPEN A PR — only after the suite is GREEN:
-     • Create a NEW feature branch (NEVER commit on main):
-         git fetch origin {base_branch}
-         git checkout -b {branch} {base_ref}
+6. OPEN A PR — only after the suite is GREEN:
+     • Confirm you are still on `{branch}`; NEVER commit on main.
      • Choose a Conventional Commits type allowed by CONTRIBUTING.md and
        .github/workflows/pr-title.yml. Use `feat` for new/changed brief output
        and `fix` for a broken existing brief behavior. Do NOT use `evolve:`:
@@ -165,7 +181,7 @@ DO, strictly in order:
        gh path.
      • Capture the PR URL that gh prints.
 
-6. RECORD COMPLETION — ONLY after gh pr create printed a real PR URL — call the
+7. RECORD COMPLETION — ONLY after gh pr create printed a real PR URL — call the
    thread-keeper MCP tool:
        evolve_mark_applied(evolve_id={evolve_id}, pr_url="<the PR url>")
    This sets applied=1 so the suggestion stops resurfacing.
@@ -345,20 +361,37 @@ other agents do not start the same issue in parallel. Do not remove it. If you
 abort after doing meaningful investigation, leave a normal issue comment with
 the blocker/status so a later agent has enough context.
 
-2. Read the relevant code and docs before editing. Also read docs/ROADMAP.md
+2. Prepare or resume the issue branch BEFORE reading or editing so a branch-name
+   collision cannot leave implementation changes on the managed checkout's base:
+     git fetch origin
+     if git show-ref --verify --quiet refs/heads/{branch}; then
+       git checkout {branch}
+       if git show-ref --verify --quiet refs/remotes/origin/{branch}; then
+         git merge --ff-only origin/{branch}
+       fi
+     elif git show-ref --verify --quiet refs/remotes/origin/{branch}; then
+       git checkout -b {branch} origin/{branch}
+     else
+       git checkout -b {branch} {base_ref}
+     fi
+     git rebase {base_ref}
+   If the branch already contains a previous implementation attempt, inspect
+   and validate it instead of recreating it. If the branch cannot be resumed
+   safely, comment with the blocker and stop before editing.
+
+3. Read the relevant code and docs before editing. Also read docs/ROADMAP.md
    and the issue body so the implementation matches the tracked roadmap item.
 
-3. Implement only this issue. Keep the change surgical, update README /
+4. Implement only this issue. Keep the change surgical, update README /
    docs/ARCHITECTURE.md / docs/ROADMAP.md / CHANGELOG.md when behavior or
    documented state changes, and add focused tests proportional to risk.
 
-4. Run the full suite from the repo root and read the FINAL summary line:
+5. Run the full suite from the repo root and read the FINAL summary line:
      env -u THREADKEEPER_NO_EMBEDDINGS .venv/bin/python -m pytest -q
    It MUST report 0 failed. Fix related failures and re-run until green.
 
-5. Open a PR on a new branch; never commit on main:
-     git fetch origin {base_branch}
-     git checkout -b {branch} {base_ref}
+6. Open a PR from the prepared issue branch; never commit on main:
+     git branch --show-current  # must print {branch}
      git add <only files you changed>
      git commit -m "<type>: <short imperative summary>"
      git push -u origin {branch}
@@ -372,7 +405,7 @@ the blocker/status so a later agent has enough context.
    the real GitHub CLI receives them, and refuses if unsafe content remains. Do
    not bypass it with an absolute gh path.
 
-6. ONLY after gh prints a real PR URL, call:
+7. ONLY after gh prints a real PR URL, call:
      evolve_mark_roadmap_issue_applied(
        issue_number={issue_number},
        pr_url="<the PR url>"
@@ -985,10 +1018,13 @@ def _recover_abandoned_managed_wip(
     does not apply there, and the dirty gate then blocks every future backlog
     item until a human resets the checkout (observed live: one abandoned
     `roadmap/issue-…` branch stalled a 43-item backlog for days). Deliberately
-    narrow: managed checkout only, applier-owned branch, no merge in progress,
-    the branch's PR state must be readable (any state — none, open, merged,
-    closed — is safe once the diff is preserved), and the tracked diff is
-    archived before any reset. Uncertain state stays fail-closed for a human.
+    narrow: managed checkout only, an applier-owned branch or the configured
+    base branch, no merge in progress, and an archived tracked diff before any
+    reset. Applier branches additionally require readable PR state (any state —
+    none, open, merged, closed — is safe once the diff is preserved). Base-branch
+    WIP is recoverable because this checkout is disposable and never an explicit
+    operator checkout; this covers a child that failed to create/resume its
+    deterministic branch before editing. Uncertain state stays fail-closed.
 
     The caller has already established that no PR-producing child is running,
     so the WIP is orphaned rather than owned.
@@ -1003,11 +1039,14 @@ def _recover_abandoned_managed_wip(
     branch, branch_err = _current_branch(repo_root)
     if branch_err:
         return False, f"abandoned_wip_branch_failed={_short(branch_err)}"
-    if not branch.startswith(APPLIER_BRANCH_PREFIXES):
+    is_applier_branch = branch.startswith(APPLIER_BRANCH_PREFIXES)
+    is_base_branch = branch == _base_branch_name()
+    if not is_applier_branch and not is_base_branch:
         return False, f"abandoned_wip_non_applier_branch={_short(branch or '?')}"
-    _prs, pr_err = _prs_for_head_branch(branch, repo_root)
-    if pr_err:
-        return False, f"abandoned_wip_pr_fetch_failed={_short(pr_err)}"
+    if is_applier_branch:
+        _prs, pr_err = _prs_for_head_branch(branch, repo_root)
+        if pr_err:
+            return False, f"abandoned_wip_pr_fetch_failed={_short(pr_err)}"
 
     fetch_err = _run(
         ["git", "fetch", "origin", _base_branch_name()],
@@ -1044,6 +1083,14 @@ def _recover_abandoned_managed_wip(
         f"recovered_abandoned_wip branch={_short(branch, 80)} "
         f"backup={backup.name}"
     )
+
+
+def _recover_dirty_managed_checkout(repo_root: Path) -> tuple[bool, str]:
+    """Recover orphaned dirty state after the live-writer check passed."""
+    recovered, recovery = _recover_stale_managed_merge(repo_root)
+    if not recovered and not recovery:
+        recovered, recovery = _recover_abandoned_managed_wip(repo_root)
+    return recovered, recovery
 
 
 def _record_git_safety_event(
@@ -1125,11 +1172,7 @@ def _git_worktree_precondition(
         _record_git_safety_event(conn, actor, outcome)
         return outcome
     if dirty:
-        recovered, recovery = _recover_stale_managed_merge(repo_root)
-        if not recovered and not recovery:
-            # No merge in progress (and no engaged-but-failed reason): a dead
-            # child may have left plain uncommitted WIP on its applier branch.
-            recovered, recovery = _recover_abandoned_managed_wip(repo_root)
+        recovered, recovery = _recover_dirty_managed_checkout(repo_root)
         if recovered:
             _record_git_safety_event(conn, actor, recovery)
             dirty, err = _tracked_worktree_status(repo_root)
@@ -1219,26 +1262,39 @@ def _provision_managed_repo(dest: Path) -> str:
 def _refresh_managed_repo(dest: Path) -> str:
     """Fast-forward only the disposable managed checkout to its base branch.
 
-    Explicit checkout roots are never routed here. A clean but old applier
-    branch is safe to replace after its child has ended; tracked edits and live
-    writers fail closed instead of being reset underneath their owner.
+    Explicit checkout roots are never routed here. Live writers fail closed.
+    Orphaned tracked edits are archived and recovered before refresh; uncertain
+    ownership still fails closed instead of being reset underneath an owner.
     """
     with _repo_provision_lock() as lock_err:
         if lock_err:
             return lock_err
         if not _is_git_repo(dest):
             return "ERR evolve_repo_refresh_missing_checkout"
-        dirty, status_err = _tracked_worktree_status(dest)
-        if status_err:
-            return f"ERR evolve_repo_refresh_status_failed={_short(status_err)}"
-        if dirty:
-            return "ERR evolve_repo_refresh_blocked_dirty"
         try:
-            running = _running_git_writer_children(get_db())
+            conn = get_db()
+            running = _running_git_writer_children(conn)
         except Exception as e:  # noqa: BLE001 — fail closed before a reset.
             return f"ERR evolve_repo_refresh_running_check_failed={_short(str(e))}"
         if running:
             return f"ERR evolve_repo_refresh_in_use n={len(running)}"
+        dirty, status_err = _tracked_worktree_status(dest)
+        if status_err:
+            return f"ERR evolve_repo_refresh_status_failed={_short(status_err)}"
+        if dirty:
+            recovered, recovery = _recover_dirty_managed_checkout(dest)
+            if not recovered:
+                suffix = f" reason={_short(recovery)}" if recovery else ""
+                return f"ERR evolve_repo_refresh_blocked_dirty{suffix}"
+            _record_git_safety_event(conn, "managed_repo_refresh", recovery)
+            dirty, status_err = _tracked_worktree_status(dest)
+            if status_err:
+                return (
+                    "ERR evolve_repo_refresh_status_failed_after_recovery="
+                    f"{_short(status_err)}"
+                )
+            if dirty:
+                return "ERR evolve_repo_refresh_recovery_left_dirty"
         branch = _base_branch_name()
         fetch_err = _run(["git", "fetch", "origin", branch], 60, cwd=dest)
         if fetch_err:


### PR DESCRIPTION
## What changed

- recover eligible abandoned tracked WIP before refreshing the disposable managed checkout
- allow archived recovery of orphaned WIP left on the configured base branch
- prepare or resume deterministic applier branches before any reading or editing
- stop `ERR` and spawn-failure pass events from refreshing the agent health success clock
- document the lifecycle and add regression coverage

## Root cause

Managed checkout refresh rejected a dirty tree before the abandoned-WIP recovery gate could run. A failed retry of issue #120 also created its deterministic branch only after implementation, so a pre-existing local branch caused checkout to fail after twelve files had already been edited on `main`. Every later scheduled pass then returned `evolve_repo_refresh_blocked_dirty`.

## Impact

A dead implementer can no longer stall every queued roadmap issue. Eligible orphaned changes are preserved as owner-only recovery patches before reset, while active writers, explicit operator checkouts, and uncertain ownership remain fail-closed.

## Validation

- `env -u THREADKEEPER_NO_EMBEDDINGS .venv/bin/python -m pytest -q tests/test_evolve_applier.py tests/test_agent_status.py`
- `env -u THREADKEEPER_NO_EMBEDDINGS .venv/bin/python -m pytest -q`
- live managed-checkout recovery preserved the abandoned #120 diff as a `0600` patch and returned the checkout cleanly to `main@b52a9f6`
