### PR TITLE
fix: recover interrupted open PR merges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,15 @@ version bumps follow semver per the policy in
   restart-only and hot-config reload logs then ignores them, closing runtime
   source redirection through a host settings file. The managed clone's remote
   code-execution trust boundary and shared-host opt-out are documented.
+- **Fixed: interrupted conflict repair no longer deadlocks Evolve apply.** If a
+  conflict-repair child exited after `git merge` while its PR remained open,
+  managed refresh treated the unresolved merge as permanently dirty and every
+  scheduled pass stopped before the conflicted-PR sweep. With no live git
+  writer, the parent now verifies the exact open applier PR, archives the merge
+  diff as an owner-only recovery patch, aborts the orphaned merge, refreshes the
+  disposable checkout, and retries that same PR through the normal protected
+  conflict-repair flow. Closed-unmerged/unreadable PRs and explicit operator
+  checkouts remain fail-closed.
 - **Fixed: one abandoned Evolve attempt can no longer deadlock the apply
   scheduler.** Managed-checkout refresh used to reject a dirty tree before the
   abandoned-WIP recovery gate ran, so a child that edited `main` and then hit a

--- a/README.md
+++ b/README.md
@@ -859,13 +859,17 @@ overlapping in the same checkout.
 If a killed child leaves an unresolved merge or plain tracked WIP in the default
 auto-managed checkout, the next code-producing pass archives the diff before
 recovering it. Merge recovery remains limited to `roadmap/…`/`evolve/…`
-branches whose exact PR is confirmed merged. Plain abandoned WIP is recoverable
-on those applier branches when PR state is readable, and also on the configured
+branches whose exact PR is confirmed open or merged. For an open PR, the parent
+archives the interrupted merge, aborts it, refreshes the disposable checkout,
+and lets the normal conflict-repair sweep retry that same PR. A merged PR's
+leftover merge is discarded as stale. Plain abandoned WIP is recoverable on
+those applier branches when PR state is readable, and also on the configured
 base branch: the disposable base can contain orphaned edits when an older child
 failed during late branch creation. Recovery patches are owner-only files under
 `~/.threadkeeper/evolve-recovery/`, and `evolve_git_safety` records the action.
-Unknown ownership, a live writer, or unreadable required PR state remains
-fail-closed. An explicit `THREADKEEPER_EVOLVE_REPO_ROOT` is never auto-reset.
+Unknown ownership, a live writer, a closed-unmerged PR, or unreadable required
+PR state remains fail-closed. An explicit `THREADKEEPER_EVOLVE_REPO_ROOT` is
+never auto-reset.
 
 The default managed checkout is refreshed before every code-producing pass:
 after checking that no Evolve git writer is live, it archives and recovers any

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -732,13 +732,14 @@ moving the high-water forward; `force=True` bypasses this due gate.
   dirty-state recovery so active child WIP is never discarded.
   For the default auto-managed checkout only, an in-progress merge on an
   applier-owned branch is treated as recoverable when GitHub proves the exact
-  PR is already merged. The parent fetches the configured base, archives the
-  tracked diff as an owner-only (`0600`)
-  `DB_PATH.parent/evolve-recovery/stale-merge-pr-*.patch`, then
-  hard-resets the disposable checkout and switches it to the configured pinned
-  commit. For merges, unknown/open/closed-unmerged PR state
-  and explicit operator checkouts remain fail-closed with
-  `skipped_dirty_worktree`. Plain uncommitted WIP (no merge in progress) on an
+  PR is open or merged. The parent fetches the configured base and archives the
+  tracked diff as an owner-only (`0600`) recovery patch. An open PR merge is
+  explicitly aborted so the normal conflict-repair sweep can retry that same
+  PR from its remote branch; an already-merged PR's local merge is hard-reset
+  as stale. Both paths switch the disposable checkout to the configured pinned
+  commit. Unknown/closed-unmerged PR state and explicit
+  operator checkouts remain fail-closed with `skipped_dirty_worktree`. Plain
+  uncommitted WIP (no merge in progress) on an
   applier-owned branch of the managed checkout — the leftovers of a killed
   implementer child — is likewise auto-recovered: with no PR-producing child
   running and the branch's PR state readable (any state, including none), the

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -96,12 +96,14 @@ remains a live question.
   overlapping reviewer/applier git writers in the shared checkout, and prompts
   children to fetch the configured branch but branch only from the configured
   immutable managed-checkout pin instead of arbitrary current `HEAD`.
