### PR TITLE
fix: pin embedding model revisions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,6 +18,9 @@
 # ── embeddings / semantic search ──
 # THREADKEEPER_EMBED_MODEL=paraphrase-multilingual-MiniLM-L12-v2
 # THREADKEEPER_EMBED_BACKEND=onnx              # onnx | sentence-transformers
+# THREADKEEPER_EMBED_REVISION=                 # blank = built-in immutable pin; set a commit SHA only when intentionally upgrading
+# THREADKEEPER_EMBED_CACHE_DIR=~/.cache/huggingface/hub  # durable snapshot cache; set a shared CI cache location if HOME is isolated
+# THREADKEEPER_EMBED_LOCAL_FILES_ONLY=false     # true = require the pinned snapshot to already be cached (offline/air-gapped)
 # THREADKEEPER_NO_EMBEDDINGS=false             # true on slim children (FTS-only)
 
 # ── identity / process origin ──

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,9 @@ jobs:
   pytest:
     name: pytest (py${{ matrix.python }})
     runs-on: ubuntu-latest
+    env:
+      # This remains stable while tests intentionally isolate HOME per case.
+      THREADKEEPER_EMBED_CACHE_DIR: ${{ github.workspace }}/.cache/huggingface/hub
     strategy:
       fail-fast: false
       matrix:
@@ -34,8 +37,18 @@ jobs:
           # test_vec_search) assert on actual cosine search behavior and
           # don't have a skip-when-missing guard. semantic now uses
           # fastembed/ONNX Runtime (no PyTorch) + numpy + sqlite-vec; the
-          # model is fetched from HF on first use and is small.
+          # model snapshot is pinned and pre-fetched below.
           pip install -e '.[semantic,dev]'
+
+      - name: Cache pinned embedding snapshot
+        uses: actions/cache@v4
+        with:
+          path: ${{ github.workspace }}/.cache/huggingface
+          key: huggingface-${{ runner.os }}-py${{ matrix.python }}-${{ hashFiles('threadkeeper/config.py') }}
+
+      - name: Pre-fetch pinned embedding snapshot
+        run: |
+          python -c 'from threadkeeper.embeddings import prefetch_embedding_model; print(prefetch_embedding_model())'
 
       - name: Run pytest
         env:
@@ -45,6 +58,9 @@ jobs:
           THREADKEEPER_SHADOW_REVIEW_INTERVAL_S: "0"
           THREADKEEPER_SPAWN_BUDGET_POLL_S: "0"
           THREADKEEPER_SEARCH_PROXY_POLL_S: "0"
+          # Semantic tests prove the cached pin is usable without a Hub request.
+          THREADKEEPER_EMBED_LOCAL_FILES_ONLY: "1"
+          HF_HUB_OFFLINE: "1"
         run: |
           # --forked isolates each test in its own process. The suite's
           # per-test package re-import (tests/conftest.py) otherwise piles up

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,17 @@ version bumps follow semver per the policy in
   `mp_dashboard()` now reports managed repo/venv/total/free-disk footprint, and
   `evolve_prune_managed_venv(confirm=True)` explicitly reclaims the managed
   virtualenv without deleting its clone.
