### PR TITLE
fix: pin managed evolve clone execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ version bumps follow semver per the policy in
 [CONTRIBUTING.md → Releases](CONTRIBUTING.md#releases).
 
 ## [Unreleased]
+- **Fixed: managed Evolve clones now execute only a verified pinned commit
+  (#132).** Auto-provisioning accepts only HTTPS `github.com` URLs, detaches at
+  `THREADKEEPER_EVOLVE_REPO_COMMIT`, and verifies `HEAD` before reusing or
+  creating the `[semantic,dev]` virtualenv. URL, branch, and commit changes are
+  restart-only and hot-config reload logs then ignores them, closing runtime
+  source redirection through a host settings file. The managed clone's remote
+  code-execution trust boundary and shared-host opt-out are documented.
 - **Fixed: curator report application now requires pass provenance (#143).**
   Before a Curator child is dispatched, its parent authorizes each exact report
   destination in a `curator_pass` event. The spawned Curator report writer

--- a/README.md
+++ b/README.md
@@ -847,17 +847,16 @@ throttling the roadmap loop.
 Before any PR-producing reviewer/audit or applier child is spawned, the parent
 checks the target checkout with `git status --porcelain --untracked-files=no`.
 Tracked-file WIP records `skipped_dirty_worktree` and no child is dispatched;
-untracked scratch files do not block. The child prompts also fetch the configured
-base branch and create feature branches from `origin/main` (or the configured
-`THREADKEEPER_EVOLVE_REPO_BRANCH`), not from whatever `HEAD` the daemon happens
-to have checked out. A shared git-writer running-task check prevents the
+untracked scratch files do not block. Managed-checkout child prompts fetch the
+configured branch only to retrieve the configured immutable commit, then create
+feature branches from `THREADKEEPER_EVOLVE_REPO_COMMIT`, never from its moving
+tip. A shared git-writer running-task check prevents the
 privileged reviewer audit and code/PR applier from overlapping in the same
 checkout. If a killed conflict-repair child leaves an unresolved merge in the
 default auto-managed checkout, the next code-applying pass can recover it — but
 only when the current branch is `roadmap/…`/`evolve/…` and GitHub confirms that
-exact PR is already merged. Before returning the managed tree to fresh
-`origin/<THREADKEEPER_EVOLVE_REPO_BRANCH>`, thread-keeper archives the tracked
-diff under
+exact PR is already merged. Before returning the managed tree to its pinned
+commit, thread-keeper archives the tracked diff under
 `~/.threadkeeper/evolve-recovery/stale-merge-pr-*.patch` and records
 `recovered_stale_merge` telemetry. Open, closed-unmerged, missing, or
 unreadable PR state remains fail-closed. An explicit
@@ -865,8 +864,13 @@ unreadable PR state remains fail-closed. An explicit
 
 The default managed checkout is refreshed before every code-producing pass:
 after checking that no Evolve git writer is live and that tracked files are
-clean, it fetches the configured branch, checks out that branch, and resets to
-`origin/<THREADKEEPER_EVOLVE_REPO_BRANCH>`. Explicit
+clean, it fetches the configured branch and checks out the pinned
+`THREADKEEPER_EVOLVE_REPO_COMMIT`. Provisioning refuses clone URLs outside the
+HTTPS `github.com` allowlist, verifies `HEAD` against that pin before creating
+or reusing its virtualenv, and the config watcher ignores source/pin edits until
+the process is restarted. The managed clone runs `pip install -e` and its test
+suite, so leave auto-clone off (`THREADKEEPER_EVOLVE_AUTO_CLONE=0`) on shared or
+multi-user hosts unless that execution boundary is explicitly acceptable. Explicit
 `THREADKEEPER_EVOLVE_REPO_ROOT` checkouts are never refreshed or reset by this
 path. Provisioning reserves 5 GiB by default before clone or `.venv` creation
 (`THREADKEEPER_EVOLVE_REPO_MIN_FREE_BYTES=0` disables that preflight), and a
@@ -1174,9 +1178,10 @@ The most-used env knobs (full list in `threadkeeper/config.py`):
 | `THREADKEEPER_EVOLVE_REVIEW_BACKLOG_MAX` | 25 | max open, not-yet-applied roadmap issues before the issue-creating audit is skipped and records `backlog_saturated`; `0` disables the cap |
 | `THREADKEEPER_EVOLVE_APPLY_INTERVAL_S` | 0 (off) | evolve-applier daemon tick (s); implements one open GitHub issue at a time, then falls back to Curator reports and promoted legacy evolve suggestions. Empty checks are throttled between intervals; actionable work and manual apply tools still dispatch |
 | `THREADKEEPER_EVOLVE_REPO_ROOT` | (auto) | absolute path to the thread-keeper git checkout the evolve reviewer/applier branch, test, and open PRs against. When empty, the repo is resolved automatically: the package's parent dir for an editable `install.sh`, else a managed checkout under the DB dir that is auto-cloned on first use. Set this to pin an explicit checkout |
-| `THREADKEEPER_EVOLVE_AUTO_CLONE` | true | auto-provision (git clone + `.venv` with `[semantic,dev]`) a managed checkout when installed without a source tree (PyPI/site-packages), so the evolve loops work by default. Set `0`/`false` to disable — then a non-checkout install requires an editable install or an explicit `EVOLVE_REPO_ROOT`, otherwise the loops return `ERR evolve_repo_unavailable` |
-| `THREADKEEPER_EVOLVE_REPO_URL` | upstream repo | git URL the managed checkout is cloned from |
-| `THREADKEEPER_EVOLVE_REPO_BRANCH` | `main` | branch the managed checkout tracks |
+| `THREADKEEPER_EVOLVE_AUTO_CLONE` | true | auto-provision a managed checkout that runs remote `pip install -e` and tests; set `0`/`false` on shared or multi-user hosts unless that remote-code-execution boundary is explicitly accepted |
+| `THREADKEEPER_EVOLVE_REPO_URL` | upstream repo | HTTPS `github.com` source for the managed clone; restart-only, and other hosts/schemes are refused |
+| `THREADKEEPER_EVOLVE_REPO_BRANCH` | `main` | branch used only to retrieve the pinned commit; restart-only |
+| `THREADKEEPER_EVOLVE_REPO_COMMIT` | `b52a9f6cc8e35373819ffb6db3d31935fc62e185` | required immutable 40-character commit SHA checked before any managed virtualenv install or test; restart-only |
 | `THREADKEEPER_EVOLVE_REPO_MIN_FREE_BYTES` | 5368709120 (5 GiB) | minimum free space required before a managed clone or managed `.venv` is created; `0` disables the preflight |
 | `THREADKEEPER_EVOLVE_REPO_PROVISION_LOCK_TIMEOUT_S` | 5 | maximum seconds to wait for another clone/venv provisioning operation before returning `ERR evolve_repo_provisioning_in_progress retry_later=1`; `0` is immediate |
 | `THREADKEEPER_EVOLVE_APPLY_SKIP_LABELS` | `blocked,needs-design,wontfix,question,discussion,help wanted` | comma-separated labels that exclude GitHub issues from autonomous Evolve applier pickup. Exact-number apply returns `skipped: label X`; set to `off` to clear |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -66,6 +66,27 @@ Editable git checkouts are still treated as developer-controlled working trees:
 dirty/diverged checkouts are skipped, but signed git tag/commit enforcement is
 not yet implemented for that path.
 
+### Managed Evolve checkout (pinned remote code → local execution)
+
+When `THREADKEEPER_EVOLVE_AUTO_CLONE=1`, Evolve can provision a disposable
+managed checkout and execute its `pip install -e` build path and test suite.
+That is an explicit remote-code-execution trust boundary. Disable auto-clone on
+shared or multi-user hosts unless the operator deliberately accepts it:
+`THREADKEEPER_EVOLVE_AUTO_CLONE=0`.
+
+Mitigations:
+
+- The clone URL must be HTTPS on the built-in `github.com` allowlist; other
+  schemes, hosts, credentials, nonstandard ports, queries, and fragments are
+  refused before `git clone` runs.
+- `THREADKEEPER_EVOLVE_REPO_COMMIT` is a required full commit SHA. The managed
+  checkout is detached at that commit and its `HEAD` is verified before a new
+  or existing managed virtualenv can be used. A mismatch returns an `ERR` and
+  neither installs nor tests checkout code.
+- `THREADKEEPER_EVOLVE_REPO_URL`, `THREADKEEPER_EVOLVE_REPO_BRANCH`, and
+  `THREADKEEPER_EVOLVE_REPO_COMMIT` are restart-only. Hot-config reload logs
+  and ignores edits, so a running server cannot silently redirect its clone.
+
 ### Autonomous GitHub writers (stored / issue content → public GitHub)
 
 The evolve reviewer and evolve applier can run privileged children that edit the

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -676,10 +676,11 @@ moving the high-water forward; `force=True` bypasses this due gate.
   operate on a real git checkout, resolved by `_ensure_repo_ready()` in this
   order: (1) an explicit `EVOLVE_REPO_ROOT` (`THREADKEEPER_EVOLVE_REPO_ROOT`);
   (2) by default, a dedicated **managed checkout** under the DB dir
-  (`~/.threadkeeper/evolve-repo`), **auto-cloned on first use** (from
-  `EVOLVE_REPO_URL`/`EVOLVE_REPO_BRANCH`, defaulting to the upstream repo) and
-  given its own `.venv` with the `[semantic,dev]` extras so the children can
-  branch, run the suite, and open PRs; (3) only when auto-clone is disabled does
+  (`~/.threadkeeper/evolve-repo`), **auto-cloned on first use** from the
+  HTTPS `github.com` allowlist and checked out at the immutable
+  `EVOLVE_REPO_COMMIT` pin (the configured branch only retrieves that commit),
+  then given its own `.venv` with the `[semantic,dev]` extras so the children
+  can branch, run the suite, and open PRs; (3) only when auto-clone is disabled does
   the package's parent dir (when it carries a `.git` entry — the
   editable-from-checkout `install.sh`) serve as an in-place fallback. The
   managed checkout is the default even for editable installs on purpose
@@ -695,8 +696,13 @@ moving the high-water forward; `force=True` bypasses this due gate.
   provided. An explicit override that is not itself a checkout is never
   auto-cloned into and reports `ERR repo_root_not_git`. The disposable managed
   checkout is refreshed before every code-producing pass: after a clean-tree
-  and no-live-writer check, the parent fetches the configured branch, checks it
-  out, and hard-resets to `origin/<EVOLVE_REPO_BRANCH>`. Explicit checkout
+  and no-live-writer check, the parent fetches the configured branch and checks
+  out `EVOLVE_REPO_COMMIT`, rejecting a missing or mismatched pin before any
+  virtualenv install or test can execute it. `EVOLVE_REPO_URL`,
+  `EVOLVE_REPO_BRANCH`, and `EVOLVE_REPO_COMMIT` are restart-only: hot-config
+  reload logs and ignores changes to them. The managed clone runs remote build
+  and test code, so shared or multi-user hosts should disable auto-clone unless
+  that explicit execution trust boundary is acceptable. Explicit checkout
   roots are never refreshed or reset. Before clone or heavyweight
   `[semantic,dev]` virtualenv creation, a 5 GiB free-space reserve is checked
   (`EVOLVE_REPO_MIN_FREE_BYTES=0` disables it); `mp_dashboard()` reports

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -89,8 +89,8 @@ remains a live question.
   audit or code/PR applier child can spawn, the parent rejects tracked-file WIP
   with `skipped_dirty_worktree` (untracked scratch files do not block), refuses
   overlapping reviewer/applier git writers in the shared checkout, and prompts
-  children to fetch and branch from `origin/main` / `origin/<EVOLVE_REPO_BRANCH>`
-  instead of arbitrary current `HEAD`.
+  children to fetch the configured branch but branch only from the configured
+  immutable managed-checkout pin instead of arbitrary current `HEAD`.
 - Evolve managed-checkout stale-merge recovery: a killed conflict-repair child
   no longer blocks the entire backlog after its PR was merged elsewhere. The
   parent first excludes live git writers, requires the default managed checkout
@@ -98,10 +98,15 @@ remains a live question.
   tracked diff under `evolve-recovery/`, and returns the checkout to the fetched
   base. Explicit operator checkouts and uncertain PR states remain fail-closed.
 - Evolve managed-checkout lifecycle (#128): the disposable clone now refreshes
-  to the configured `origin/<EVOLVE_REPO_BRANCH>` base before each code pass,
-  without touching explicit checkouts. Clone/venv provisioning has a bounded
+  to its configured base before each code pass, without touching explicit
+  checkouts. Clone/venv provisioning has a bounded
   lock, a configurable free-disk reserve, visible footprint telemetry, and an
   explicit managed-venv prune tool.
+- Evolve managed-clone execution integrity (#132): auto-provisioning accepts
+  only HTTPS `github.com` URLs, checks out and verifies a release-pinned commit
+  before `pip install -e` or tests, and ignores runtime reloads of the source,
+  branch, or pin. The remote-code-execution boundary and shared-host opt-out
+  are documented.
 - Evolve reviewer roadmap-doc PR dedup (#54): before spawning the privileged
   audit child, the parent checks open PRs for automation-owned changes touching
   `docs/ROADMAP.md`; the prompt tells the reviewer to append/skip when one

--- a/tests/test_config_watcher.py
+++ b/tests/test_config_watcher.py
@@ -13,6 +13,7 @@ Contract:
 from __future__ import annotations
 
 import json
+import logging
 import sys
 import time
 from pathlib import Path
@@ -165,6 +166,49 @@ def test_deleting_key_reverts_to_default(tmp_path, monkeypatch):
     assert out.startswith("reloaded")
     assert config.SHADOW_REVIEW_INTERVAL_S == 0.0
     assert "THREADKEEPER_SHADOW_REVIEW_INTERVAL_S" not in w._applied_keys
+
+
+def test_repo_source_knobs_are_restart_only(tmp_path, monkeypatch, caplog):
+    """A settings.json edit cannot silently re-point executable clone code."""
+    for key in (
+        "THREADKEEPER_EVOLVE_REPO_URL",
+        "THREADKEEPER_EVOLVE_REPO_BRANCH",
+        "THREADKEEPER_EVOLVE_REPO_COMMIT",
+    ):
+        monkeypatch.delenv(key, raising=False)
+    pkg = _bootstrap(tmp_path, monkeypatch, shadow="600")
+    config = pkg["config"]
+    w = pkg["watcher"]
+    old = (
+        config.EVOLVE_REPO_URL,
+        config.EVOLVE_REPO_BRANCH,
+        config.EVOLVE_REPO_COMMIT,
+    )
+    w.run_config_watch_pass()  # initialize baseline
+
+    caplog.set_level(logging.WARNING, logger="threadkeeper.config_watcher")
+    _write_env(
+        pkg["settings_json"],
+        {
+            "THREADKEEPER_SHADOW_REVIEW_INTERVAL_S": "600",
+            "THREADKEEPER_EVOLVE_REPO_URL": "https://example.invalid/repo",
+            "THREADKEEPER_EVOLVE_REPO_BRANCH": "attacker-branch",
+            "THREADKEEPER_EVOLVE_REPO_COMMIT": "0" * 40,
+        },
+    )
+    out = w.run_config_watch_pass()
+
+    assert out.startswith("reloaded changed=0"), out
+    assert (
+        config.EVOLVE_REPO_URL,
+        config.EVOLVE_REPO_BRANCH,
+        config.EVOLVE_REPO_COMMIT,
+    ) == old
+    assert not (
+        w._applied_keys
+        & w._RESTART_REQUIRED_REPO_SOURCE_KEYS
+    )
+    assert "ignored restart-required managed repo source change" in caplog.text
 
 
 def test_disabled_watcher_is_noop(tmp_path, monkeypatch):

--- a/tests/test_evolve_applier.py
+++ b/tests/test_evolve_applier.py
@@ -15,6 +15,8 @@ import sys
 import time
 from pathlib import Path
 
+import pytest
+
 
 _FAKE_CID = "aaaa1111-2222-3333-4444-555566667777"
 
@@ -319,7 +321,7 @@ def test_apply_evolve_builds_spawn_call(tmp_path, monkeypatch):
     assert "git fetch origin main" in p
     assert (
         f"git checkout -b {pkg['ea'].branch_name(eid, 'add a failed_paths field per thread')} "
-        "origin/main"
+        f"{pkg['ea']._base_ref()}"
     ) in p
     assert 'git commit -m "evolve:' not in p
     assert 'gh pr create --title "evolve:' not in p
@@ -1122,7 +1124,7 @@ def test_apply_roadmap_issue_builds_evolve_applier_spawn(
     assert "git fetch origin main" in prompt
     assert (
         f"git checkout -b {pkg['ea'].roadmap_issue_branch_name(6, 'Telemetry dashboard')} "
-        "origin/main"
+        f"{pkg['ea']._base_ref()}"
     ) in prompt
 
 
@@ -1227,6 +1229,10 @@ def test_managed_checkout_recovers_stale_merge_after_pr_merged(
     (repo / "shared.txt").write_text("main\n", encoding="utf-8")
     git("commit", "-am", "main change")
     git("push", "origin", "main")
+    monkeypatch.setattr(
+        pkg["ea"], "EVOLVE_REPO_COMMIT",
+        git("rev-parse", "origin/main").stdout.strip(),
+    )
     git("checkout", branch)
     conflicted = git("merge", "origin/main", check=False)
     assert conflicted.returncode != 0
@@ -2407,6 +2413,7 @@ def test_managed_checkout_refreshes_to_latest_origin_base(tmp_path, monkeypatch)
     run("git", "commit", "-m", "advance base", cwd=source)
     run("git", "push", "origin", "main", cwd=source)
     upstream_head = run("git", "rev-parse", "HEAD", cwd=source).stdout.strip()
+    monkeypatch.setattr(pkg["ea"], "EVOLVE_REPO_COMMIT", upstream_head)
 
     root, err = pkg["ea"]._ensure_repo_ready()
 
@@ -2415,6 +2422,49 @@ def test_managed_checkout_refreshes_to_latest_origin_base(tmp_path, monkeypatch)
     assert (repo / "upstream.txt").read_text(encoding="utf-8") == "new base\n"
     assert run("git", "rev-parse", "HEAD", cwd=repo).stdout.strip() == upstream_head
     assert upstream_head != old_head
+
+
+@pytest.mark.parametrize(
+    "source",
+    ["http://github.com/po4erk91/thread-keeper", "https://example.invalid/repo"],
+)
+def test_managed_provision_refuses_untrusted_source_before_clone(
+    tmp_path, monkeypatch, source,
+):
+    pkg = _bootstrap(tmp_path, monkeypatch, pin_repo=False)
+    monkeypatch.setattr(pkg["ea"], "EVOLVE_REPO_URL", source)
+    monkeypatch.setattr(
+        pkg["ea"],
+        "_run",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("must not run git or install from an untrusted URL")
+        ),
+    )
+
+    out = pkg["ea"]._provision_managed_repo(tmp_path / "managed-repo")
+
+    assert out.startswith("ERR evolve_repo_url_refused"), out
+
+
+def test_managed_provision_aborts_on_pinned_ref_mismatch_before_venv(
+    tmp_path, monkeypatch,
+):
+    pkg = _bootstrap(tmp_path, monkeypatch, pin_repo=False)
+    commands = []
+    monkeypatch.setattr(
+        pkg["ea"], "_run", lambda cmd, *args, **kwargs: commands.append(cmd) or ""
+    )
+    monkeypatch.setattr(
+        pkg["ea"], "_managed_repo_head", lambda dest: ("0" * 40, "")
+    )
+
+    out = pkg["ea"]._provision_managed_repo(tmp_path / "managed-repo")
+
+    assert out.startswith("ERR evolve_repo_pin_mismatch"), out
+    assert any(cmd[:2] == ["git", "clone"] for cmd in commands)
+    assert any(cmd[:3] == ["git", "checkout", "--detach"] for cmd in commands)
+    assert not any("venv" in " ".join(cmd) for cmd in commands)
+    assert not any("install" in cmd for cmd in commands)
 
 
 def test_managed_provision_fails_before_clone_when_disk_is_low(
@@ -2929,6 +2979,10 @@ def test_managed_checkout_recovers_abandoned_wip_without_merge(
     git("commit", "-m", "base")
     git("remote", "add", "origin", str(remote))
     git("push", "-u", "origin", "main")
+    monkeypatch.setattr(
+        pkg["ea"], "EVOLVE_REPO_COMMIT",
+        git("rev-parse", "origin/main").stdout.strip(),
+    )
 
     branch = "roadmap/issue-9-abandoned-wip"
     git("checkout", "-b", branch)

--- a/tests/test_evolve_daemon.py
+++ b/tests/test_evolve_daemon.py
@@ -615,7 +615,7 @@ def test_run_evolve_pass_audit_phase_no_web_consumes_fenced_research(
     assert pkg["ed"].EVOLVE_RESEARCH_FENCE in calls["prompt"]
     assert "git fetch origin main" in calls["prompt"]
     assert "git checkout -b docs/roadmap-audit-" in calls["prompt"]
-    assert "origin/main" in calls["prompt"]
+    assert pkg["ed"]._base_ref() in calls["prompt"]
     assert "No open reviewer roadmap-doc PR touching docs/ROADMAP.md" in (
         calls["prompt"]
     )

--- a/threadkeeper/config.py
+++ b/threadkeeper/config.py
@@ -406,10 +406,14 @@ class Settings(BaseSettings):
     # evolve loops work out of the box; set 0/false to disable — then the loops
     # require an editable install or an explicit EVOLVE_REPO_ROOT.
     evolve_auto_clone: bool = True
-    # Canonical repo the managed checkout is cloned from, and the branch it
-    # tracks. Defaults to the upstream thread-keeper project.
+    # Canonical repo the managed checkout is cloned from. The mutable branch is
+    # used only to retrieve the immutable commit below; managed code always
+    # checks out and executes that exact commit.
     evolve_repo_url: str = "https://github.com/po4erk91/thread-keeper"
     evolve_repo_branch: str = "main"
+    # Immutable commit allowed to execute in an auto-managed checkout. Bump
+    # this with a reviewed release; never follow a moving branch tip here.
+    evolve_repo_commit: str = "b52a9f6cc8e35373819ffb6db3d31935fc62e185"
     # Fail before a managed clone / its heavyweight semantic+dev venv can
     # consume the last free space on a host. 0 deliberately disables the
     # guard for constrained test or operator-managed environments.
@@ -851,6 +855,7 @@ def _derive_constants(s: "Settings") -> dict:
         "EVOLVE_AUTO_CLONE": s.evolve_auto_clone,
         "EVOLVE_REPO_URL": s.evolve_repo_url,
         "EVOLVE_REPO_BRANCH": s.evolve_repo_branch,
+        "EVOLVE_REPO_COMMIT": s.evolve_repo_commit,
         "EVOLVE_REPO_MIN_FREE_BYTES": s.evolve_repo_min_free_bytes,
         "EVOLVE_REPO_PROVISION_LOCK_TIMEOUT_S": (
             s.evolve_repo_provision_lock_timeout_s
@@ -930,14 +935,23 @@ def _propagate(new_values: dict) -> None:
                 d[cname] = val
 
 
+_RELOAD_PRESERVABLE_FIELDS = {
+    "EVOLVE_REPO_URL": "evolve_repo_url",
+    "EVOLVE_REPO_BRANCH": "evolve_repo_branch",
+    "EVOLVE_REPO_COMMIT": "evolve_repo_commit",
+}
+
+
 def reload_settings(env: Optional[dict] = None,
-                    remove: Optional[list] = None) -> dict:
+                    remove: Optional[list] = None,
+                    preserve: Optional[set[str]] = None) -> dict:
     """Re-read configuration in place (hot-config reload — issue #2).
 
     Steps:
       1. Optionally mutate `os.environ`: drop `remove` keys, set `env` keys.
          (The config_watcher uses this to mirror ~/.claude/settings.json.)
       2. Re-instantiate `Settings()` (re-reads os.environ + the .env file).
+         `preserve` keeps selected restart-only constants at their prior values.
       3. Recompute the UPPER_CASE constants and republish them on this module.
       4. Propagate every CHANGED constant to all loaded `threadkeeper.*`
          modules so daemons/tools that imported a copy observe the new value.
@@ -955,7 +969,13 @@ def reload_settings(env: Optional[dict] = None,
             os.environ[k] = str(v)
 
     old = _derive_constants(settings)
-    settings = Settings()
+    refreshed = Settings()
+    preserved = {
+        field: getattr(settings, field)
+        for const, field in _RELOAD_PRESERVABLE_FIELDS.items()
+        if const in (preserve or set())
+    }
+    settings = refreshed.model_copy(update=preserved) if preserved else refreshed
     _warn_unknown_threadkeeper_env_keys()
     new = _derive_constants(settings)
 

--- a/threadkeeper/config_watcher.py
+++ b/threadkeeper/config_watcher.py
@@ -14,14 +14,16 @@ stat per target per tick — cheap):
    Desktop, Codex, Antigravity, Copilot, VS Code) — not just Claude.
    On change we call `config.reload_settings()` with NO os.environ mirroring:
    pydantic re-reads the file natively and real spawn-time env vars keep their
-   precedence (env var > .env file > default). No precedence inversion.
+   precedence (env var > .env file > default). No precedence inversion. The
+   managed-clone source, branch, and commit stay at their process-start values.
 
 2. **The host CLI's own env-block file**, resolved from the active-CLI
    identity (Claude Code → `~/.claude/settings.json`). Its `env` block is
    mirrored into `os.environ` and republished — MINUS any key a
-   higher-priority layer already pinned at spawn (see below). CLIs whose env
-   block we cannot yet parse as a flat map rely on target 1 alone (they still
-   hot-reload, just via the universal `.env`).
+   higher-priority layer already pinned at spawn and the restart-only
+   `THREADKEEPER_EVOLVE_REPO_{URL,BRANCH,COMMIT}` keys (see below). CLIs whose
+   env block we cannot yet parse as a flat map rely on target 1 alone (they
+   still hot-reload, just via the universal `.env`).
 
 `THREADKEEPER_CONFIG_WATCH_PATH` is an escape hatch / test seam: when set it
 pins ONE file (watched as a CLI-settings target), and the universal env-file
@@ -32,7 +34,8 @@ On a real change the daemon:
 1. parses the changed file (target 2) or re-reads natively (target 1),
 2. for target 2, mirrors the threadkeeper-relevant keys into `os.environ`
    (applying new values and dropping keys the user deleted), excluding keys a
-   higher-priority scope pinned at spawn (issue #133 precedence guard),
+   higher-priority scope pinned at spawn (issue #133 precedence guard) and the
+   restart-only managed-clone source keys,
 3. calls `config.reload_settings()` which re-instantiates `Settings`,
    re-publishes the module constants, and propagates every changed value into
    the loaded `threadkeeper.*` modules that imported a copy, and
@@ -50,6 +53,10 @@ Caveats (from the roadmap item):
 - Racy multi-writer edits are handled by debounce (poll granularity) + a
   JSON-parse guard: a half-written file is skipped and retried next tick, and
   the mtime cursor is only advanced on a clean read.
+- Changes to `THREADKEEPER_EVOLVE_REPO_URL`,
+  `THREADKEEPER_EVOLVE_REPO_BRANCH`, or `THREADKEEPER_EVOLVE_REPO_COMMIT` are
+  logged and ignored until the host process is restarted. Those settings govern
+  a checkout whose build and tests execute remote code.
 """
 
 from __future__ import annotations
@@ -90,6 +97,27 @@ _shadowed_keys: set[str] = set()             # cli-file keys a higher layer pins
 _UNPREFIXED_KEYS: frozenset[str] = frozenset(
     {"CLAUDE_SKILLS_DIR", "CLAUDE_PROJECTS_DIR"}
 )
+
+# The managed checkout installs and tests remote code. Its source and immutable
+# commit are accepted only at process start, never from a hot-reloaded file.
+# A restart makes any attempted change explicit in the host's process boundary.
+_RESTART_REQUIRED_REPO_SOURCE_KEYS: frozenset[str] = frozenset({
+    "THREADKEEPER_EVOLVE_REPO_URL",
+    "THREADKEEPER_EVOLVE_REPO_BRANCH",
+    "THREADKEEPER_EVOLVE_REPO_COMMIT",
+})
+_RESTART_REQUIRED_REPO_SOURCE_CONSTANTS: frozenset[str] = frozenset({
+    "EVOLVE_REPO_URL",
+    "EVOLVE_REPO_BRANCH",
+    "EVOLVE_REPO_COMMIT",
+})
+_RESTART_REQUIRED_REPO_SOURCE_FIELDS: dict[str, str] = {
+    "THREADKEEPER_EVOLVE_REPO_URL": "evolve_repo_url",
+    "THREADKEEPER_EVOLVE_REPO_BRANCH": "evolve_repo_branch",
+    "THREADKEEPER_EVOLVE_REPO_COMMIT": "evolve_repo_commit",
+}
+_env_repo_source_values: dict[str, str] = {}
+_cli_repo_source_values: dict[str, str] = {}
 
 # Host CLI -> its env-block settings file (relative to $HOME). Only CLIs whose
 # env block we can parse as a flat {key: value} JSON map appear here. Others
@@ -162,6 +190,23 @@ def _relevant_env(path: Path) -> dict[str, str]:
     }
 
 
+def _warn_ignored_repo_source_changes(
+    previous: dict[str, str], current: dict[str, str], *, source: str,
+) -> None:
+    """Log restart-required managed-checkout changes without their values."""
+    changed = sorted(
+        key for key in set(previous) | set(current)
+        if previous.get(key) != current.get(key)
+    )
+    if changed:
+        logger.warning(
+            "config_watch: ignored restart-required managed repo source "
+            "change(s) from %s: %s",
+            source,
+            ", ".join(changed),
+        )
+
+
 def _record_pass(conn: sqlite3.Connection, mtime: float, outcome: str) -> None:
     """Write a `config_watch_pass` event for observability (status tool +
     dashboards). `target` carries the mtime cursor, `summary` the outcome."""
@@ -208,7 +253,7 @@ def _tick_env_file(force: bool) -> Optional[str]:
     NO os.environ mirroring, so the real spawn-time env still wins (pydantic
     precedence: env vars > .env file). Returns a per-target status string, or
     None when the file is absent (nothing to watch)."""
-    global _env_last_mtime
+    global _env_last_mtime, _env_repo_source_values
     path = _env_file_path()
     try:
         mtime = path.stat().st_mtime
@@ -223,13 +268,29 @@ def _tick_env_file(force: bool) -> Optional[str]:
     # First sighting (cold process): the file was already loaded by Settings()
     # at spawn, so just record the baseline. No reload — nothing changed yet.
     if not force and _env_last_mtime is None:
+        loaded = config.Settings()
+        _env_repo_source_values = {
+            key: str(getattr(loaded, field))
+            for key, field in _RESTART_REQUIRED_REPO_SOURCE_FIELDS.items()
+        }
         _env_last_mtime = mtime
         return "initialized"
 
     # Native re-read: reload_settings() re-instantiates Settings(), which reads
-    # os.environ + the .env file fresh. Passing no env/remove means we never
-    # mirror the (lower-priority) file into os.environ.
-    changed = config.reload_settings()
+    # os.environ + the .env file fresh. Source settings remain restart-only so
+    # a file edit cannot re-point the managed remote in a running process.
+    loaded = config.Settings()
+    repo_source_values = {
+        key: str(getattr(loaded, field))
+        for key, field in _RESTART_REQUIRED_REPO_SOURCE_FIELDS.items()
+    }
+    _warn_ignored_repo_source_changes(
+        _env_repo_source_values, repo_source_values, source="env-file",
+    )
+    _env_repo_source_values = repo_source_values
+    changed = config.reload_settings(
+        preserve=set(_RESTART_REQUIRED_REPO_SOURCE_CONSTANTS),
+    )
     _env_last_mtime = mtime
     started = _restart_changed_daemons(changed)
     return f"reloaded changed={len(changed)} started={started}"
@@ -245,7 +306,7 @@ def _tick_cli_settings(force: bool) -> Optional[str]:
     Returns a per-target status string, or None when there is no CLI env-block
     file for this host (the universal env-file target covers it instead).
     """
-    global _last_mtime, _applied_keys, _shadowed_keys
+    global _last_mtime, _applied_keys, _shadowed_keys, _cli_repo_source_values
     path = _cli_settings_path()
     if path is None:
         return None
@@ -273,7 +334,15 @@ def _tick_cli_settings(force: bool) -> Optional[str]:
             k for k, v in present.items()
             if os.environ.get(k) not in (None, v)
         }
-        _applied_keys = set(present) - _shadowed_keys
+        _cli_repo_source_values = {
+            key: value for key, value in present.items()
+            if key in _RESTART_REQUIRED_REPO_SOURCE_KEYS
+        }
+        _applied_keys = (
+            set(present)
+            - _shadowed_keys
+            - _RESTART_REQUIRED_REPO_SOURCE_KEYS
+        )
         _last_mtime = mtime
         return "initialized"
 
@@ -284,7 +353,19 @@ def _tick_cli_settings(force: bool) -> Optional[str]:
         # has finished. This is the debounce/lock guard for racy writers.
         return f"parse_error: {e}"
 
-    desired = {k: v for k, v in present.items() if k not in _shadowed_keys}
+    repo_source_values = {
+        key: value for key, value in present.items()
+        if key in _RESTART_REQUIRED_REPO_SOURCE_KEYS
+    }
+    _warn_ignored_repo_source_changes(
+        _cli_repo_source_values, repo_source_values, source="cli-settings",
+    )
+    _cli_repo_source_values = repo_source_values
+    desired = {
+        k: v for k, v in present.items()
+        if k not in _shadowed_keys
+        and k not in _RESTART_REQUIRED_REPO_SOURCE_KEYS
+    }
     remove = sorted(_applied_keys - set(desired))
     changed = config.reload_settings(env=desired, remove=remove)
     _applied_keys = set(desired)

--- a/threadkeeper/evolve_applier.py
+++ b/threadkeeper/evolve_applier.py
@@ -60,6 +60,7 @@ import threading
 import time
 from pathlib import Path
 from typing import Iterator, Optional
+from urllib.parse import urlsplit
 
 from .config import (
     CURATOR_REPORTS_DIR,
@@ -68,6 +69,7 @@ from .config import (
     EVOLVE_AUTO_CLONE,
     EVOLVE_APPLY_SKIP_LABELS,
     EVOLVE_REPO_BRANCH,
+    EVOLVE_REPO_COMMIT,
     EVOLVE_REPO_MIN_FREE_BYTES,
     EVOLVE_REPO_PROVISION_LOCK_TIMEOUT_S,
     EVOLVE_REPO_ROOT,
@@ -623,7 +625,85 @@ def _base_branch_name() -> str:
 
 
 def _base_ref() -> str:
-    return f"origin/{_base_branch_name()}"
+    """The immutable base every managed child branches from."""
+    return str(EVOLVE_REPO_COMMIT or "").strip().lower()
+
+
+_MANAGED_REPO_ALLOWED_HOSTS = frozenset({"github.com"})
+_FULL_COMMIT_SHA = re.compile(r"^[0-9a-f]{40}$")
+
+
+def _expected_managed_commit() -> tuple[str, str]:
+    """Return the configured immutable commit or a clear fail-closed error."""
+    commit = _base_ref()
+    if not _FULL_COMMIT_SHA.fullmatch(commit):
+        return "", (
+            "ERR evolve_repo_pin_invalid (THREADKEEPER_EVOLVE_REPO_COMMIT "
+            "must be a 40-character lowercase commit SHA)"
+        )
+    return commit, ""
+
+
+def _validate_managed_repo_source() -> str:
+    """Reject clone URLs outside the fixed HTTPS allowlist before git runs."""
+    source = str(EVOLVE_REPO_URL or "").strip()
+    try:
+        parsed = urlsplit(source)
+        port = parsed.port
+    except ValueError:
+        parsed = None
+        port = None
+    if (
+        parsed is None
+        or parsed.scheme.lower() != "https"
+        or parsed.hostname not in _MANAGED_REPO_ALLOWED_HOSTS
+        or parsed.username is not None
+        or parsed.password is not None
+        or port not in (None, 443)
+        or not parsed.path
+        or parsed.query
+        or parsed.fragment
+    ):
+        return (
+            "ERR evolve_repo_url_refused (managed clone URL must use HTTPS on "
+            "an allowlisted host)"
+        )
+    _commit, pin_err = _expected_managed_commit()
+    return pin_err
+
+
+def _managed_repo_head(dest: Path) -> tuple[str, str]:
+    """Return ``HEAD`` without running checkout code."""
+    try:
+        proc = subprocess.run(
+            ["git", "-C", str(dest), "rev-parse", "HEAD"],
+            text=True, capture_output=True, timeout=10, check=False,
+        )
+    except FileNotFoundError:
+        return "", "git_not_found"
+    except subprocess.TimeoutExpired:
+        return "", "git_head_timeout"
+    except OSError as e:
+        return "", f"git_head_error: {_short(str(e))}"
+    if proc.returncode != 0:
+        return "", _short(proc.stderr or proc.stdout or f"exit={proc.returncode}")
+    return (proc.stdout or "").strip().lower(), ""
+
+
+def _verify_managed_repo_ref(dest: Path) -> str:
+    """Ensure no managed venv or test can run a ref other than the pin."""
+    commit, pin_err = _expected_managed_commit()
+    if pin_err:
+        return pin_err
+    head, head_err = _managed_repo_head(dest)
+    if head_err:
+        return f"ERR evolve_repo_pin_verify_failed={_short(head_err)}"
+    if head != commit:
+        return (
+            "ERR evolve_repo_pin_mismatch "
+            f"expected={commit} actual={_short(head or 'unknown', 40)}"
+        )
+    return ""
 
 
 def _disk_free_bytes(path: Path) -> tuple[int, str]:
@@ -1171,10 +1251,13 @@ def _ensure_managed_venv(dest: Path) -> str:
     import sys
     venv_py = dest / ".venv" / "bin" / "python"
     if venv_py.exists():
-        return ""
+        return _verify_managed_repo_ref(dest)
     space_err = _managed_disk_preflight(dest)
     if space_err:
         return space_err
+    pin_err = _verify_managed_repo_ref(dest)
+    if pin_err:
+        return pin_err
     err = _run([sys.executable, "-m", "venv", str(dest / ".venv")],
                EVOLVE_VENV_TIMEOUT_S)
     if err:
@@ -1188,12 +1271,15 @@ def _ensure_managed_venv(dest: Path) -> str:
 
 
 def _provision_managed_repo(dest: Path) -> str:
-    """Clone the canonical repo into `dest` and provision its venv. Serialized
-    and idempotent: re-checks under the lock so a concurrent winner's clone is
+    """Clone a trusted source, pin it, then provision its venv. Serialized and
+    idempotent: re-checks under the lock so a concurrent winner's clone is
     reused. Returns '' on success or an ERR string."""
     with _repo_provision_lock() as lock_err:
         if lock_err:
             return lock_err
+        source_err = _validate_managed_repo_source()
+        if source_err:
+            return source_err
         if _is_git_repo(dest):
             return _ensure_managed_venv(dest)
         if dest.exists() and any(dest.iterdir()):
@@ -1207,17 +1293,25 @@ def _provision_managed_repo(dest: Path) -> str:
             return space_err
         dest.parent.mkdir(parents=True, exist_ok=True)
         err = _run(
-            ["git", "clone", "--quiet", "--branch", str(EVOLVE_REPO_BRANCH),
-             str(EVOLVE_REPO_URL), str(dest)],
+            ["git", "clone", "--quiet", "--no-checkout", "--branch",
+             _base_branch_name(), str(EVOLVE_REPO_URL), str(dest)],
             EVOLVE_CLONE_TIMEOUT_S,
         )
         if err:
             return f"ERR evolve_repo_clone_failed={dest}: {err}"
+        commit, _pin_err = _expected_managed_commit()
+        checkout_err = _run(
+            ["git", "checkout", "--detach", "--force", commit],
+            EVOLVE_CLONE_TIMEOUT_S,
+            cwd=dest,
+        )
+        if checkout_err:
+            return f"ERR evolve_repo_pin_checkout_failed={_short(checkout_err)}"
         return _ensure_managed_venv(dest)
 
 
 def _refresh_managed_repo(dest: Path) -> str:
-    """Fast-forward only the disposable managed checkout to its base branch.
+    """Refresh only the disposable managed checkout to its pinned base.
 
     Explicit checkout roots are never routed here. A clean but old applier
     branch is safe to replace after its child has ended; tracked edits and live
@@ -1226,6 +1320,9 @@ def _refresh_managed_repo(dest: Path) -> str:
     with _repo_provision_lock() as lock_err:
         if lock_err:
             return lock_err
+        source_err = _validate_managed_repo_source()
+        if source_err:
+            return source_err
         if not _is_git_repo(dest):
             return "ERR evolve_repo_refresh_missing_checkout"
         dirty, status_err = _tracked_worktree_status(dest)
@@ -1243,14 +1340,18 @@ def _refresh_managed_repo(dest: Path) -> str:
         fetch_err = _run(["git", "fetch", "origin", branch], 60, cwd=dest)
         if fetch_err:
             return f"ERR evolve_repo_refresh_fetch_failed={_short(fetch_err)}"
-        checkout_err = _run(["git", "checkout", "-f", branch], 30, cwd=dest)
-        if checkout_err:
-            return f"ERR evolve_repo_refresh_checkout_failed={_short(checkout_err)}"
-        reset_err = _run(
-            ["git", "reset", "--hard", _base_ref()], 30, cwd=dest
+        commit, _pin_err = _expected_managed_commit()
+        checkout_err = _run(
+            ["git", "checkout", "--detach", "--force", commit], 30, cwd=dest
         )
-        if reset_err:
-            return f"ERR evolve_repo_refresh_reset_failed={_short(reset_err)}"
+        if checkout_err:
+            return (
+                "ERR evolve_repo_refresh_pin_checkout_failed="
+                f"{_short(checkout_err)}"
+            )
+        pin_err = _verify_managed_repo_ref(dest)
+        if pin_err:
+            return pin_err
     return ""
 
 


### PR DESCRIPTION
## Summary
- pin managed Evolve checkouts to a verified immutable commit before install or tests
- refuse non-HTTPS and non-allowlisted clone sources
- keep managed clone source settings restart-only during hot reload

## Validation
- env -u THREADKEEPER_NO_EMBEDDINGS .venv/bin/python -m pytest -q

Closes #132