### PR TITLE
fix: alert on quota-exhausted child + self-heal a solo wedged host

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ version bumps follow semver per the policy in
 
 ## [Unreleased]
 
+- **Fixed: quota/credit exhaustion in a spawned child now alerts even when its
+  exit code was lost.** The notifier's dead-child source only surfaced children
+  whose row recorded a non-zero `return_code`. A child reaped after the DB
+  writer wedged — or reaped cross-session — closes with `return_code` NULL, so
+  the very failure the notifier exists to catch (a subscription running out
+  mid-run, which can itself stall the writer) produced no notification.
+  `_scan_dead_children` now also inspects NULL-`return_code` children and alerts
+  when the captured log carries a fatal degradation signature (monthly-quota /
+  credit / auth), while clean completions with a lost code stay silent.
+- **Fixed: a solo daemon-host no longer stays wedged indefinitely when a leaked
+  write transaction starves the SQLite writer.** The cross-host recovery only
+  fired when another host booted, so a machine with no new sessions could sit
+  wedged for as long as it was left alone. The host now tracks how long its own
+  heartbeat has been starved and self-terminates after
+  `HOST_WEDGE_KILL_AFTER_S`, letting the supervisor respawn a clean host (whose
+  teardown drops the leaked connection and releases the lock).
+
 ## v0.17.0 — 2026-08-24
 
 - **Added: pre-ingest transcript privacy denylist (#145).**

--- a/tests/test_host_main.py
+++ b/tests/test_host_main.py
@@ -36,3 +36,29 @@ def test_serve_wires_local_encoder(monkeypatch, tmp_path):
     assert seen["sock"] == config.HOST_SOCK_PATH
     # the wired encoder delegates to embeddings._encode
     assert callable(seen["enc"])
+
+
+def test_wedge_deadline_self_heal(monkeypatch, tmp_path):
+    host = _reimport(monkeypatch, tmp_path)
+    f = host._wedge_deadline_passed
+    # no starvation streak → never heals
+    assert f(None, 1000.0, 600.0) is False
+    # streak shorter than the window → hold on
+    assert f(1000.0, 1000.0 + 599.0, 600.0) is False
+    # streak reached the window → self-heal
+    assert f(1000.0, 1000.0 + 600.0, 600.0) is True
+    assert f(1000.0, 1000.0 + 900.0, 600.0) is True
+    # feature disabled (wedge_s <= 0) → never heals even when long-starved
+    assert f(1000.0, 1000.0 + 100000.0, 0.0) is False
+
+
+def test_heartbeat_returns_bool(monkeypatch, tmp_path):
+    host = _reimport(monkeypatch, tmp_path)
+    import threadkeeper.db as db
+    monkeypatch.setattr(db, "run_write", lambda *a, **k: None)
+    monkeypatch.setattr(host, "_heartbeat", host._heartbeat)  # ensure real fn
+    assert host._heartbeat() is True
+    def _boom(*a, **k):
+        raise RuntimeError("wedged")
+    monkeypatch.setattr(db, "run_write", _boom)
+    assert host._heartbeat() is False

--- a/tests/test_notify_daemon.py
+++ b/tests/test_notify_daemon.py
@@ -131,6 +131,41 @@ def test_timeout_and_zero_exit_children_ignored(tmp_path, monkeypatch):
     assert out == "ok fired=0", out
 
 
+def test_dead_child_returncode_null_with_fatal_log_fires(tmp_path, monkeypatch, caplog):
+    # A child reaped after the DB writer wedged closes its row with the exit
+    # code lost (return_code NULL). It must still alert when the captured log
+    # shows a fatal degradation signature — the quota-exhaustion case that
+    # first exposed the gap.
+    m = _bootstrap(tmp_path, monkeypatch)
+    notify, db = m["notify"], m["db"]
+    conn = db.get_db()
+    assert notify.run_notify_pass(force=True) == "seed"
+    (tmp_path / "tasks" / "child-q.log").write_text(
+        "booting\nYou have exceeded your monthly quota\n")
+    _task(conn, "child-q", rc=None, role="candidate_reviewer",
+          ended_at=int(time.time()))
+    with caplog.at_level(logging.WARNING, logger="threadkeeper.notify"):
+        out = notify.run_notify_pass(force=True)
+    assert out == "ok fired=1", out
+    assert "candidate_reviewer child died (rc=unknown)" in caplog.text
+    assert "exceeded your monthly quota" in caplog.text
+
+
+def test_dead_child_returncode_null_clean_log_ignored(tmp_path, monkeypatch):
+    # return_code NULL with no failure evidence in the log is indistinguishable
+    # from a clean completion — must NOT fire (no false positives).
+    m = _bootstrap(tmp_path, monkeypatch)
+    notify, db = m["notify"], m["db"]
+    conn = db.get_db()
+    assert notify.run_notify_pass(force=True) == "seed"
+    (tmp_path / "tasks" / "child-clean.log").write_text(
+        "starting\nall done, wrote 2 notes\n")
+    _task(conn, "child-clean", rc=None, role="curator",
+          ended_at=int(time.time()))
+    out = notify.run_notify_pass(force=True)
+    assert out == "ok fired=0", out
+
+
 # ── cooldown / de-dup ───────────────────────────────────────────────────────
 
 def test_cooldown_dedups_repeat_failures(tmp_path, monkeypatch):

--- a/threadkeeper/host.py
+++ b/threadkeeper/host.py
@@ -120,15 +120,54 @@ def main() -> int:
             # confirmed empirically while building this).
             stop = threading.Event()
             signal.signal(signal.SIGTERM, lambda *_: stop.set())
+            # Self-heal: a leaked write transaction elsewhere in this process
+            # (a legacy get_db() connection left mid-write) holds SQLite's
+            # single-writer lock, starving every run_write — including this
+            # heartbeat — indefinitely. The cross-host recovery in
+            # _recover_wedged_host only fires when ANOTHER host boots, so a
+            # solo host with no new sessions would stay wedged forever. When
+            # heartbeats have been starved for HOST_WEDGE_KILL_AFTER_S, exit so
+            # the supervisor respawns a clean host (process teardown drops the
+            # leaked connection and releases the lock).
+            starved_since: float | None = None
+            wedge_s = float(getattr(config, "HOST_WEDGE_KILL_AFTER_S", 0.0) or 0.0)
             while not stop.is_set():
-                _heartbeat()
+                if _heartbeat():
+                    starved_since = None
+                else:
+                    if starved_since is None:
+                        starved_since = time.monotonic()
+                    if _wedge_deadline_passed(starved_since, time.monotonic(),
+                                              wedge_s):
+                        logger.error(
+                            "host: heartbeat starved >= %.0fs (DB writer wedged); "
+                            "self-terminating for a clean supervisor respawn",
+                            wedge_s,
+                        )
+                        break
                 stop.wait(min(30.0, config.HOST_HEARTBEAT_TTL_S / 2))
         finally:
             _clear_host_pidfile(only_pid=os.getpid())
     return 0
 
 
-def _heartbeat() -> None:
+def _wedge_deadline_passed(starved_since: float | None, now: float,
+                           wedge_s: float) -> bool:
+    """True when the host has gone without a successful heartbeat for at least
+    ``wedge_s`` seconds — i.e. the DB writer is wedged and this solo host should
+    self-terminate so the supervisor respawns a clean one. Disabled when
+    ``wedge_s`` <= 0 or no starvation streak is in progress."""
+    return (
+        wedge_s > 0
+        and starved_since is not None
+        and (now - starved_since) >= wedge_s
+    )
+
+
+def _heartbeat() -> bool:
+    """Write one host heartbeat. Returns True on success, False on any failure
+    (the sustained-failure case is a wedged DB writer — see the self-heal in
+    :func:`main`)."""
     from .db import run_write
     from . import identity
     try:
@@ -136,8 +175,10 @@ def _heartbeat() -> None:
         # Session initialization and recurring heartbeat are intentionally
         # separate: ordinary read tools no longer turn into writers.
         run_write("host-heartbeat", identity._heartbeat, deadline_s=2.0)
+        return True
     except Exception:
         logger.debug("host: heartbeat failed", exc_info=True)
+        return False
 
 
 def ensure_host_running() -> bool:

--- a/threadkeeper/notify.py
+++ b/threadkeeper/notify.py
@@ -69,6 +69,22 @@ _FAIL_TOKENS = (
 )
 _SPAWN_TIMEOUT_RETURN_CODE = 124  # spawn_budget.SPAWN_TIMEOUT_RETURN_CODE
 
+# A child can end with return_code=NULL when its exit code was never captured —
+# the parent reaper's waitpid can't see a cross-session child, and a child
+# reaped AFTER the DB writer wedged closes its row (ended_at set) with the code
+# lost. A NULL code is otherwise indistinguishable from a clean completion, so
+# such rows are surfaced ONLY when the captured log carries one of these fatal
+# degradation signatures. This is the case that first exposed the gap: a
+# spawned child hit "exceeded your monthly quota", died, and — because the same
+# exhaustion had wedged the writer — its row closed with no return_code, so the
+# return_code!=0 branch never saw it and no alert fired.
+_CHILD_FATAL_LOG_TOKENS = (
+    "exceeded your monthly quota", "monthly quota", "quota exceeded",
+    "credit balance is too low", "insufficient credits", "out of credits",
+    "usage limit", "invalid api key", "authentication_error",
+    "unauthorized", "login expired", "please run /login",
+)
+
 
 # ── classification ──────────────────────────────────────────────────────────
 
@@ -106,13 +122,18 @@ def _reason_from_summary(summary: str) -> str:
     return (tail[:120] or "spawn failed")
 
 
-def _reason_from_task_log(task_id: str) -> str:
-    """Last meaningful line of a dead child's captured log (the failure reason)."""
+def _child_log_tail(task_id: str) -> str:
+    """Tail of a spawned child's captured log ('' when unavailable)."""
     try:
         from .tools.spawn import task_logs  # lazy: spawn imports identity/config
-        txt = task_logs(task_id, tail_lines=12)
+        return task_logs(task_id, tail_lines=12)
     except Exception:
-        return "no_log"
+        return ""
+
+
+def _reason_from_task_log(task_id: str, tail: str | None = None) -> str:
+    """Last meaningful line of a dead child's captured log (the failure reason)."""
+    txt = _child_log_tail(task_id) if tail is None else tail
     lines = [ln for ln in txt.splitlines() if ln.strip()]
     return (lines[-1][:180] if lines else "no_log")
 
@@ -210,14 +231,26 @@ def _scan_failures(conn: sqlite3.Connection, ev_floor: int,
 
 def _scan_dead_children(conn: sqlite3.Connection, tk_floor: int,
                         tk_ceil: int) -> list[dict]:
-    """SOURCE 2: spawned children that ended non-zero (excluding timeouts and
-    children superseded by a retry). Catches subscription-exhausted-mid-run."""
+    """SOURCE 2: spawned children that ended badly (excluding timeouts and
+    children superseded by a retry). Catches subscription-exhausted-mid-run.
+
+    Two shapes qualify:
+      * return_code present and non-zero (and not the timeout code) — an
+        outright failed child; always surfaced.
+      * return_code NULL — the exit code was never captured (cross-session
+        reap, or a child reaped after the writer wedged). Indistinguishable
+        from a clean completion on its own, so surfaced ONLY when the captured
+        log carries a fatal degradation signature (_CHILD_FATAL_LOG_TOKENS).
+        This is the branch that catches quota/credit exhaustion whose very
+        failure mode also stalled the DB writer that would have stamped rc.
+    """
     out: list[dict] = []
     try:
         rows = conn.execute(
             "SELECT id, role, chosen_cli, return_code FROM tasks "
             "WHERE ended_at IS NOT NULL AND ended_at > ? AND ended_at <= ? "
-            "AND return_code IS NOT NULL AND return_code != 0 AND return_code != ? "
+            "AND (return_code IS NULL "
+            "     OR (return_code != 0 AND return_code != ?)) "
             "AND timeout_respawned_as IS NULL ORDER BY ended_at",
             (tk_floor, tk_ceil, _SPAWN_TIMEOUT_RETURN_CODE),
         ).fetchall()
@@ -225,11 +258,20 @@ def _scan_dead_children(conn: sqlite3.Connection, tk_floor: int,
         return out
     for r in rows:
         label = r["role"] or r["chosen_cli"] or "child"
+        rc = r["return_code"]
+        tail = _child_log_tail(r["id"])
+        if rc is None:
+            low = tail.lower()
+            if not any(tok in low for tok in _CHILD_FATAL_LOG_TOKENS):
+                continue  # code lost but no failure evidence — likely clean.
+            rc_disp: object = "unknown"
+        else:
+            rc_disp = rc
         out.append({
             "kind": f"child:{label}",
             "label": label,
-            "rc": r["return_code"],
-            "reason": _reason_from_task_log(r["id"]),
+            "rc": rc_disp,
+            "reason": _reason_from_task_log(r["id"], tail=tail),
         })
     return out
 


### PR DESCRIPTION
## Incident

A spawned learning-loop child (`candidate_reviewer`, copilot backend) hit **"You have exceeded your monthly quota"** and died ~6s in. **No notification fired** — the exact silent-degradation case the notifier was built to catch.

## Root cause

Three compounding bugs, all verified against a live wedge:

1. **notify blind to lost exit codes.** `_scan_dead_children` only surfaced children whose row recorded `return_code != 0`. But the child's death was never stamped: a leaked write transaction (a legacy `get_db()` connection left mid-write) held SQLite's single-writer lock, so `run_write` (heartbeat, reaper, `notify_pass`) starved on `SQLITE_BUSY`. The child row closed later via the reaper's `ChildProcessError` fallback with `return_code` **NULL** → invisible to the `return_code != 0` filter. The notifier that exists to catch subscription-exhaustion was blind *because* the exhaustion wedged the writer it depends on.
2. **Solo host never self-recovers.** `_recover_wedged_host` only SIGTERMs a wedged host when *another* host boots via `ensure_host_running`. A machine with no new sessions stayed wedged 30+ min (observed).

## Fixes

- **notify:** `_scan_dead_children` now also inspects `return_code IS NULL` children and alerts (`rc=unknown`) when the captured log carries a fatal degradation signature (monthly-quota / credit / auth). Completions with a merely-lost code stay silent — no false positives. New `_child_log_tail` reads the tail once.
- **host:** the serve loop tracks how long its own heartbeat has been starved and self-terminates after `HOST_WEDGE_KILL_AFTER_S` (default 600s) so the supervisor respawns a clean host (teardown drops the leaked connection, releasing the lock). Decision extracted to the pure, tested helper `_wedge_deadline_passed`; `_heartbeat` now returns a success bool.

## Tests

- `test_dead_child_returncode_null_with_fatal_log_fires` — quota log with NULL rc alerts (`rc=unknown`).
- `test_dead_child_returncode_null_clean_log_ignored` — NULL rc + clean log stays silent.
- `test_wedge_deadline_self_heal`, `test_heartbeat_returns_bool`.

120 passed across notify / host / daemon / db / spawn suites.

## Not addressed here (follow-up — the true root)

`get_db()` returns a fresh **non-autocommit** connection per call and callers frequently don't `.close()` (42 leaked DB fds observed on the wedged host); any DML then holds a write transaction open until close/GC. That is the underlying wedge source. Recommend migrating remaining write paths off `get_db()` onto `run_write` (autocommit, fresh conn per call, guaranteed rollback+close) and adding a leaked-transaction guard. Filing separately.