### PR TITLE
ci: add CodeQL and dependency vulnerability gate

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,3 +33,17 @@ updates:
       - "ci"
     commit-message:
       prefix: "ci"
+
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "UTC"
+    open-pull-requests-limit: 3
+    labels:
+      - "dependencies"
+      - "ci"
+    commit-message:
+      prefix: "ci"

--- a/.github/pip-audit-ignores.txt
+++ b/.github/pip-audit-ignores.txt
@@ -1,0 +1,10 @@
+# Reviewed pip-audit suppressions
+#
+# Keep this file empty unless an advisory is demonstrably inapplicable or has
+# no safe upgrade path. Each active, non-comment line must use exactly:
+#
+#   ADVISORY-ID | tracking issue or PR | rationale | next review date (YYYY-MM-DD)
+#
+# The CI workflow rejects malformed entries and passes each advisory ID to
+# pip-audit's --ignore-vuln option. Remove the entry as soon as an upgrade or
+# other remediation is available. There are no active suppressions at present.

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,38 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Re-scan the default query suite even when no code changes land.
+    - cron: "17 3 * * 1"
+  workflow_dispatch:
+
+# CodeQL uploads SARIF results to the repository Security tab. Keep the
+# permission narrow: this workflow never writes repository contents.
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  analyze:
+    name: Analyze Python
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      # Python is interpreted, so CodeQL's no-build mode is the supported
+      # analysis mode. Omitting a `queries` override intentionally keeps the
+      # default suite until any security-extended findings are triaged.
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: python
+          build-mode: none
+
+      - name: Analyze and upload results
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: "/language:python"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,3 +72,44 @@ jobs:
           # the suite for parallel runs is tracked separately; xdist is shipped
           # as an opt-in local accelerator (see CONTRIBUTING).
           python -m pytest -q --forked --tb=short
