### PR TITLE
feat: denylist transcript ingestion by project path

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -30,6 +30,9 @@ python -m threadkeeper._setup --dry-run
 - [ ] If a new MCP tool — added to `threadkeeper/tools/` AND imported in `server.py`
 - [ ] If a new adapter — registered in `adapters/__init__.py` with a test in `tests/test_adapters.py`
 - [ ] If user-visible behavior changed — README / CONTRIBUTING reflects it
+- [ ] Version is bumped in `pyproject.toml`, `server.json`, and `Dockerfile`
+      (fix → patch, feature → minor, replacement/breaking implementation → major),
+      with a matching versioned `CHANGELOG.md` heading
 - [ ] No new emoji in code or docs (per house style)
 - [ ] No new locale strings outside `threadkeeper/i18n.py`
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -111,5 +111,8 @@ jobs:
             ignore_args+=(--ignore-vuln "$vulnerability_id")
           done < .github/pip-audit-ignores.txt
           # With no input arguments, pip-audit audits this fully resolved
-          # environment. --strict makes incomplete dependency collection fail.
-          pip-audit --local --strict "${ignore_args[@]}"
+          # environment. The checkout itself is an editable package whose new
+          # release version does not exist on PyPI yet, so skip only that local
+          # package while retaining the full transitive dependency audit.
+          # --strict still makes incomplete dependency collection fail.
+          pip-audit --local --strict --skip-editable "${ignore_args[@]}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -92,6 +92,11 @@ jobs:
           # Audit the same runtime, semantic, and test dependency set that CI
           # resolves, rather than only direct requirements from pyproject.toml.
           python -m pip install -e '.[semantic,dev]'
+          # Keep the resolved dependencies but remove the editable project:
+          # its bumped version intentionally does not exist on PyPI before the
+          # release, and --strict treats even an explicit editable skip as an
+          # incomplete audit.
+          python -m pip uninstall -y threadkeeper
           python -m pip install pip-audit
 
       - name: Fail on known dependency vulnerabilities
@@ -111,8 +116,6 @@ jobs:
             ignore_args+=(--ignore-vuln "$vulnerability_id")
           done < .github/pip-audit-ignores.txt
           # With no input arguments, pip-audit audits this fully resolved