-- Evolve managed-checkout stale-merge recovery: a killed conflict-repair child
-  no longer blocks the entire backlog after its PR was merged elsewhere. The
-  parent first excludes live git writers, requires the default managed checkout
-  plus an applier-owned branch and an exact GitHub `MERGED` state, archives the
-  tracked diff under `evolve-recovery/`, and returns the checkout to the fetched
-  base. Explicit operator checkouts and uncertain PR states remain fail-closed.
+- Evolve managed-checkout interrupted-merge recovery: a killed conflict-repair
+  child no longer blocks the entire backlog whether its exact PR remains open
+  or was merged elsewhere. The parent first excludes live git writers, requires
+  the default managed checkout plus an applier-owned branch, archives the
+  tracked diff under `evolve-recovery/`, aborts open-PR merges for a clean retry,
+  and discards already-merged leftovers as stale before returning to the fetched
+  pinned base. Explicit operator checkouts and uncertain/closed-unmerged PR states
+  remain fail-closed.
 - Evolve managed-checkout lifecycle (#128): the disposable clone now refreshes
   to its configured base before each code pass, without touching explicit
   checkouts. Clone/venv provisioning has a bounded

--- a/tests/test_evolve_applier.py
+++ b/tests/test_evolve_applier.py
@@ -1186,13 +1186,31 @@ def test_apply_roadmap_issue_skips_dirty_worktree_and_records_event(
     assert row["summary"] == "skipped_dirty_worktree mode=git"
 
 
-def test_managed_checkout_recovers_stale_merge_after_pr_merged(
-    tmp_path, monkeypatch,
+@pytest.mark.parametrize(
+    ("pr_state", "merged_at", "backup_prefix", "recovery_summary"),
+    [
+        (
+            "MERGED",
+            "2026-07-12T10:28:56Z",
+            "stale-merge-pr-7",
+            "recovered_stale_merge pr=#7",
+        ),
+        (
+            "OPEN",
+            None,
+            "interrupted-open-pr-merge-pr-7",
+            "recovered_open_pr_merge pr=#7",
+        ),
+    ],
+)
+def test_managed_checkout_recovers_orphaned_merge_for_known_pr(
+    tmp_path, monkeypatch, pr_state, merged_at, backup_prefix, recovery_summary,
 ):
     """A killed repair child must not leave the whole backlog blocked forever.
 
     Recovery is restricted to the auto-managed checkout and archives the
     tracked merge diff before returning the tree to the fresh configured base.
+    Open PR merges are aborted for a clean retry; merged PR leftovers are stale.
     """
     pkg = _bootstrap(tmp_path, monkeypatch, pin_repo=False)
     conn = pkg["db"].get_db()
@@ -1252,8 +1270,8 @@ def test_managed_checkout_recovers_stale_merge_after_pr_merged(
         pkg["ea"], "_prs_for_head_branch",
         lambda head, repo_root=None: ([{
             "number": 7,
-            "state": "MERGED",
-            "mergedAt": "2026-07-12T10:28:56Z",
+            "state": pr_state,
+            "mergedAt": merged_at,
             "headRefName": branch,
             "url": "https://github.com/o/r/pull/7",
         }], ""),
@@ -1273,7 +1291,7 @@ def test_managed_checkout_recovers_stale_merge_after_pr_merged(
         "rev-parse", "-q", "--verify", "MERGE_HEAD", check=False
     ).returncode == 1
     backups = list(
-        (tmp_path / "evolve-recovery").glob("stale-merge-pr-7-*.patch")
+        (tmp_path / "evolve-recovery").glob(f"{backup_prefix}-*.patch")
     )
     assert len(backups) == 1
     assert "diff --git" in backups[0].read_text(encoding="utf-8")
@@ -1283,7 +1301,7 @@ def test_managed_checkout_recovers_stale_merge_after_pr_merged(
         (pkg["ea"].EVOLVE_GIT_SAFETY_KIND,),
     ).fetchone()
     assert row["target"] == "roadmap_issue"
-    assert "recovered_stale_merge pr=#7" in row["summary"]
+    assert recovery_summary in row["summary"]
     assert backups[0].name in row["summary"]
 
 
@@ -1312,11 +1330,11 @@ def test_explicit_checkout_never_auto_recovers_dirty_merge(
     assert out == "skipped_dirty_worktree mode=git"
 
 
-def test_managed_checkout_keeps_open_pr_merge_fail_closed(
+def test_managed_checkout_keeps_closed_unmerged_pr_merge_fail_closed(
     tmp_path, monkeypatch,
 ):
     pkg = _bootstrap(tmp_path, monkeypatch)
-    branch = "roadmap/issue-7-still-open"
+    branch = "roadmap/issue-7-closed-unmerged"
     monkeypatch.setattr(
         pkg["ea"], "_managed_repo_auto_recovery_allowed", lambda repo: True,
     )
@@ -1326,7 +1344,7 @@ def test_managed_checkout_keeps_open_pr_merge_fail_closed(
         pkg["ea"], "_prs_for_head_branch",
         lambda head, repo_root=None: ([{
             "number": 7,
-            "state": "OPEN",
+            "state": "CLOSED",
             "mergedAt": None,
             "headRefName": branch,
         }], ""),
@@ -1334,7 +1352,7 @@ def test_managed_checkout_keeps_open_pr_merge_fail_closed(
     monkeypatch.setattr(
         pkg["ea"], "_archive_stale_merge_diff",
         lambda *args: (_ for _ in ()).throw(
-            AssertionError("open PR state must never be reset")
+            AssertionError("closed-unmerged PR state must never be reset")
         ),
     )
 
@@ -1343,7 +1361,7 @@ def test_managed_checkout_keeps_open_pr_merge_fail_closed(
     )
 
     assert recovered is False
-    assert reason == "stale_merge_pr_not_merged=#7:OPEN"
+    assert reason == "stale_merge_pr_not_recoverable=#7:CLOSED"
 
 
 def test_prs_for_head_branch_filters_cross_repository_matches(

--- a/threadkeeper/evolve_applier.py
+++ b/threadkeeper/evolve_applier.py
@@ -997,6 +997,16 @@ def _archive_stale_merge_diff(
     return _archive_tracked_diff(repo_root, f"stale-merge-pr-{int(pr_number)}")
 
 
+def _archive_interrupted_open_pr_merge_diff(
+    repo_root: Path,
+    pr_number: int,
+) -> tuple[Optional[Path], str]:
+    """Persist an interrupted open-PR merge before restarting its repair."""
+    return _archive_tracked_diff(
+        repo_root, f"interrupted-open-pr-merge-pr-{int(pr_number)}"
+    )
+
+
 def _archive_abandoned_wip_diff(
     repo_root: Path,
     branch: str,
@@ -1008,13 +1018,15 @@ def _archive_abandoned_wip_diff(
 def _recover_stale_managed_merge(
     repo_root: Path,
 ) -> tuple[bool, str]:
-    """Recover an orphaned merge only when its applier PR is already merged.
+    """Recover an orphaned merge for a known applier PR.
 
     The managed checkout is shared across passes, so a killed conflict-repair
     child can otherwise block every future backlog item. This recovery is
     intentionally narrow: managed checkout, merge in progress, applier-owned
-    branch, exact GitHub PR proven merged, archived tracked diff. Any uncertain
-    state remains fail-closed for a human.
+    branch, exact GitHub PR proven open or merged, archived tracked diff. An
+    open PR's interrupted merge is aborted so the conflict-repair child can
+    restart it; an already-merged PR is discarded as stale. Any uncertain state
+    remains fail-closed for a human.
     """
     if not _managed_repo_auto_recovery_allowed(repo_root):
         return False, ""
@@ -1033,6 +1045,13 @@ def _recover_stale_managed_merge(
         return False, f"stale_merge_pr_fetch_failed={_short(pr_err)}"
     if not prs:
         return False, "stale_merge_pr_not_found"
+    opened = next(
+        (
+            pr for pr in prs
+            if str(pr.get("state") or "").upper() == "OPEN"
+        ),
+        None,
+    )
     merged = next(
         (
             pr for pr in prs
@@ -1041,13 +1060,14 @@ def _recover_stale_managed_merge(
         ),
         None,
     )
-    if merged is None:
+    recoverable_pr = opened or merged
+    if recoverable_pr is None:
         state = str(prs[0].get("state") or "UNKNOWN").upper()
         return False, (
-            f"stale_merge_pr_not_merged=#{int(prs[0].get('number') or 0)}"
+            f"stale_merge_pr_not_recoverable=#{int(prs[0].get('number') or 0)}"
             f":{state}"
         )
-    pr_number = int(merged.get("number") or 0)
+    pr_number = int(recoverable_pr.get("number") or 0)
     if pr_number <= 0:
         return False, "stale_merge_pr_number_invalid"
 
@@ -1058,15 +1078,27 @@ def _recover_stale_managed_merge(
     )
     if fetch_err:
         return False, f"stale_merge_fetch_failed={_short(fetch_err)}"
-    backup, backup_err = _archive_stale_merge_diff(repo_root, pr_number)
+    if opened is not None:
+        backup, backup_err = _archive_interrupted_open_pr_merge_diff(
+            repo_root, pr_number
+        )
+        backup_kind = "open_pr_merge"
+    else:
+        backup, backup_err = _archive_stale_merge_diff(repo_root, pr_number)
+        backup_kind = "stale_merge"
     if backup_err or backup is None:
-        return False, f"stale_merge_backup_failed={_short(backup_err)}"
+        return False, f"{backup_kind}_backup_failed={_short(backup_err)}"
 
-    reset_err = _run(
-        ["git", "reset", "--hard", "HEAD"], timeout=30, cwd=repo_root
-    )
-    if reset_err:
-        return False, f"stale_merge_reset_failed={_short(reset_err)}"
+    if opened is not None:
+        reset_err = _run(["git", "merge", "--abort"], timeout=30, cwd=repo_root)
+        if reset_err:
+            return False, f"open_pr_merge_abort_failed={_short(reset_err)}"
+    else:
+        reset_err = _run(
+            ["git", "reset", "--hard", "HEAD"], timeout=30, cwd=repo_root
+        )
+        if reset_err:
+            return False, f"stale_merge_reset_failed={_short(reset_err)}"
     checkout_err = _run(
         [
             "git", "checkout", "-f", "-B", _base_branch_name(),
@@ -1082,6 +1114,11 @@ def _recover_stale_managed_merge(
         return False, f"stale_merge_recheck_failed={_short(status_err)}"
     if dirty:
         return False, "stale_merge_recovery_left_dirty"
+    if opened is not None:
+        return True, (
+            f"recovered_open_pr_merge pr=#{pr_number} "
+            f"branch={_short(branch, 80)} backup={backup.name}"
+        )
     return True, (
         f"recovered_stale_merge pr=#{pr_number} branch={_short(branch, 80)} "
         f"backup={backup.name}"


### PR DESCRIPTION
## Summary
- recognize an orphaned merge for the exact open same-repo applier PR in the disposable managed checkout
- archive the tracked conflict diff with owner-only permissions, abort the merge, and retry through the existing protected conflict-repair sweep
- keep closed-unmerged or unreadable PRs, live writers, and explicit operator checkouts fail-closed

## Validation
- 166 affected tests passed
- full suite: 1420 passed, 3 skipped