+
+  pip-audit:
+    name: pip-audit (resolved dependencies)
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.13"
+          cache: "pip"
+
+      - name: Resolve project dependencies
+        run: |
+          python -m pip install --upgrade pip
+          # Audit the same runtime, semantic, and test dependency set that CI
+          # resolves, rather than only direct requirements from pyproject.toml.
+          python -m pip install -e '.[semantic,dev]'
+          python -m pip install pip-audit
+
+      - name: Fail on known dependency vulnerabilities
+        shell: bash
+        run: |
+          set -euo pipefail
+          ignore_args=()
+          while IFS='|' read -r vulnerability_id tracking rationale review_by; do
+            if [[ "$vulnerability_id" =~ ^[[:space:]]*(#|$) ]]; then
+              continue
+            fi
+            if [[ -z "$tracking" || -z "$rationale" || -z "$review_by" ]]; then
+              echo "::error::Malformed .github/pip-audit-ignores.txt entry for $vulnerability_id"
+              exit 1
+            fi
+            vulnerability_id="${vulnerability_id//[[:space:]]/}"
+            ignore_args+=(--ignore-vuln "$vulnerability_id")
+          done < .github/pip-audit-ignores.txt
+          # With no input arguments, pip-audit audits this fully resolved
+          # environment. --strict makes incomplete dependency collection fail.
+          pip-audit --local --strict "${ignore_args[@]}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ version bumps follow semver per the policy in
 [CONTRIBUTING.md → Releases](CONTRIBUTING.md#releases).
 
 ## [Unreleased]
+- **Added: CI security scanning (#144).** CodeQL analyzes the default Python
+  query suite on pull requests and pushes to `main`, plus weekly, and uploads
+  results to the Security tab. A blocking `pip-audit` job scans the fully
+  resolved runtime, semantic, and development dependency set; suppressions are
+  advisory-specific, reviewed entries in `.github/pip-audit-ignores.txt`.
+  Dependabot now tracks the Docker base image as well.
 - **Fixed: one abandoned Evolve attempt can no longer deadlock the apply
   scheduler.** Managed-checkout refresh used to reject a dirty tree before the
   abandoned-WIP recovery gate ran, so a child that edited `main` and then hit a

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,6 +56,10 @@ CI runs the full suite under `--forked` (each test in its own process; the
 per-test package re-import otherwise piles up native ONNX/tokenizer thread
 pools that can deadlock sqlite finalize in one long-lived interpreter).
 
+CI also runs a blocking `pip-audit` job against the fully resolved
+`.[semantic,dev]` environment. It fails for known dependency vulnerabilities;
+see [Security scanning](#security-scanning) before adding an exception.
+
 Test isolation uses a tempdir DB per test, all daemons disabled via env
 (`THREADKEEPER_*_INTERVAL_S=0`). See `tests/conftest.py`.
 
@@ -157,6 +161,25 @@ python -m threadkeeper._setup --dry-run           # setup is idempotent
 
 If any of these report something unexpected on a clean checkout, that's
 a bug — please open an issue or a PR.
+
+## Security scanning
+
+GitHub Actions runs CodeQL's default Python query suite on every PR and push to
+`main`, plus weekly, and uploads findings to the repository Security tab.
+`pip-audit` runs on every PR and push against CI's resolved runtime, semantic,
+and development dependencies, and fails on known vulnerabilities.
+
+The baseline currently has no dependency-audit exceptions. If an advisory is
+demonstrably inapplicable or cannot yet be safely upgraded, add one reviewed
+line to `.github/pip-audit-ignores.txt` in this format:
+
+```
+ADVISORY-ID | tracking issue or PR | rationale | next review date (YYYY-MM-DD)
+```
+
+Keep the exception narrowly scoped to the advisory ID, link its remediation
+work, and remove it as soon as a safe fix is available. The workflow rejects
+malformed entries; it does not suppress the `pip-audit` exit status globally.
 
 ## Pull request workflow
 

--- a/README.md
+++ b/README.md
@@ -1706,7 +1706,10 @@ python -m pytest
 ```
 
 869 tests passing on Python 3.11 / 3.12 / 3.13 (1 skipped). CI runs
-the suite on every push and PR.
+the suite and a resolved-dependency `pip-audit` gate on every push and PR.
+CodeQL scans the Python source on those changes and weekly; see
+[SECURITY.md](SECURITY.md#continuous-security-scanning) for the exception
+process and reporting policy.
 
 ---
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -32,6 +32,20 @@ user data. Startup and `get_db()` best-effort set `~/.threadkeeper` to
 Headless spawn stdout logs are also created `0600`. Permission hardening
 is skipped on platforms without POSIX mode bits and never blocks startup.
 
+## Continuous security scanning
+
+GitHub Actions runs CodeQL's default Python query suite on pull requests and
+pushes to `main`, plus a weekly scheduled scan; CodeQL uploads its findings to
+the repository Security tab. A separate blocking `pip-audit` job audits the
+fully resolved runtime, semantic, and development dependency environment on
+each pull request and push.
+
+Known-vulnerability findings fail the job. The only exception mechanism is the
+reviewed, advisory-specific `.github/pip-audit-ignores.txt` list: each entry
+must include an advisory ID, a tracking issue or PR, a rationale, and a next
+review date. This list is empty for the current baseline; exceptions must be
+removed once a safe remediation is available.
+
 ## Trust boundaries
 
 ### Auto-update (future maintainer code → local execution)

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -578,6 +578,15 @@ applier drains them. Listed here so the roadmap reflects the live backlog.
   injected content) and #63 (issue-author trust gate); the open web cannot be
   author-allowlisted, so those don't cover this path. Scope was S–M.
 
+- ✅ DONE (#144). **CI security scanning.** CodeQL now analyzes the default
+  Python query suite on PRs and pushes to `main` plus a weekly schedule, and
+  uploads results to the Security tab. A blocking `pip-audit` job scans the
+  fully resolved runtime, semantic, and development dependency set; the
+  initially clean baseline has no exceptions, and any future advisory-specific
+  suppression must be reviewed, tracked, justified, and dated in
+  `.github/pip-audit-ignores.txt`. Dependabot also tracks the Docker base image.
+  Scope was S.
+
 **Evolve issue-flow reliability.** The applier posts a claim comment *before*
 spawning the implementer; a spawn failure or red-CI abort leaks the claim for a
 full 24h (TTL-only, no reaper), and a marker-write failure after `gh pr create`

--- a/tests/test_release_workflows.py
+++ b/tests/test_release_workflows.py
@@ -7,6 +7,8 @@ import yaml
 ROOT = Path(__file__).resolve().parents[1]
 WORKFLOWS = ROOT / ".github" / "workflows"
 DOCKERFILE = ROOT / "Dockerfile"
+DEPENDABOT = ROOT / ".github" / "dependabot.yml"
+PIP_AUDIT_IGNORES = ROOT / ".github" / "pip-audit-ignores.txt"
 
 BOT_TAGGER_EMAIL = "41898282+github-actions[bot]@users.noreply.github.com"
 
@@ -113,3 +115,33 @@ def test_mcp_requirement_is_capped_while_the_1x_import_path_is_used():
     mcp_req = next(d for d in deps if d.split(">")[0].split("<")[0].strip() == "mcp")
 
     assert "<2" in mcp_req, f"mcp requirement must exclude 2.x, got {mcp_req!r}"
+
+
+def test_ci_security_scanning_covers_code_and_resolved_dependencies():
+    codeql = _workflow("codeql.yml")
+    codeql_text = _workflow_text("codeql.yml")
+    pip_audit_job = _workflow("test.yml")["jobs"]["pip-audit"]
+    dependabot = yaml.safe_load(DEPENDABOT.read_text())
+
+    assert codeql["permissions"] == {
+        "contents": "read",
+        "security-events": "write",
+    }
+    assert "branches: [main]" in codeql_text
+    assert "cron:" in codeql_text
+    assert "github/codeql-action/init@v4" in codeql_text
+    assert "github/codeql-action/analyze@v4" in codeql_text
+    assert "languages: python" in codeql_text
+    assert "build-mode: none" in codeql_text
+    assert "queries:" not in codeql_text  # Keep the default suite for now.
+
+    audit_text = _workflow_text("test.yml")
+    assert pip_audit_job["name"] == "pip-audit (resolved dependencies)"
+    assert "python -m pip install -e '.[semantic,dev]'" in audit_text
+    assert "pip-audit --local --strict" in audit_text
+    assert "--ignore-vuln" in audit_text
+    assert "Malformed .github/pip-audit-ignores.txt entry" in audit_text
+    assert "There are no active suppressions at present." in PIP_AUDIT_IGNORES.read_text()
+
+    ecosystems = {entry["package-ecosystem"] for entry in dependabot["updates"]}
+    assert "docker" in ecosystems


### PR DESCRIPTION
## Summary

- add weekly and pull-request CodeQL scanning for Python
- gate the resolved dependency environment with pip-audit and reviewed advisory suppressions
- track Docker base-image updates with Dependabot

## Validation

- full pytest suite: 0 failed
- fresh resolved environment: pip-audit --local --strict reported no vulnerabilities

Closes #144