-          # environment. The checkout itself is an editable package whose new
-          # release version does not exist on PyPI yet, so skip only that local
-          # package while retaining the full transitive dependency audit.
-          # --strict still makes incomplete dependency collection fail.
-          pip-audit --local --strict --skip-editable "${ignore_args[@]}"
+          # dependency environment. --strict makes incomplete dependency
+          # collection fail.
+          pip-audit --local --strict "${ignore_args[@]}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ version bumps follow semver per the policy in
 [CONTRIBUTING.md → Releases](CONTRIBUTING.md#releases).
 
 ## [Unreleased]
+- **Added: pre-ingest transcript privacy denylist (#145).**
+  `THREADKEEPER_INGEST_DENY_GLOBS` and the line-based local denylist file skip
+  matching adapter project/CWD messages before text, FTS, vector embeddings, or
+  learning-loop inputs are written. File watermarks advance normally, and
+  `mp_dashboard()` reports active patterns with the cumulative skipped count.
 - **Added: CI security scanning (#144).** CodeQL analyzes the default Python
   query suite on pull requests and pushes to `main`, plus weekly, and uploads
   results to the Security tab. A blocking `pip-audit` job scans the fully

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,18 @@ version bumps follow semver per the policy in
 [CONTRIBUTING.md → Releases](CONTRIBUTING.md#releases).
 
 ## [Unreleased]
+
+## v0.17.0 — 2026-08-24
+
 - **Added: pre-ingest transcript privacy denylist (#145).**
   `THREADKEEPER_INGEST_DENY_GLOBS` and the line-based local denylist file skip
   matching adapter project/CWD messages before text, FTS, vector embeddings, or
   learning-loop inputs are written. File watermarks advance normally, and
   `mp_dashboard()` reports active patterns with the cumulative skipped count.
+- **Fixed: Evolve implementation PRs now include release metadata.** The
+  applier prompt requires the SemVer bump, matching `server.json` fields,
+  Docker release pin, and versioned changelog heading in the same PR; the PR
+  checklist mirrors that requirement for human-authored changes.
 - **Added: CI security scanning (#144).** CodeQL analyzes the default Python
   query suite on pull requests and pushes to `main`, plus weekly, and uploads
   results to the Security tab. A blocking `pip-audit` job scans the fully

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,10 +18,10 @@ version bumps follow semver per the policy in
   applier prompt requires the SemVer bump, matching `server.json` fields,
   Docker release pin, and versioned changelog heading in the same PR; the PR
   checklist mirrors that requirement for human-authored changes. The dependency
-  audit skips only the unreleased editable project itself while continuing to
-  audit its fully resolved transitive dependencies, so a required version bump
-  no longer makes `pip-audit --strict` fail merely because that version is not
-  on PyPI yet.
+  audit now removes only the unreleased editable project after resolving its
+  dependency set, then audits the remaining full environment, so a required
+  version bump no longer makes `pip-audit --strict` fail merely because that
+  version is not on PyPI yet.
 - **Added: CI security scanning (#144).** CodeQL analyzes the default Python
   query suite on pull requests and pushes to `main`, plus weekly, and uploads
   results to the Security tab. A blocking `pip-audit` job scans the fully

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,11 @@ version bumps follow semver per the policy in
 - **Fixed: Evolve implementation PRs now include release metadata.** The
   applier prompt requires the SemVer bump, matching `server.json` fields,
   Docker release pin, and versioned changelog heading in the same PR; the PR
-  checklist mirrors that requirement for human-authored changes.
+  checklist mirrors that requirement for human-authored changes. The dependency
+  audit skips only the unreleased editable project itself while continuing to
+  audit its fully resolved transitive dependencies, so a required version bump
+  no longer makes `pip-audit --strict` fail merely because that version is not
+  on PyPI yet.
 - **Added: CI security scanning (#144).** CodeQL analyzes the default Python
   query suite on pull requests and pushes to `main`, plus weekly, and uploads
   results to the Security tab. A blocking `pip-audit` job scans the fully

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -322,7 +322,7 @@ friction) out.
 |---|---|---|
 | `feat:` | minor | 0.6.0 |
 | `fix:`, `perf:`, `refactor:`, `docs:`, `test:`, `chore:`, `ci:`, `build:`, `deps:`, `revert:` | patch | 0.5.4 |
-| `BREAKING CHANGE:` footer | minor while in 0.x (manual promotion to 1.0.0 when API is stable) | 0.6.0 |
+| Ground-up replacement, `!` marker, or `BREAKING CHANGE:` footer | major, including while in 0.x | 1.0.0 |
 
 If a single commit touches multiple concerns (rare — squash-merge
 typically prevents this), pick the highest bump that applies.
@@ -349,9 +349,8 @@ mcp-publisher login github
 mcp-publisher publish
 ```
 
-### Promoting to 1.0.0
+### Major releases
 
-Once the API is stable and the next BREAKING CHANGE should land 1.0.0:
-bump `pyproject.toml` to `1.0.0` directly in that release PR; the same
-auto-tag flow releases it. No config flip needed — manual control by
-design.
+A ground-up replacement or breaking new implementation bumps the major version
+directly, including from 0.x to 1.0.0. The same auto-tag flow releases it; no
+config flip is needed.

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ WORKDIR /app
 # Install the release this checkout declares. Skip the [semantic] extra (~700
 # MB fastembed ONNX model) — Glama only inspects the MCP tool schema, not
 # embedding quality.
-RUN pip install --no-cache-dir threadkeeper==0.16.3
+RUN pip install --no-cache-dir threadkeeper==0.17.0
 
 # Don't spawn shadow-review / curator / probe / dialectic daemons in
 # the Glama sandbox — they would try to invoke claude / codex / agy

--- a/README.md
+++ b/README.md
@@ -1173,6 +1173,7 @@ The most-used env knobs (full list in `threadkeeper/config.py`):
 | `THREADKEEPER_MEMORY_GUARD_RETIRE_LIVE` | "" (off) | allow retiring parent-alive MCP servers; off protects live clients |
 | `THREADKEEPER_MEMORY_GUARD_NOTIFY` | "1" | send macOS desktop notification when possible |
 | `THREADKEEPER_INGEST_INTERVAL_S` | 3 | transcript ingest tick (s) |
+| `THREADKEEPER_INGEST_DENY_GLOBS` | "" | comma/newline-separated project/CWD paths or shell globs to exclude before transcript content is persisted; literal paths also exclude descendants. `~/.threadkeeper/ingest_denylist.txt` adds one pattern per non-comment line; use `THREADKEEPER_INGEST_DENYLIST_FILE` to relocate it. Active patterns and the cumulative skipped count appear in `mp_dashboard()` |
 | `THREADKEEPER_REDACT_DIALOG_SECRETS` | true | scrub common credential-shaped values before transcript text is persisted to `dialog_messages` / `dialog_fts`; set `0` only for rare local debugging where raw transcript fidelity is more important than durable secret protection; the v2 schema migration also scrubs legacy pre-redaction rows in place |
 | `THREADKEEPER_NO_EMBEDDINGS` | "" | force-disable the embedding model (FTS5 + delegate only) |
 | `THREADKEEPER_EMBED_BACKEND` | `onnx` | embedding runtime: `onnx` (fastembed, no PyTorch) or `sentence-transformers` (legacy fallback) |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -183,6 +183,15 @@ pasted by the user, echoed by a tool, or copied from a config file.
 
 Mitigations:
 
+- **Pre-ingest project denylist.** Set `THREADKEEPER_INGEST_DENY_GLOBS` to a
+  comma- or newline-separated list of project/CWD paths or shell globs, or add
+  one pattern per non-comment line to `~/.threadkeeper/ingest_denylist.txt`.
+  Literal paths include descendants. A matching Claude Code, Codex, or Copilot
+  transcript message is skipped before its text is scrubbed, embedded, or
+  written to `dialog_messages`/FTS/vector stores, so it cannot enter the
+  shadow-review, extraction, or dialectic inputs. `mp_dashboard()` displays the
+  active patterns and cumulative skipped-message count. This is preventative
+  only: use `forget` for any rows ingested before a denylist was configured.
 - **Default-on redaction.** Before transcript content is persisted, mirrored
   into FTS, embedded, or inserted by FTS backfill, thread-keeper masks common
   credential-shaped values. Covered shapes include `Authorization:` /

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -227,6 +227,14 @@ Steady-state access is split by intent:
    `*_TOKEN=` / `*_SECRET=` assignments. The redaction is default-on and can be
    disabled with `THREADKEEPER_REDACT_DIALOG_SECRETS=0` only for local debugging
    that intentionally trades away the durable secret-scrubbing guarantee.
+   Before that scrub/embed/write pipeline, adapter-reported project/CWD values
+   are matched against `THREADKEEPER_INGEST_DENY_GLOBS` plus the local
+   `~/.threadkeeper/ingest_denylist.txt` (one path/glob per non-comment line).
+   A match drops the normalized message before any dialog, FTS, vector, skill,
+   or learning-loop input is created, while the file cursor advances normally.
+   Literal paths cover descendants; `mp_dashboard()` exposes configured patterns
+   and the cumulative skipped-message count. Existing data is intentionally not
+   erased by configuration; use `forget` for the #104 post-hoc path.
    Targeted privacy erasure is handled by `forget(selector, dry_run=True)` /
    `tk-forget`: given a session/cid it deletes matching dialog rows and their
    FTS/vector mirrors, plus directly sourced notes, verbatim, dialectic,

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -151,9 +151,10 @@ Semantic versioning, conservative bumps:
   ones, no breaking config changes.
 - **MINOR** (`0.4.0` → `0.5.0`) — new MCP tools, new env knobs, new
   daemons, new adapters, new prompt variants. Backwards compatible.
-- **MAJOR** (`0.4.0` → `1.0.0`) — breaking changes to MCP tool
-  signatures, removed tools, schema migrations that require manual
-  intervention, removed env knobs. Bump only when truly necessary.
+- **MAJOR** (`0.4.0` → `1.0.0`) — a ground-up replacement or breaking
+  new implementation: incompatible MCP tool signatures, removed tools,
+  schema migrations that require manual intervention, or removed env knobs.
+  Major means the next major even while the project is in 0.x.
 
 ## Yank / re-release
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -157,6 +157,12 @@ remains a live question.
   sidecars, notes, verbatim, dialectic observations/evidence/claims, extract
   candidates, task rows/spool files, signals, and session sidecars, while
   surfacing lessons/skills that cite the purged source for manual re-review.
+- Pre-ingest privacy denylist (#145): configured project/CWD paths and globs
+  now drop matching adapter messages before redaction, embedding, or any dialog
+  write. The per-file ingest watermark still advances past skipped messages;
+  `mp_dashboard()` displays the active patterns and cumulative skipped count.
+  This prevention control complements secret redaction (#37), retention (#45),
+  and selective erasure (#104) for data stored before the denylist was enabled.
 - Cross-CLI ingest production verification (issue #1): the contract test in
   `scripts/tk_verify_ingest.py` gained a read-only `--live` mode that scores
   the three acceptance criteria — all CLI slots have production rows, shadow-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "threadkeeper"
-version = "0.16.3"
+version = "0.17.0"
 description = "Multi-agent shared brain across Claude Code/Desktop, Codex, Antigravity CLI, Copilot, and VS Code. Cross-session memory, self-improving skill loops, inter-agent signaling — one local MCP server."
 requires-python = ">=3.11"
 authors = [{ name = "thread-keeper contributors" }]

--- a/server.json
+++ b/server.json
@@ -7,12 +7,12 @@
     "url": "https://github.com/po4erk91/thread-keeper",
     "source": "github"
   },
-  "version": "0.16.3",
+  "version": "0.17.0",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "threadkeeper",
-      "version": "0.16.3",
+      "version": "0.17.0",
       "transport": {
         "type": "stdio"
       }

--- a/tests/test_evolve_applier.py
+++ b/tests/test_evolve_applier.py
@@ -1126,6 +1126,13 @@ def test_apply_roadmap_issue_builds_evolve_applier_spawn(
     assert "evolve_mark_roadmap_issue_applied" in prompt
     assert "THREADKEEPER_NO_EMBEDDINGS" in prompt
     assert "<!-- thread-keeper:evolve-applier-claim -->" in prompt
+    assert "Releasing is part of EVERY implementation PR" in prompt
+    assert "fix/internal/docs-only change -> PATCH" in prompt
+    assert "new backwards-compatible functionality (`feat:`) -> MINOR" in prompt
+    assert "ground-up replacement or breaking new implementation -> MAJOR" in prompt
+    assert "both `server.json` version fields" in prompt
+    assert "Dockerfile" in prompt
+    assert "Never leave" in prompt and "only under `[Unreleased]`" in prompt
     branch = pkg["ea"].roadmap_issue_branch_name(6, "Telemetry dashboard")
     base_ref = pkg["ea"]._base_ref()
     assert "git fetch origin" in prompt

--- a/tests/test_ingest_denylist.py
+++ b/tests/test_ingest_denylist.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+from threadkeeper.adapters.base import NormalizedMessage
+
+
+class _FakeAdapter:
+    name = "fake-cli"
+
+    def __init__(self, messages: list[NormalizedMessage]) -> None:
+        self._messages = messages
+        self.iter_calls = 0
+        self.files: list[Path] = []
+
+    def transcript_files(self) -> list[Path]:
+        return self.files
+
+    def iter_messages(self, _fp: Path):
+        self.iter_calls += 1
+        yield from self._messages
+
+    def project_label(self, _fp: Path) -> str:
+        return "fake-project"
+
+
+def _message(uuid: str, content: str, origin_path: str) -> NormalizedMessage:
+    return NormalizedMessage(
+        uuid=uuid,
+        session_id="denylist-session",
+        role="user",
+        content=content,
+        model="",
+        created_at=int(time.time()),
+        raw={"role": "user", "content": content},
+        origin_path=origin_path,
+    )
+
+
+def test_denylisted_messages_never_persist_or_reach_shadow_window(
+    fresh_mp, tmp_path, monkeypatch
+):
+    from threadkeeper import ingest, shadow_review
+
+    sensitive_root = tmp_path / "sensitive-client"
+    allowed_root = tmp_path / "ordinary-project"
+    monkeypatch.setenv("THREADKEEPER_INGEST_DENY_GLOBS", str(sensitive_root))
+    fresh_mp["config"].reload_settings()
+    monkeypatch.setattr(ingest, "SEMANTIC_AVAILABLE", False)
+
+    transcript = tmp_path / "session.jsonl"
+    transcript.write_text("fixture\n", encoding="utf-8")
+    adapter = _FakeAdapter([
+        _message("denied-1", "client secret must not persist", str(sensitive_root)),
+        _message("allowed-1", "ordinary project can persist", str(allowed_root)),
+    ])
+    conn = fresh_mp["db"].get_db()
+    skipped = [0]
+
+    assert ingest._ingest_file(
+        conn, transcript, max_msgs=100, adapter=adapter, skipped_counter=skipped
+    ) == 1
+    conn.commit()
+
+    assert skipped == [1]
+    assert conn.execute(
+        "SELECT 1 FROM dialog_messages WHERE uuid='denied-1'"
+    ).fetchone() is None
+    assert conn.execute(
+        "SELECT 1 FROM dialog_fts WHERE dialog_fts MATCH 'client secret'"
+    ).fetchone() is None
+    dump, _, _, _ = shadow_review._collect_window(conn, 0, 3600)
+    assert "ordinary project can persist" in dump
+    assert "client secret must not persist" not in dump
+
+    state = conn.execute(
+        "SELECT last_size, last_mtime FROM ingest_state WHERE file_path=?",
+        (str(transcript),),
+    ).fetchone()
+    assert state["last_size"] == transcript.stat().st_size
+    assert state["last_mtime"] == int(transcript.stat().st_mtime)
+    assert ingest._ingest_file(conn, transcript, max_msgs=100, adapter=adapter) == 0
+    assert adapter.iter_calls == 1
+
+
+def test_denylist_file_and_status_report_skipped_messages(
+    fresh_mp, tmp_path, monkeypatch
+):
+    from threadkeeper import ingest
+
+    denylist = tmp_path / "ingest_denylist.txt"
+    sensitive_root = tmp_path / "regulated"
+    denylist.write_text(
+        "# do not index this client\n" + str(sensitive_root) + "\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("THREADKEEPER_INGEST_DENYLIST_FILE", str(denylist))
+    fresh_mp["config"].reload_settings()
+    monkeypatch.setattr(ingest, "SEMANTIC_AVAILABLE", False)
+
+    transcript = tmp_path / "session.jsonl"
+    transcript.write_text("fixture\n", encoding="utf-8")
+    adapter = _FakeAdapter([
+        _message("denied-file-1", "regulated transcript text", str(sensitive_root)),
+    ])
+    adapter.files = [transcript]
+    conn = fresh_mp["db"].get_db()
+    from threadkeeper import adapters
+    monkeypatch.setattr(adapters, "installed_adapters", lambda: [adapter])
+    assert ingest._ingest_all(conn) == (0, 1)
+
+    out = fresh_mp["mcp"]._tool_manager._tools["mp_dashboard"].fn()
+    assert f"denylist={sensitive_root}" in out
+    assert "ingest_denied_messages=1" in out

--- a/tests/test_ingest_status.py
+++ b/tests/test_ingest_status.py
@@ -28,7 +28,7 @@ def test_ingest_pass_event_recorded_for_status_ui(mp_with_cid):
 
     assert row["kind"] == "ingest_pass"
     assert row["target"]
-    assert row["summary"] == "ok mode=recent new=2 files=5"
+    assert row["summary"] == "ok mode=recent new=2 files=5 skipped=0"
 
 
 def test_start_background_ingester_respects_disable_bg_daemons(mp_with_cid, monkeypatch):

--- a/tests/test_release_workflows.py
+++ b/tests/test_release_workflows.py
@@ -138,8 +138,8 @@ def test_ci_security_scanning_covers_code_and_resolved_dependencies():
     audit_text = _workflow_text("test.yml")
     assert pip_audit_job["name"] == "pip-audit (resolved dependencies)"
     assert "python -m pip install -e '.[semantic,dev]'" in audit_text
+    assert "python -m pip uninstall -y threadkeeper" in audit_text
     assert "pip-audit --local --strict" in audit_text
-    assert "--skip-editable" in audit_text
     assert "--ignore-vuln" in audit_text
     assert "Malformed .github/pip-audit-ignores.txt entry" in audit_text
     assert "There are no active suppressions at present." in PIP_AUDIT_IGNORES.read_text()

--- a/tests/test_release_workflows.py
+++ b/tests/test_release_workflows.py
@@ -139,6 +139,7 @@ def test_ci_security_scanning_covers_code_and_resolved_dependencies():
     assert pip_audit_job["name"] == "pip-audit (resolved dependencies)"
     assert "python -m pip install -e '.[semantic,dev]'" in audit_text
     assert "pip-audit --local --strict" in audit_text
+    assert "--skip-editable" in audit_text
     assert "--ignore-vuln" in audit_text
     assert "Malformed .github/pip-audit-ignores.txt entry" in audit_text
     assert "There are no active suppressions at present." in PIP_AUDIT_IGNORES.read_text()

--- a/threadkeeper/adapters/base.py
+++ b/threadkeeper/adapters/base.py
@@ -62,6 +62,8 @@ class NormalizedMessage:
       raw         — the original parsed dict, in case downstream code
                     needs to peek into adapter-specific fields (e.g.
                     Skill tool_use detection in ingest).
+      origin_path — originating project/CWD when the transcript provides it.
+                    It is used only for pre-persistence ingest policy.
     """
     uuid: str
     session_id: str
@@ -70,6 +72,7 @@ class NormalizedMessage:
     model: str
     created_at: int
     raw: dict
+    origin_path: str = ""
 
 
 class CLIAdapter(ABC):

--- a/threadkeeper/adapters/claude_code.py
+++ b/threadkeeper/adapters/claude_code.py
@@ -297,6 +297,7 @@ class ClaudeCodeAdapter(CLIAdapter):
                         model=msg.get("model") or "",
                         created_at=created,
                         raw=msg,
+                        origin_path=(obj.get("cwd") or msg.get("cwd") or ""),
                     )
         except OSError:
             return

--- a/threadkeeper/adapters/codex.py
+++ b/threadkeeper/adapters/codex.py
@@ -427,6 +427,7 @@ class CodexAdapter(CLIAdapter):
     def iter_messages(self, fp: Path) -> Iterator[NormalizedMessage]:
         sess_id = ""
         forced_session_id = ""
+        cwd = ""
         pending: list[NormalizedMessage] = []
         try:
             with fp.open("r", encoding="utf-8", errors="replace") as f:
@@ -442,9 +443,12 @@ class CodexAdapter(CLIAdapter):
                     payload = env.get("payload") or {}
                     if typ == "session_meta" and isinstance(payload, dict):
                         sess_id = payload.get("id") or sess_id
-                        if sess_id and not forced_session_id:
-                            for msg in pending:
+                        cwd = payload.get("cwd") or cwd
+                        for msg in pending:
+                            if sess_id and not forced_session_id:
                                 msg.session_id = sess_id
+                            if cwd:
+                                msg.origin_path = cwd
                         continue
                     if typ != "response_item":
                         continue
@@ -465,8 +469,10 @@ class CodexAdapter(CLIAdapter):
                         forced_session_id = cid
                         for msg in pending:
                             msg.session_id = forced_session_id
-                            yield msg
-                        pending.clear()
+                        if cwd:
+                            for msg in pending:
+                                yield msg
+                            pending.clear()
                     # Stable per-line id: use payload.id when present,
                     # else fall back to timestamp plus line index.
                     uuid = (
@@ -481,8 +487,9 @@ class CodexAdapter(CLIAdapter):
                         model=payload.get("model") or "",
                         created_at=_ts(env.get("timestamp", "")),
                         raw=payload,
+                        origin_path=cwd,
                     )
-                    if forced_session_id:
+                    if forced_session_id and cwd:
                         yield msg
                     else:
                         pending.append(msg)

--- a/threadkeeper/adapters/copilot.py
+++ b/threadkeeper/adapters/copilot.py
@@ -241,16 +241,26 @@ class CopilotAdapter(CLIAdapter):
         except sqlite3.OperationalError:
             return
         try:
-            rows = conn.execute(
-                "SELECT session_id, turn_index, user_message, "
-                "assistant_response, timestamp FROM turns "
-                "ORDER BY session_id, turn_index"
-            ).fetchall()
+            try:
+                rows = conn.execute(
+                    "SELECT turns.session_id, turn_index, user_message, "
+                    "assistant_response, timestamp, sessions.cwd "
+                    "FROM turns LEFT JOIN sessions ON sessions.id=turns.session_id "
+                    "ORDER BY turns.session_id, turn_index"
+                ).fetchall()
+            except sqlite3.OperationalError:
+                # Older or partial stores may lack the sessions relation. They
+                # remain ingestible, but cannot participate in a CWD denylist.
+                rows = [(*row, "") for row in conn.execute(
+                    "SELECT session_id, turn_index, user_message, "
+                    "assistant_response, timestamp FROM turns "
+                    "ORDER BY session_id, turn_index"
+                ).fetchall()]
         except sqlite3.OperationalError:
             conn.close()
             return
         conn.close()
-        for sess_id, turn_idx, user_msg, asst_msg, ts in rows:
+        for sess_id, turn_idx, user_msg, asst_msg, ts, cwd in rows:
             created = _ts(ts or "")
             if user_msg:
                 yield NormalizedMessage(
@@ -261,6 +271,7 @@ class CopilotAdapter(CLIAdapter):
                     model="",
                     created_at=created,
                     raw={"turn_index": turn_idx},
+                    origin_path=cwd or "",
                 )
             if asst_msg:
                 yield NormalizedMessage(
@@ -271,6 +282,7 @@ class CopilotAdapter(CLIAdapter):
                     model="",
                     created_at=created,
                     raw={"turn_index": turn_idx},
+                    origin_path=cwd or "",
                 )
 
 

--- a/threadkeeper/config.py
+++ b/threadkeeper/config.py
@@ -229,6 +229,15 @@ class Settings(BaseSettings):
             "THREADKEEPER_INGEST_WINDOW_S", "ingest_window_s"
         ),
     )
+    # Comma- or newline-separated project/CWD globs that ingest must skip
+    # before any dialog, FTS, vector, or learning-loop write occurs.
+    ingest_deny_globs: str = ""
+    ingest_denylist_file: Path = Field(
+        default=Path("~/.threadkeeper/ingest_denylist.txt"),
+        validation_alias=AliasChoices(
+            "THREADKEEPER_INGEST_DENYLIST_FILE", "ingest_denylist_file"
+        ),
+    )
     redact_dialog_secrets: bool = True
 
     # ── SQLite retention / compaction ────────────────────────────────────────
@@ -807,6 +816,8 @@ def _derive_constants(s: "Settings") -> dict:
         "INGEST_CAP_PER_CALL": s.ingest_cap,
         "INGEST_INTERVAL_S": s.ingest_interval_s,
         "INGEST_RECENT_WINDOW_S": s.ingest_window_s,
+        "INGEST_DENY_GLOBS": s.ingest_deny_globs,
+        "INGEST_DENYLIST_FILE": s.ingest_denylist_file,
         "RETENTION_INTERVAL_S": s.retention_interval_s,
         "DIALOG_RETENTION_DAYS": s.dialog_retention_days,
         "TASK_RETENTION_DAYS": s.task_retention_days,

--- a/threadkeeper/evolve_applier.py
+++ b/threadkeeper/evolve_applier.py
@@ -381,12 +381,24 @@ the blocker/status so a later agent has enough context.
    and validate it instead of recreating it. If the branch cannot be resumed
    safely, comment with the blocker and stop before editing.
 
-3. Read the relevant code and docs before editing. Also read docs/ROADMAP.md
-   and the issue body so the implementation matches the tracked roadmap item.
+3. Read the relevant code and docs before editing. Also read docs/ROADMAP.md,
+   CONTRIBUTING.md's Releases section, and the issue body so the implementation
+   matches the tracked roadmap item and its release metadata is complete.
 
 4. Implement only this issue. Keep the change surgical, update README /
-   docs/ARCHITECTURE.md / docs/ROADMAP.md / CHANGELOG.md when behavior or
-   documented state changes, and add focused tests proportional to risk.
+   docs/ARCHITECTURE.md / docs/ROADMAP.md when behavior or documented state
+   changes, and add focused tests proportional to risk.
+
+   Releasing is part of EVERY implementation PR. Choose the final Conventional
+   Commit type, then bump from the base branch version using the highest change
+   class present:
+     - fix/internal/docs-only change -> PATCH;
+     - new backwards-compatible functionality (`feat:`) -> MINOR;
+     - ground-up replacement or breaking new implementation -> MAJOR.
+   Update `pyproject.toml`, both `server.json` version fields, the Dockerfile
+   `threadkeeper==...` pin, and add the matching
+   `## vX.Y.Z — YYYY-MM-DD` heading to CHANGELOG.md in this same PR. Never leave
+   implementation notes only under `[Unreleased]`.
 
 5. Run the full suite from the repo root and read the FINAL summary line:
      env -u THREADKEEPER_NO_EMBEDDINGS .venv/bin/python -m pytest -q

--- a/threadkeeper/ingest.py
+++ b/threadkeeper/ingest.py
@@ -2,6 +2,8 @@
 Background daemon ticks every INGEST_INTERVAL_S; brief() can also call _ingest_recent_only directly."""
 from __future__ import annotations
 
+import fnmatch
+import glob
 import json as _json
 import os
 import re
@@ -103,12 +105,78 @@ def _scrub_dialog_secrets(text: str) -> str:
     return scrubbed
 
 
+def ingest_deny_globs() -> tuple[str, ...]:
+    """Return the active pre-ingest CWD/project exclusion patterns.
+
+    The environment value is deliberately read from ``config`` on each pass so
+    hot-config reloads take effect without restarting the ingester. The file is
+    also read per pass: it is a small, local policy file and immediate pickup is
+    more important than caching it in a process that may run for days.
+    """
+    from . import config
+
+    entries: list[str] = []
+    for part in str(config.INGEST_DENY_GLOBS or "").replace("\n", ",").split(","):
+        item = part.strip()
+        if item:
+            entries.append(item)
+    try:
+        lines = Path(config.INGEST_DENYLIST_FILE).expanduser().read_text(
+            encoding="utf-8"
+        ).splitlines()
+    except OSError:
+        lines = []
+    for line in lines:
+        item = line.strip()
+        if item and not item.startswith("#"):
+            entries.append(item)
+    # Preserve order for status output while making duplicated config harmless.
+    return tuple(dict.fromkeys(entries))
+
+
+def _normalized_path(value: str) -> str:
+    return os.path.normcase(os.path.normpath(
+        os.path.abspath(os.path.expanduser(str(value)))
+    ))
+
+
+def _origin_is_denied(origin_path: str, patterns: tuple[str, ...]) -> bool:
+    """Whether an adapter-reported project/CWD is excluded by policy.
+
+    A literal entry covers the project directory and descendants; wildcard
+    entries use shell-style glob matching against the normalized absolute CWD.
+    """
+    if not origin_path:
+        return False
+    origin = _normalized_path(origin_path)
+    for raw_pattern in patterns:
+        pattern = _normalized_path(raw_pattern)
+        if fnmatch.fnmatchcase(origin, pattern):
+            return True
+        if not glob.has_magic(pattern) and origin.startswith(pattern + os.sep):
+            return True
+    return False
+
+
+def ingest_denylist_status(conn: sqlite3.Connection) -> tuple[tuple[str, ...], int]:
+    """Return active patterns and the durable total of skipped messages."""
+    try:
+        skipped = conn.execute(
+            "SELECT COALESCE(SUM(CAST(target AS INTEGER)), 0) "
+            "FROM events WHERE kind='ingest_deny_skipped'"
+        ).fetchone()[0]
+    except sqlite3.OperationalError:
+        skipped = 0
+    return (ingest_deny_globs(), int(skipped or 0))
+
+
 def _record_ingest_pass(
     conn: sqlite3.Connection,
     *,
     mode: str,
     new_msgs: int,
     files_seen: int,
+    skipped_msgs: int = 0,
 ) -> None:
     """Emit a lightweight telemetry event for status/UI clients.
 
@@ -117,7 +185,8 @@ def _record_ingest_pass(
     """
     global _last_ingest_event_at
     now = int(time.time())
-    if new_msgs <= 0 and now < _last_ingest_event_at + _INGEST_EVENT_IDLE_THROTTLE_S:
+    if (new_msgs <= 0 and skipped_msgs <= 0
+            and now < _last_ingest_event_at + _INGEST_EVENT_IDLE_THROTTLE_S):
         return
     try:
         from . import identity
@@ -129,10 +198,23 @@ def _record_ingest_pass(
             (
                 session_id,
                 str(now),
-                f"ok mode={mode} new={int(new_msgs)} files={int(files_seen)}",
+                f"ok mode={mode} new={int(new_msgs)} files={int(files_seen)} "
+                f"skipped={int(skipped_msgs)}",
                 now,
             ),
         )
+        if skipped_msgs:
+            # Store only a count, never the excluded path or transcript text.
+            conn.execute(
+                "INSERT INTO events (session_id, kind, target, summary, created_at) "
+                "VALUES (?, 'ingest_deny_skipped', ?, ?, ?)",
+                (
+                    session_id,
+                    str(int(skipped_msgs)),
+                    f"mode={mode} skipped={int(skipped_msgs)}",
+                    now,
+                ),
+            )
         conn.commit()
         _last_ingest_event_at = now
     except sqlite3.OperationalError:
@@ -355,7 +437,7 @@ def _extract_text(msg: dict) -> str:
 
 
 def _ingest_file(conn: sqlite3.Connection, fp: Path, max_msgs: int,
-                 adapter=None) -> int:
+                 adapter=None, skipped_counter: Optional[list[int]] = None) -> int:
     """Incrementally ingest one transcript file from the given adapter.
     Returns number of new messages added.
 
@@ -387,6 +469,8 @@ def _ingest_file(conn: sqlite3.Connection, fp: Path, max_msgs: int,
     # SELECT does not start Python sqlite3's implicit write transaction; this
     # keeps model inference entirely outside the single-writer critical path.
     prepared: list[dict] = []
+    deny_patterns = ingest_deny_globs()
+    skipped = 0
     text_candidates = 0
     hit_cap = False
     try:
@@ -395,6 +479,12 @@ def _ingest_file(conn: sqlite3.Connection, fp: Path, max_msgs: int,
                 hit_cap = True
                 break
             if not nm.uuid:
+                continue
+            # This must precede every database lookup, scrub, embedding, and
+            # skill scan: excluded transcript content never enters a durable
+            # store or any downstream learning-loop input.
+            if _origin_is_denied(nm.origin_path, deny_patterns):
+                skipped += 1
                 continue
             if conn.execute(
                 "SELECT 1 FROM dialog_messages WHERE uuid=?", (nm.uuid,)
@@ -470,6 +560,8 @@ def _ingest_file(conn: sqlite3.Connection, fp: Path, max_msgs: int,
         "  ingested_at=excluded.ingested_at, msg_count=ingest_state.msg_count+excluded.msg_count",
         (str(fp), next_size, next_mtime, int(time.time()), added)
     )
+    if skipped_counter is not None:
+        skipped_counter[0] += skipped
     return added
 
 
@@ -478,6 +570,7 @@ def _ingest_all(conn: sqlite3.Connection, max_msgs: int = 1_000_000) -> tuple[in
     transcript file. Returns (new_msgs, files_seen) across ALL adapters."""
     from .adapters import installed_adapters
     total = 0
+    skipped = [0]
     files_seen = 0
     for adapter in installed_adapters():
         files = adapter.transcript_files()
@@ -490,7 +583,10 @@ def _ingest_all(conn: sqlite3.Connection, max_msgs: int = 1_000_000) -> tuple[in
         for fp in files:
             if total >= max_msgs:
                 break
-            added = _ingest_file(conn, fp, max_msgs - total, adapter=adapter)
+            added = _ingest_file(
+                conn, fp, max_msgs - total, adapter=adapter,
+                skipped_counter=skipped,
+            )
             total += added
             # Bound lock duration to one transcript file. Embedding for that
             # file already completed before its first DML statement.
@@ -498,7 +594,10 @@ def _ingest_all(conn: sqlite3.Connection, max_msgs: int = 1_000_000) -> tuple[in
                 conn.commit()
     _normalize_codex_spawned_session_ids(conn)
     conn.commit()
-    _record_ingest_pass(conn, mode="all", new_msgs=total, files_seen=files_seen)
+    _record_ingest_pass(
+        conn, mode="all", new_msgs=total, files_seen=files_seen,
+        skipped_msgs=skipped[0],
+    )
     return (total, files_seen)
 
 
@@ -524,10 +623,14 @@ def _ingest_recent_only(conn: sqlite3.Connection,
                 fresh.append((m, p, adapter))
     fresh.sort(key=lambda x: x[0], reverse=True)
     total = 0
+    skipped = [0]
     for _, fp, adapter in fresh:
         if total >= max_msgs:
             break
-        added = _ingest_file(conn, fp, max_msgs - total, adapter=adapter)
+        added = _ingest_file(
+            conn, fp, max_msgs - total, adapter=adapter,
+            skipped_counter=skipped,
+        )
         total += added
         if conn.in_transaction:
             try:
@@ -542,7 +645,10 @@ def _ingest_recent_only(conn: sqlite3.Connection,
         except sqlite3.OperationalError:
             conn.rollback()
             raise
-    _record_ingest_pass(conn, mode="recent", new_msgs=total, files_seen=len(fresh))
+    _record_ingest_pass(
+        conn, mode="recent", new_msgs=total, files_seen=len(fresh),
+        skipped_msgs=skipped[0],
+    )
     return (total, len(fresh))
 
 

--- a/threadkeeper/tools/dashboard.py
+++ b/threadkeeper/tools/dashboard.py
@@ -371,6 +371,12 @@ def mp_dashboard(window_days: int = 7) -> str:
         f"dialog_vec={emb_health['dialog_vec']} "
         f"generation={emb_health['generation']}"
     )
+    from .. import ingest
+    deny_globs, denied_messages = ingest.ingest_denylist_status(conn)
+    out.append("  ingest_privacy: " + (
+        "denylist=" + ", ".join(deny_globs) if deny_globs else "denylist=(none)"
+    ))
+    out.append(f"  ingest_denied_messages={denied_messages}")
 
     # ── loops ─────────────────────────────────────────────────────────
     # Per loop: fires in window, fires in 30d, age of last fire. A loop


### PR DESCRIPTION
## Summary
- Add configurable project/CWD denylist for transcript ingestion.
- Skip matching messages before persistence, embeddings, skill parsing, or learning-loop inputs while advancing file watermarks.
- Surface active patterns and cumulative skipped messages in the dashboard.

## Tests
- env -u THREADKEEPER_NO_EMBEDDINGS .venv/bin/python -m pytest -q

Closes #145