+- **Fixed: embedding artifacts are revision-pinned (#120).** Both backends now
+  use immutable Hugging Face commits by default; the revision is configurable
+  through `THREADKEEPER_EMBED_REVISION`, part of the stored
+  embedding-generation fingerprint, and visible in dashboard generation
+  health. FastEmbed resolves the exact ONNX snapshot before loading, while the
+  sentence-transformers fallback receives its revision directly. CI caches and
+  pre-fetches the snapshot into `THREADKEEPER_EMBED_CACHE_DIR`, then runs
+  semantic tests in offline mode; set
+  `THREADKEEPER_EMBED_LOCAL_FILES_ONLY=1` to require that same cached-only
+  behavior in an air-gapped deployment. Change a model/revision deliberately
+  and run `tk-migrate-embeddings --all` to recompute the store.
 - **Fixed: evolve reviewer backlog is mechanically bounded (#115).** Before
   dispatching its privileged issue-creating audit phase, the reviewer now
   counts open, not-yet-applied roadmap issues and records

--- a/README.md
+++ b/README.md
@@ -1163,6 +1163,9 @@ The most-used env knobs (full list in `threadkeeper/config.py`):
 | `THREADKEEPER_NO_EMBEDDINGS` | "" | force-disable the embedding model (FTS5 + delegate only) |
 | `THREADKEEPER_EMBED_BACKEND` | `onnx` | embedding runtime: `onnx` (fastembed, no PyTorch) or `sentence-transformers` (legacy fallback) |
 | `THREADKEEPER_EMBED_MODEL` | `paraphrase-multilingual-MiniLM-L12-v2` | 384-dim cross-lingual embedding model |
+| `THREADKEEPER_EMBED_REVISION` | backend-specific immutable commit | Hugging Face snapshot pin; set an intentional replacement commit only together with a re-embedding plan |
+| `THREADKEEPER_EMBED_CACHE_DIR` | `~/.cache/huggingface/hub` | durable Hugging Face snapshot cache |
+| `THREADKEEPER_EMBED_LOCAL_FILES_ONLY` | false | require the pinned snapshot in the local Hugging Face cache (offline / air-gapped mode) |
 | `THREADKEEPER_SPAWNED_CHILD` | "" | spawn-internal marker; disables autonomous daemons in children |
 | `THREADKEEPER_SKILL_NUDGE_INTERVAL` | 10 | events between `skill_hint` nudges |
 | `THREADKEEPER_DIALECTIC_MINE_INTERVAL_S` | 0 (off) | dialectic_miner daemon tick (s); 0 disables mechanical observation capture |
@@ -1474,6 +1477,13 @@ RU+EN+50 langs). The default backend is **fastembed / ONNX Runtime** — no
 PyTorch. A model-loaded process sits at ~700 MB physical footprint
 (~850 MB RSS), down from ~1.8 GB on the PyTorch backend.
 
+The model artifact is loaded from an immutable, backend-specific Hugging Face
+commit by default. The active model and revision are part of the stored
+embedding-generation fingerprint shown by `mp_dashboard()`, so changing a
+snapshot cannot silently mix vectors with an older space. Set
+`THREADKEEPER_EMBED_LOCAL_FILES_ONLY=1` after priming the Hugging Face cache to
+run semantic search without model-download network access.
+
 A **sentence-transformers** (PyTorch) backend is kept as an opt-in fallback.
 It is heavier (~1.8 GB RSS) and produces vectors that are *not numerically
 identical* to the ONNX backend's, so switching backends warrants a recompute:
@@ -1492,6 +1502,12 @@ tk-migrate-embeddings --dry-run      # report stale counts only
 The migration is batched, resumable, and idempotent (a second run finds
 nothing stale). Both backends emit 384-dim vectors, so the `vec0` schema is
 unchanged.
+
+**Intentional model revision upgrade.** Set `THREADKEEPER_EMBED_REVISION` to
+the immutable commit for the selected backend's Hugging Face artifact, restart
+the host, then run `tk-migrate-embeddings --all`. A changed revision is a new
+embedding generation; until migration, old vectors remain available through
+FTS rather than being compared against the new vector space.
 
 Stored rows carry an embedding-generation fingerprint, not just the backend:
 backend, model ID, vector dimension, pooling contract, and compatible runtime

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1418,10 +1418,15 @@ default `onnx` runs the model through **fastembed / ONNX Runtime** (no PyTorch,
 ~700 MB footprint / ~850 MB RSS); `sentence-transformers` is a heavier opt-in
 fallback (~1.8 GB). `_encode()` L2-normalizes both backends' output so the dot product
 used by vec0 and the legacy path equals cosine. Each row records a generation
-fingerprint in `embed_backend`: backend, model, dimension, pooling contract,
-and compatible runtime version (NULL = legacy). Dense retrieval filters to the
-current fingerprint; stale rows remain visible to the always-on FTS channel.
-After a backend/runtime generation switch, run `tk-migrate-embeddings --all`
+fingerprint in `embed_backend`: backend, model, immutable Hugging Face
+revision, dimension, pooling contract, and compatible runtime version (NULL =
+legacy). FastEmbed resolves its ONNX artifact to a pinned local Hub snapshot
+before loading; sentence-transformers receives its configured revision directly.
+`THREADKEEPER_EMBED_CACHE_DIR` holds the durable snapshot cache, and
+`THREADKEEPER_EMBED_LOCAL_FILES_ONLY=1` makes a cache miss fail without a Hub
+request. Dense retrieval filters to the current fingerprint; stale rows remain
+visible to the always-on FTS channel. After a backend/model/revision/runtime
+generation switch, run `tk-migrate-embeddings --all`
 (`migrate_embeddings.py`) to recompute stale rows into one consistent space.
 
 `retrieval.py` normalizes notes and dialog hits into one `Candidate` model.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -47,6 +47,11 @@ remains a live question.
 - sqlite-vec HNSW: `notes_vec` / `dialog_vec` virtual tables on vec0,
   ~10x faster than Python-side cosine, fallback when vec0 is absent.
 - FTS5 + semantic hybrid in `search` / `dialog_search`.
+- Reproducible embedding snapshots (#120): both backends use immutable Hugging
+  Face revisions by default, the revision is part of the searchable vector
+  generation, and CI pre-fetches the pinned snapshot before running semantic
+  tests offline. An intentional model/revision upgrade requires
+  `tk-migrate-embeddings --all`.
 - `extract_recent` + review/accept/reject ledger — regex candidates with
   manual approval (mem0-style without LLM on this side).
 - ingest fix — Skill-tool-only messages are no longer skipped.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,8 @@ semantic = [
     # family so stored document vectors and fresh query vectors share a space;
     # embeddings.py fingerprints the generation for resumable migration.
     "fastembed>=0.8,<0.9",
+    # Used directly to resolve the pinned FastEmbed snapshot before model load.
+    "huggingface-hub>=0.20",
     "numpy>=1.24.0",
     "sqlite-vec>=0.1.9",
 ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,6 +23,15 @@ def isolated_cli_homes(tmp_path, monkeypatch):
     home.mkdir(parents=True, exist_ok=True)
     monkeypatch.setenv("HOME", str(home))
     monkeypatch.setenv("CODEX_HOME", str(home / ".codex"))
+    # Model snapshots are large and immutable. Reuse one cache across the
+    # per-test HOME sandboxes so a normal local full-suite run downloads the
+    # pinned artifact once rather than once per semantic test. CI's explicit
+    # workspace cache continues to win when supplied.
+    if "THREADKEEPER_EMBED_CACHE_DIR" not in os.environ:
+        monkeypatch.setenv(
+            "THREADKEEPER_EMBED_CACHE_DIR",
+            str(Path(tempfile.gettempdir()) / "threadkeeper-test-hf-cache"),
+        )
     monkeypatch.setenv("THREADKEEPER_AUTO_UPDATE_INTERVAL_S", "0")
     monkeypatch.setenv("THREADKEEPER_SKILL_UPDATE_INTERVAL_S", "0")
     monkeypatch.delenv("THREADKEEPER_EXTRA_SKILLS_DIRS", raising=False)

--- a/tests/test_config_settings.py
+++ b/tests/test_config_settings.py
@@ -54,6 +54,9 @@ def test_defaults_match(monkeypatch):
     assert c.AUTO_UPDATE_EXPECTED_PUBLISHER_REPOSITORY == "po4erk91/thread-keeper"
     assert c.AUTO_UPDATE_EXPECTED_PUBLISHER_WORKFLOW == "publish.yml"
     assert c.AUTO_UPDATE_EXPECTED_PUBLISHER_ENVIRONMENT == "pypi"
+    assert c.EMBED_REVISION == c.DEFAULT_FASTEMBED_EMBED_REVISION
+    assert c.EMBED_LOCAL_FILES_ONLY is False
+    assert c.EMBED_CACHE_DIR == Path.home() / ".cache" / "huggingface" / "hub"
     assert c.SKILL_UPDATE_INTERVAL_S == 302400
     assert c.SKILL_UPDATE_INFER_SOURCES is True
     assert c.CURATOR_SNAPSHOT_RETENTION == 10
@@ -65,6 +68,22 @@ def test_defaults_match(monkeypatch):
 def test_env_overrides_default(monkeypatch):
     c = _fresh_config(monkeypatch, env={"THREADKEEPER_MEMORY_NUDGE_INTERVAL": "3"})
     assert c.MEMORY_NUDGE_INTERVAL == 3
+
+
+def test_embed_revision_is_backend_pinned_and_configurable(monkeypatch):
+    c = _fresh_config(monkeypatch, env={
+        "THREADKEEPER_EMBED_BACKEND": "sentence-transformers",
+    })
+    assert c.EMBED_REVISION == c.DEFAULT_SENTENCE_TRANSFORMERS_EMBED_REVISION
+
+    c = _fresh_config(monkeypatch, env={
+        "THREADKEEPER_EMBED_REVISION": "custom-snapshot",
+        "THREADKEEPER_EMBED_LOCAL_FILES_ONLY": "1",
+        "THREADKEEPER_EMBED_CACHE_DIR": "/tmp/pinned-model-cache",
+    })
+    assert c.EMBED_REVISION == "custom-snapshot"
+    assert c.EMBED_LOCAL_FILES_ONLY is True
+    assert c.EMBED_CACHE_DIR == Path("/tmp/pinned-model-cache")
 
 
 def test_retention_env_overrides(monkeypatch):
@@ -238,7 +257,10 @@ def test_all_exported_names_present(monkeypatch):
         "DIALECTIC_VALIDATE_MIN",
         "DIALOG_LOG",
         "EMBED_BACKEND",
+        "EMBED_CACHE_DIR",
+        "EMBED_LOCAL_FILES_ONLY",
         "EMBED_MODEL_NAME",
+        "EMBED_REVISION",
         "EVOLVE_REVIEW_INTERVAL_S",
         "EVOLVE_REVIEW_MIN",
         "EVOLVE_REVIEW_BACKLOG_MAX",

--- a/tests/test_embedding_generation.py
+++ b/tests/test_embedding_generation.py
@@ -10,6 +10,7 @@ def test_fingerprint_names_vector_space(fresh_mp):
     tag = embeddings.embedding_fingerprint()
     assert fresh_mp["config"].EMBED_BACKEND in tag
     assert fresh_mp["config"].EMBED_MODEL_NAME in tag
+    assert f"revision={fresh_mp['config'].EMBED_REVISION}" in tag
     assert f"dim={fresh_mp['config'].EMBED_DIM}" in tag
     assert "pool=" in tag
     assert "runtime=" in tag

--- a/tests/test_embedding_model_revision.py
+++ b/tests/test_embedding_model_revision.py
@@ -1,0 +1,90 @@
+"""Embedding loaders must resolve immutable Hub snapshots before loading."""
+from __future__ import annotations
+
+import importlib
+import sys
+from types import ModuleType
+
+
+def _reimport(monkeypatch, tmp_path, **env):
+    base = {
+        "THREADKEEPER_DB": str(tmp_path / "db.sqlite"),
+        "THREADKEEPER_DISABLE_BG_DAEMONS": "1",
+    }
+    base.update(env)
+    for key, value in base.items():
+        monkeypatch.setenv(key, value)
+    for name in [name for name in sys.modules if name.startswith("threadkeeper")]:
+        del sys.modules[name]
+    return importlib.import_module("threadkeeper.embeddings")
+
+
+def test_onnx_loader_uses_configured_pinned_snapshot(monkeypatch, tmp_path):
+    emb = _reimport(
+        monkeypatch, tmp_path,
+        THREADKEEPER_EMBED_REVISION="test-pinned-revision",
+        THREADKEEPER_EMBED_LOCAL_FILES_ONLY="1",
+    )
+    seen = {}
+
+    class FakeTextEmbedding:
+        def __init__(self, **kwargs):
+            seen["loader"] = kwargs
+
+        @staticmethod
+        def list_supported_models():
+            return [{
+                "model": emb.FASTEMBED_MODEL_ID,
+                "sources": {"hf": "Qdrant/pinned-onnx-artifact"},
+            }]
+
+    fake_fastembed = ModuleType("fastembed")
+    fake_fastembed.TextEmbedding = FakeTextEmbedding
+    fake_hub = ModuleType("huggingface_hub")
+
+    def snapshot_download(**kwargs):
+        seen["snapshot"] = kwargs
+        return "/cached/pinned-snapshot"
+
+    fake_hub.snapshot_download = snapshot_download
+    monkeypatch.setitem(sys.modules, "fastembed", fake_fastembed)
+    monkeypatch.setitem(sys.modules, "huggingface_hub", fake_hub)
+    monkeypatch.setattr(emb, "SEMANTIC_AVAILABLE", True)
+
+    assert isinstance(emb._get_model(), FakeTextEmbedding)
+    assert seen["snapshot"]["repo_id"] == "Qdrant/pinned-onnx-artifact"
+    assert seen["snapshot"]["revision"] == "test-pinned-revision"
+    assert seen["snapshot"]["cache_dir"] == str(emb.EMBED_CACHE_DIR)
+    assert seen["snapshot"]["local_files_only"] is True
+    assert seen["loader"] == {
+        "model_name": emb.FASTEMBED_MODEL_ID,
+        "specific_model_path": "/cached/pinned-snapshot",
+    }
+
+
+def test_sentence_transformer_loader_passes_configured_revision(monkeypatch, tmp_path):
+    emb = _reimport(
+        monkeypatch, tmp_path,
+        THREADKEEPER_EMBED_REVISION="test-pinned-revision",
+    )
+    seen = {}
+
+    class FakeSentenceTransformer:
+        def __init__(self, model_name, **kwargs):
+            seen["model_name"] = model_name
+            seen["kwargs"] = kwargs
+
+    fake_st = ModuleType("sentence_transformers")
+    fake_st.SentenceTransformer = FakeSentenceTransformer
+    monkeypatch.setitem(sys.modules, "sentence_transformers", fake_st)
+    monkeypatch.setattr(emb, "SEMANTIC_AVAILABLE", True)
+    monkeypatch.setattr(emb, "EMBED_BACKEND", "sentence-transformers")
+
+    assert isinstance(emb._get_model(), FakeSentenceTransformer)
+    assert seen == {
+        "model_name": emb.EMBED_MODEL_NAME,
+        "kwargs": {
+            "cache_folder": str(emb.EMBED_CACHE_DIR),
+            "revision": "test-pinned-revision",
+        },
+    }

--- a/threadkeeper/config.py
+++ b/threadkeeper/config.py
@@ -26,6 +26,15 @@ from .permissions import harden_storage_paths
 
 logger = logging.getLogger(__name__)
 
+# These immutable Hugging Face commits identify the two artifacts used by the
+# default embedding backends.  FastEmbed consumes Qdrant's optimized ONNX port;
+# sentence-transformers consumes the upstream model repository, so the commits
+# necessarily differ even though both expose the same logical model.
+DEFAULT_FASTEMBED_EMBED_REVISION = "faf4aa4225822f3bc6376869cb1164e8e3feedd0"
+DEFAULT_SENTENCE_TRANSFORMERS_EMBED_REVISION = (
+    "e8f8c211226b894fcb81acc59f3b34ba3efd5f42"
+)
+
 # ── env-file path resolved at module load so THREADKEEPER_ENV_FILE override works ──
 _ENV_FILE: str = os.environ.get(
     "THREADKEEPER_ENV_FILE",
@@ -87,6 +96,32 @@ class Settings(BaseSettings):
         validation_alias=AliasChoices("THREADKEEPER_EMBED_MODEL", "embed_model"),
     )
     embed_backend: str = "onnx"
+    # Empty selects the backend-specific immutable default below. Supplying a
+    # value overrides that pin, which is deliberate model-space migration work.
+    embed_revision: str = Field(
+        default="",
+        validation_alias=AliasChoices(
+            "THREADKEEPER_EMBED_REVISION", "embed_revision"
+        ),
+    )
+    # Refuse network access when the required snapshot should already be in the
+    # Hugging Face cache. This is useful for deterministic/offline CI and
+    # air-gapped deployments.
+    embed_local_files_only: bool = Field(
+        default=False,
+        validation_alias=AliasChoices(
+            "THREADKEEPER_EMBED_LOCAL_FILES_ONLY", "embed_local_files_only"
+        ),
+    )
+    # Keep model snapshots in a durable cache instead of FastEmbed's temporary
+    # default. CI can override this with a workspace cache that survives tests'
+    # isolated HOME directories.
+    embed_cache_dir: Path = Field(
+        default=Path("~/.cache/huggingface/hub"),
+        validation_alias=AliasChoices(
+            "THREADKEEPER_EMBED_CACHE_DIR", "embed_cache_dir"
+        ),
+    )
     # Vector width the vec0 (`notes_vec`/`dialog_vec`) tables are CREATEd with.
     # Defaults to 384 (paraphrase-multilingual-MiniLM-L12-v2). When swapping in
     # a model of a different dimension via THREADKEEPER_EMBED_MODEL, set this to
@@ -503,6 +538,7 @@ class Settings(BaseSettings):
         "claude_skills_dir",
         "claude_projects_dir",
         "task_log_dir",
+        "embed_cache_dir",
         mode="after",
     )
     @classmethod
@@ -979,6 +1015,20 @@ FASTEMBED_MODEL_ID: str = (
     if "/" in EMBED_MODEL_NAME
     else f"sentence-transformers/{EMBED_MODEL_NAME}"
 )
+
+# Backend and revision are both model-space contracts: changing either in a
+# live process while its old model remains resident could tag vectors with the
+# wrong generation. Like EMBED_DIM, they intentionally take effect on restart.
+EMBED_REVISION: str = (
+    settings.embed_revision.strip()
+    or (
+        DEFAULT_SENTENCE_TRANSFORMERS_EMBED_REVISION
+        if EMBED_BACKEND == "sentence-transformers"
+        else DEFAULT_FASTEMBED_EMBED_REVISION
+    )
+)
+EMBED_LOCAL_FILES_ONLY: bool = bool(settings.embed_local_files_only)
+EMBED_CACHE_DIR: Path = settings.embed_cache_dir
 
 # Embedding dimension the vec0 virtual tables are created with. Computed once
 # here (NOT via _derive_constants) because, like the embedding backend, it is

--- a/threadkeeper/embeddings.py
+++ b/threadkeeper/embeddings.py
@@ -24,6 +24,9 @@ from .config import (
     SEMANTIC_AVAILABLE,
     EMBED_MODEL_NAME,
     EMBED_BACKEND,
+    EMBED_CACHE_DIR,
+    EMBED_LOCAL_FILES_ONLY,
+    EMBED_REVISION,
     EMBED_DIM,
     FASTEMBED_MODEL_ID,
 )
@@ -74,6 +77,67 @@ _model = None
 _model_lock = threading.RLock()
 _last_used_at = 0.0
 
+_FASTEMBED_HUB_ALLOW_PATTERNS = (
+    "config.json",
+    "tokenizer.json",
+    "tokenizer_config.json",
+    "special_tokens_map.json",
+    "preprocessor_config.json",
+    "model_optimized.onnx",
+)
+
+
+def _fastembed_snapshot_path() -> str:
+    """Return the pinned FastEmbed artifact snapshot for the active model.
+
+    FastEmbed 0.8's public ``TextEmbedding`` constructor accepts arbitrary
+    keyword arguments but does not forward ``revision`` to its Hub download
+    helper. Resolve the registry's actual Hugging Face source ourselves, then
+    hand FastEmbed that immutable local snapshot via ``specific_model_path``.
+    This keeps its model registry/pooling behavior while making the artifact
+    choice explicit and testable.
+    """
+    from fastembed import TextEmbedding  # type: ignore
+    from huggingface_hub import snapshot_download  # type: ignore
+
+    source = next(
+        (
+            model.get("sources", {}).get("hf")
+            for model in TextEmbedding.list_supported_models()
+            if model.get("model", "").lower() == FASTEMBED_MODEL_ID.lower()
+        ),
+        None,
+    )
+    if not source:
+        raise ValueError(
+            f"FastEmbed model {FASTEMBED_MODEL_ID!r} has no Hugging Face source; "
+            "choose a supported model with an HF source to use a pinned revision."
+        )
+    return str(snapshot_download(
+        repo_id=source,
+        revision=EMBED_REVISION,
+        cache_dir=str(EMBED_CACHE_DIR),
+        allow_patterns=list(_FASTEMBED_HUB_ALLOW_PATTERNS),
+        local_files_only=EMBED_LOCAL_FILES_ONLY,
+    ))
+
+
+def prefetch_embedding_model() -> str:
+    """Download (or verify from cache) the active pinned embedding snapshot.
+
+    CI calls this before entering offline test mode; deployers can use it to
+    prime an air-gapped cache without loading ONNX Runtime or encoding text.
+    """
+    if EMBED_BACKEND == "sentence-transformers":
+        from huggingface_hub import snapshot_download  # type: ignore
+        return str(snapshot_download(
+            repo_id=EMBED_MODEL_NAME,
+            revision=EMBED_REVISION,
+            cache_dir=str(EMBED_CACHE_DIR),
+            local_files_only=EMBED_LOCAL_FILES_ONLY,
+        ))
+    return _fastembed_snapshot_path()
+
 def _get_model():
     """Lazily load and cache the embedding model for the active backend.
 
@@ -85,9 +149,17 @@ def _get_model():
         return None
     with _model_lock:
         if _model is None:
+            logger.info(
+                "loading pinned embedding model backend=%s model=%s revision=%s",
+                EMBED_BACKEND, EMBED_MODEL_NAME, EMBED_REVISION,
+            )
             if EMBED_BACKEND == "sentence-transformers":
                 from sentence_transformers import SentenceTransformer  # type: ignore
-                _model = SentenceTransformer(EMBED_MODEL_NAME)
+                _model = SentenceTransformer(
+                    EMBED_MODEL_NAME,
+                    cache_folder=str(EMBED_CACHE_DIR),
+                    revision=EMBED_REVISION,
+                )
             else:  # 'onnx' (default)
                 from fastembed import TextEmbedding  # type: ignore
                 # fastembed 0.8 intentionally moved this model to mean pooling.
@@ -100,7 +172,10 @@ def _get_model():
                         message=r"The model .* now uses mean pooling .*",
                         category=UserWarning,
                     )
-                    _model = TextEmbedding(model_name=FASTEMBED_MODEL_ID)
+                    _model = TextEmbedding(
+                        model_name=FASTEMBED_MODEL_ID,
+                        specific_model_path=_fastembed_snapshot_path(),
+                    )
         return _model
 
 
@@ -221,7 +296,7 @@ def embedding_fingerprint() -> str:
         model = FASTEMBED_MODEL_ID
         pooling = "mean"
     return (
-        f"{EMBED_BACKEND}:{model}:dim={EMBED_DIM}:"
+        f"{EMBED_BACKEND}:{model}:revision={EMBED_REVISION}:dim={EMBED_DIM}:"
         f"pool={pooling}:runtime={runtime}"
     )
 


### PR DESCRIPTION
Closes #120

## What changed

- pin immutable Hugging Face revisions for both embedding backends
- resolve FastEmbed's Hugging Face source to a pinned local snapshot before loading it
- add configurable cache and offline-only controls
- include the revision in the observable embedding fingerprint and load log
- pre-fetch/cache the pinned snapshot in CI, then run semantic tests offline
- reuse one immutable snapshot cache across isolated local-test homes
- document intentional re-pinning and its re-embedding implications

## Why

Loading a model by mutable repository name allowed same-dimension vector drift without an error and made fresh CI/runtime behavior depend on an unpinned live Hub fetch. The active model revision was also absent from the embedding fingerprint.

## Validation

- resolved and downloaded the default FastEmbed snapshot at commit `faf4aa4225822f3bc6376869cb1164e8e3feedd0`
- `env -u THREADKEEPER_NO_EMBEDDINGS .venv/bin/python -m pytest -q tests/test_config_settings.py tests/test_embedding_model_revision.py tests/test_embedding_generation.py tests/test_embed_routing.py`
- `env -u THREADKEEPER_NO_EMBEDDINGS .venv/bin/python -m pytest -q`
