### PR TITLE
feat: promote dense lesson clusters to skills

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ version bumps follow semver per the policy in
 
 ## [Unreleased]
 
+- **Added: dense lesson clusters now promote to canonical skills (#163).**
+  Curator deterministically flags three-or-more lessons sharing a meaningful
+  title-term pair, then directs a validated checklist-style skill promotion
+  before retiring the unprotected source lessons. Clusters containing protected
+  lessons remain an explicit human-review plan.
+
 ## v0.17.0 — 2026-08-24
 
 - **Added: pre-ingest transcript privacy denylist (#145).**

--- a/README.md
+++ b/README.md
@@ -638,7 +638,12 @@ ThreadKeeper/Claude Code/Codex/Agent Skills compatibility, resource/link
 findings, mirror hashes, exact-body duplicate groups, and lexical candidates
 for semantic review. System and installed-plugin sources are resolved from
 their read-only caches rather than misreported as missing mirrors; telemetry
-rows with no real `SKILL.md` remain explicit orphans. The child reads every
+rows with no real `SKILL.md` remain explicit orphans. The same inventory also
+flags a dense lesson subtopic when at least
+`THREADKEEPER_CURATOR_PROMOTION_MIN_LESSONS` lessons (default 3) share a pair
+of meaningful title terms. A non-protected candidate must become one validated,
+checklist-style canonical skill before its source lessons are retired; protected
+clusters are left for human review. The child reads every
 complete skill and relevant support file, performs current web research against
 official docs and comparable
 public skills, then writes numbered per-skill verdicts to

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1149,6 +1149,16 @@ Optional subfolders: `references/`, `templates/`, `scripts/`, `assets/`.
   not an automatic deletion path, and foreground/user, pinned, and validated
   lessons are excluded.
 
+- **Lesson-to-skill promotion** — the curator also deterministically groups
+  lessons that share a pair of meaningful slug/title terms. A group reaches a
+  promotion candidate at `THREADKEEPER_CURATOR_PROMOTION_MIN_LESSONS` entries
+  (default 3). An unprotected `PROMOTE_TO_SKILL` candidate directs the curator
+  to read every source lesson, create a checklist-style canonical skill with a
+  `Retired lessons` provenance section, validate it, and only then retire those
+  source lessons. Any protected member makes the candidate `HUMAN_REVIEW`, so a
+  background curator never creates a partial promotion or deletes protected
+  memory.
+
 - **Curator recovery and destructive telemetry** — destructive curator passes
   receive a pass id and pre-mutation snapshot dir in their environment. When the
   normal `lesson_append`, `lesson_remove`, or `skill_manage` tools run under
@@ -1780,6 +1790,7 @@ unsupported CLI overrides still fall through to the next priority, and
 | `THREADKEEPER_CANDIDATE_REVIEW_FLUSH_AGE_S` | 259200 | review an undersized queue once its oldest candidate is this old (0 = threshold only) |
 | `THREADKEEPER_CURATOR_INTERVAL_S` | 259200 | deep curator audit every three days; set `0` to disable |
 | `THREADKEEPER_CURATOR_MIN_LESSONS` | 3 | min lessons before curator engages |
+| `THREADKEEPER_CURATOR_PROMOTION_MIN_LESSONS` | 3 | dense same-subtopic lessons required before the curator proposes a skill promotion |
 | `THREADKEEPER_CURATOR_DESTRUCTIVE` | `1` | curator child writes its REPORT then applies PATCH/PRUNE/CONSOLIDATE directly; set `0` for advisory-only; protected entries are refused server-side |
 | `THREADKEEPER_CURATOR_MANAGE_FOREGROUND_SKILLS` | `0` | explicit snapshot-scoped authority to repair/merge/delete foreground skills; pins and untracked provenance remain protected |
 | `THREADKEEPER_CURATOR_TRASH_TTL_DAYS` | 30 | days to retain `lesson_remove` / `skill_manage(delete)` recovery artifacts under `<db dir>/curator/trash` |

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -989,9 +989,12 @@ GitHub issues:
 - **Inbound link repair on consolidation.** Repoint or warn on `[[wikilinks]]`
   that target merged-away lesson/skill slugs so consolidation does not leave
   dead pointers behind (#162).
-- **Lesson-to-skill promotion.** When a lesson cluster becomes a dense
-  subtopic, promote it into a structured skill and retire the subsumed lessons
-  instead of leaving a noisy long tail (#163).
+- **Lesson-to-skill promotion.** ✅ DONE (#163). The Curator now flags a
+  deterministic dense subtopic when at least three lessons share a pair of
+  meaningful title terms. An unprotected candidate becomes one validated,
+  checklist-style canonical skill with a `Retired lessons` provenance section
+  before the source lessons are retired; any protected member produces a
+  `HUMAN_REVIEW` plan instead of a partial autonomous promotion.
 - **Spawn worktree isolation.** Each spawned session should get its own git
   worktree, or repo-mutating work should be blocked when sessions would share a
   checkout (#164).

--- a/tests/test_curator.py
+++ b/tests/test_curator.py
@@ -51,6 +51,7 @@ def _bootstrap(
     monkeypatch,
     interval="0",
     min_lessons="3",
+    promotion_min_lessons="3",
     destructive=None,
     retention=None,
     max_destructive=None,
@@ -70,6 +71,7 @@ def _bootstrap(
         "THREADKEEPER_CURATOR_INTERVAL_S": interval,
         "THREADKEEPER_CURATOR_MANAGE_FOREGROUND_SKILLS": "0",
         "THREADKEEPER_CURATOR_MIN_LESSONS": min_lessons,
+        "THREADKEEPER_CURATOR_PROMOTION_MIN_LESSONS": promotion_min_lessons,
         "THREADKEEPER_CURATOR_REPORTS_DIR": str(tmp_path / "curator"),
         "THREADKEEPER_LESSONS": str(tmp_path / "lessons.md"),
         "THREADKEEPER_TASK_LOG_DIR": str(tmp_path / "tasks"),
@@ -176,6 +178,61 @@ def test_collect_inventory_counts_lessons_and_skills(tmp_path, monkeypatch):
     assert "SKILL auto-created-skill [PROTECTED]" not in dump
     assert "SKILL auto-created-skill" in dump
     assert "STALE LESSONS (dry-run decay ranking)" in dump
+
+
+def test_dense_lesson_cluster_crosses_promotion_threshold(tmp_path, monkeypatch):
+    pkg = _bootstrap(tmp_path, monkeypatch, write_origin="shadow_review")
+    for title in (
+        "curator snapshot protects lesson rollback",
+        "curator snapshot keeps lesson evidence",
+    ):
+        pkg["lessons"].append_lesson(title=title, body="procedure", source="shadow")
+
+    conn = pkg["db"].get_db()
+    candidates = pkg["curator"]._detect_lesson_promotion_candidates(
+        list(pkg["lessons"].iter_lessons()),
+        pkg["lessons"].lesson_usage_map(conn),
+    )
+    assert candidates == []
+
+    pkg["lessons"].append_lesson(
+        title="curator snapshot restores lesson recovery",
+        body="procedure",
+        source="shadow",
+    )
+    candidates = pkg["curator"]._detect_lesson_promotion_candidates(
+        list(pkg["lessons"].iter_lessons()),
+        pkg["lessons"].lesson_usage_map(conn),
+    )
+    assert len(candidates) == 1
+    candidate = candidates[0]
+    assert candidate.topic_terms == ("curator", "snapshot")
+    assert candidate.decision == "PROMOTE_TO_SKILL"
+    assert candidate.protected_slugs == ()
+    assert candidate.lesson_slugs == (
+        "curator-snapshot-keeps-lesson-evidence",
+        "curator-snapshot-protects-lesson-rollback",
+        "curator-snapshot-restores-lesson-recovery",
+    )
+
+
+def test_protected_dense_cluster_requires_human_review(tmp_path, monkeypatch):
+    pkg = _bootstrap(tmp_path, monkeypatch)
+    for title in (
+        "curator snapshot protects lesson rollback",
+        "curator snapshot keeps lesson evidence",
+        "curator snapshot restores lesson recovery",
+    ):
+        pkg["lessons"].append_lesson(title=title, body="procedure", source="T123")
+
+    conn = pkg["db"].get_db()
+    candidates = pkg["curator"]._detect_lesson_promotion_candidates(
+        list(pkg["lessons"].iter_lessons()),
+        pkg["lessons"].lesson_usage_map(conn),
+    )
+    assert len(candidates) == 1
+    assert candidates[0].decision == "HUMAN_REVIEW"
+    assert candidates[0].protected_slugs == candidates[0].lesson_slugs
 
 
 def test_collect_inventory_marks_legacy_and_unknown_skills_protected(
@@ -317,6 +374,42 @@ def test_run_curator_pass_spawns_when_threshold_met(tmp_path, monkeypatch):
     assert f"AUDIT_MANIFEST_PATH = {manifests[0]}" in kw["prompt"]
     assert "THREADKEEPER_CURATOR_PASS_ID" not in os.environ
     assert "THREADKEEPER_CURATOR_SNAPSHOT_DIR" not in os.environ
+
+
+def test_run_curator_pass_hands_dense_cluster_to_skill_promotion(
+    tmp_path, monkeypatch,
+):
+    pkg = _bootstrap(
+        tmp_path,
+        monkeypatch,
+        min_lessons="3",
+        write_origin="shadow_review",
+    )
+    for title in (
+        "curator snapshot protects lesson rollback",
+        "curator snapshot keeps lesson evidence",
+        "curator snapshot restores lesson recovery",
+    ):
+        pkg["lessons"].append_lesson(title=title, body="procedure", source="shadow")
+
+    import threadkeeper.tools.spawn as spawn_mod
+    captured: list[dict] = []
+
+    def fake_spawn(**kwargs):
+        captured.append(kwargs)
+        return "spawn task_id=fake-promotion-curator pid=0"
+
+    monkeypatch.setattr(spawn_mod, "spawn", fake_spawn)
+
+    out = pkg["curator"].run_curator_pass(force=True)
+    assert "fake-promotion-curator" in out
+    assert len(captured) == 1
+    prompt = captured[0]["prompt"]
+    assert "LESSON CLUSTER PROMOTION CANDIDATES (n=1)" in prompt
+    assert "PROMOTE_TO_SKILL: topic=curator snapshot lesson_count=3" in prompt
+    assert "Create one new, clearly named canonical skill" in prompt
+    assert "## Retired lessons" in prompt
+    assert "Only after it passes may you call" in prompt
 
 
 def test_run_curator_pass_batches_large_inventory_without_oversize_prompt(

--- a/threadkeeper/config.py
+++ b/threadkeeper/config.py
@@ -372,6 +372,9 @@ class Settings(BaseSettings):
     # mutation and can be disabled explicitly with interval 0.
     curator_interval_s: float = 259_200.0
     curator_min_lessons: int = 3
+    # A dense lesson subtopic is eligible for promotion once this many lessons
+    # share the same pair of meaningful title terms.
+    curator_promotion_min_lessons: int = 3
     # THREADKEEPER_CURATOR_REPORTS_DIR — default is relative to db dir; computed post-init
     curator_reports_dir: Optional[Path] = None
     # Destructive-by-default: once the curator daemon is enabled
@@ -871,6 +874,7 @@ def _derive_constants(s: "Settings") -> dict:
         "SHADOW_REVIEW_FLUSH_AGE_S": float(s.shadow_review_flush_age_s),
         "CURATOR_INTERVAL_S": s.curator_interval_s,
         "CURATOR_MIN_LESSONS": s.curator_min_lessons,
+        "CURATOR_PROMOTION_MIN_LESSONS": s.curator_promotion_min_lessons,
         "CURATOR_REPORTS_DIR": curator_reports_dir,
         "CURATOR_DESTRUCTIVE": s.curator_destructive,
         "CURATOR_MANAGE_FOREGROUND_SKILLS": s.curator_manage_foreground_skills,

--- a/threadkeeper/curator.py
+++ b/threadkeeper/curator.py
@@ -15,7 +15,8 @@ minutes, the Curator REVIEWS THE STORE every few days:
      research, and the shared manifest/checklist.
   6. Children collectively read every full skill, research current official
      guidance and comparable skills, then choose KEEP / REPAIR / UPDATE / MERGE
-     / SPLIT / DEPRECATE / DELETE / CROSS_LINK / HUMAN_REVIEW.
+     / SPLIT / DEPRECATE / DELETE / CROSS_LINK / PROMOTE_TO_SKILL /
+     HUMAN_REVIEW.
   7. In destructive mode, parent writes a pre-mutation snapshot before
      spawning the child; child tool calls add tombstones/action telemetry.
   8. Parent records `curator_pass` event with high-water timestamp,
@@ -58,11 +59,14 @@ import re
 import sqlite3
 import threading
 import time
+from collections import defaultdict
 from dataclasses import dataclass
+from itertools import combinations
 
 from .config import (
     CURATOR_INTERVAL_S,
     CURATOR_MIN_LESSONS,
+    CURATOR_PROMOTION_MIN_LESSONS,
     CURATOR_REPORTS_DIR,
     CURATOR_DESTRUCTIVE,
     CURATOR_MAX_DESTRUCTIVE_PER_PASS,
@@ -202,6 +206,26 @@ why it was filed.
 LESSON RUBRIC (answer for every lesson; skills use the deep validator and
 verdicts above):
 
+DENSE LESSON CLUSTER PROMOTION — the inventory may include deterministic
+`PROMOTE_TO_SKILL` candidates. Each candidate names lessons that share a pair
+of meaningful title terms and crossed the configured density threshold. Treat
+an unprotected `PROMOTE_TO_SKILL` candidate as an affirmative consolidation
+decision, not merely a loose similarity lead:
+  1. Read every named lesson in full with `lesson_get` and preserve its unique
+     procedure, caveats, and examples.
+  2. Create one new, clearly named canonical skill through
+     `skill_manage(action='create', ...)`. Its body must be checklist-style and
+     include a `## Retired lessons` section listing every source slug.
+  3. Call `skill_validate(name=...)`. Only after it passes may you call
+     `lesson_remove(slug=...)` for each named, unprotected source lesson.
+  4. Record `PROMOTED_SKILL: <skill-name>` plus its retired lesson slugs and
+     validation result in REPORT.md. Do not leave copied long-form lesson
+     bodies behind once the validated skill is canonical.
+
+Candidates marked `HUMAN_REVIEW` include protected lessons. Do not mutate
+those lessons or create/retire a partial automatic cluster; write the exact
+promotion and linking plan in REPORT.md for a foreground human instead.
+
   KEEP — entry is class-level, in use, accurate. Note "KEEP: <slug>".
 
   PATCH — entry is mostly right but missing a step, has outdated
@@ -326,6 +350,106 @@ class _InventoryBatch:
     skill_count: int
     concept_count: int
     char_count: int
+
+
+@dataclass(frozen=True)
+class _LessonPromotionCandidate:
+    """A deterministic dense subtopic awaiting one curator decision."""
+
+    topic_terms: tuple[str, str]
+    lesson_slugs: tuple[str, ...]
+    protected_slugs: tuple[str, ...]
+
+    @property
+    def decision(self) -> str:
+        return "HUMAN_REVIEW" if self.protected_slugs else "PROMOTE_TO_SKILL"
+
+
+_LESSON_PROMOTION_TOKEN_RE = re.compile(r"[a-z][a-z0-9]{2,}")
+_LESSON_PROMOTION_STOP_WORDS = frozenset({
+    "about", "after", "also", "always", "before", "being", "bulk",
+    "check", "each", "from", "into", "lesson", "must", "need", "only",
+    "should", "that", "the", "then", "this", "with", "when", "where",
+})
+
+
+def _lesson_promotion_tokens(item: dict) -> frozenset[str]:
+    """Meaningful terms from a lesson's stable slug/title.
+
+    The detector deliberately does not mine arbitrary body prose: broad prose
+    tends to link otherwise unrelated lessons through generic implementation
+    words. Slugs come from the author-facing title and keep the clustering
+    deterministic even with embeddings disabled.
+    """
+    slug = (item.get("slug") or "").replace("-", " ").lower()
+    return frozenset(
+        token for token in _LESSON_PROMOTION_TOKEN_RE.findall(slug)
+        if token not in _LESSON_PROMOTION_STOP_WORDS
+    )
+
+
+def _detect_lesson_promotion_candidates(
+    lesson_items: list[dict],
+    lesson_usage: dict[str, dict],
+    *,
+    min_cluster_size: int = CURATOR_PROMOTION_MIN_LESSONS,
+) -> list[_LessonPromotionCandidate]:
+    """Find dense lesson clusters by recurring pairs of meaningful title terms.
+
+    A pair shared by at least ``min_cluster_size`` lessons is a deliberately
+    conservative offline density signal. It avoids treating one generic word
+    as a subtopic, while making the threshold and promotion decision testable
+    without an embedding model or a curator child.
+    """
+    threshold = max(2, int(min_cluster_size))
+    by_slug = {
+        item.get("slug") or "": item
+        for item in lesson_items
+        if item.get("slug")
+    }
+    pair_members: dict[tuple[str, str], set[str]] = defaultdict(set)
+    for slug, item in by_slug.items():
+        for pair in combinations(sorted(_lesson_promotion_tokens(item)), 2):
+            pair_members[pair].add(slug)
+
+    clusters: dict[frozenset[str], set[tuple[str, str]]] = defaultdict(set)
+    for pair, members in pair_members.items():
+        if len(members) >= threshold:
+            clusters[frozenset(members)].add(pair)
+
+    # A broader cluster subsumes every one of its pair-specific subsets. Keep
+    # only maximal clusters so one topic produces one promotion decision.
+    maximal_clusters = [
+        members for members in clusters
+        if not any(members < other for other in clusters)
+    ]
+    candidates: list[_LessonPromotionCandidate] = []
+    for members in sorted(maximal_clusters, key=lambda group: tuple(sorted(group))):
+        slugs = tuple(sorted(members))
+        protected = tuple(
+            slug for slug in slugs
+            if lessons.lesson_protection(
+                by_slug[slug], lesson_usage.get(slug),
+            )[0]
+        )
+        candidates.append(_LessonPromotionCandidate(
+            topic_terms=min(clusters[members]),
+            lesson_slugs=slugs,
+            protected_slugs=protected,
+        ))
+    return candidates
+
+
+def _format_lesson_promotion_candidate(
+    candidate: _LessonPromotionCandidate,
+) -> str:
+    protected = ", ".join(candidate.protected_slugs) or "-"
+    return (
+        f"- {candidate.decision}: topic={' '.join(candidate.topic_terms)} "
+        f"lesson_count={len(candidate.lesson_slugs)}\n"
+        f"    lessons: {', '.join(candidate.lesson_slugs)}\n"
+        f"    protected_lessons: {protected}"
+    )
 
 
 # ──────────────────────────────────────────────────────────────────────
@@ -682,12 +806,18 @@ def _collect_stale_lessons(conn: sqlite3.Connection) -> tuple[str, int]:
 def _collect_inventory_entry_groups(
     conn: sqlite3.Connection,
     skill_audit: dict | None = None,
-) -> tuple[list[_InventoryEntry], list[_InventoryEntry], str, int, int]:
+) -> tuple[
+    list[_InventoryEntry], list[_InventoryEntry], list[_InventoryEntry],
+    str, int, int,
+]:
     """Collect exhaustive lesson/skill entries without rendering one prompt."""
     lesson_entries: list[_InventoryEntry] = []
+    lesson_items: list[dict] = []
+    usage: dict[str, dict] = {}
     try:
         usage = lessons.lesson_usage_map(conn)
         for item in lessons.iter_lessons():
+            lesson_items.append(item)
             slug = item.get("slug") or ""
             lesson_entries.append(
                 _InventoryEntry(
@@ -698,6 +828,17 @@ def _collect_inventory_entry_groups(
             )
     except Exception:
         logger.debug("curator: iter_lessons failed", exc_info=True)
+
+    promotion_entries = [
+        _InventoryEntry(
+            "lesson_promotion",
+            "/".join(candidate.lesson_slugs),
+            _format_lesson_promotion_candidate(candidate),
+        )
+        for candidate in _detect_lesson_promotion_candidates(
+            lesson_items, usage,
+        )
+    ]
 
     audit = skill_audit or build_skill_audit(conn, include_archived=True)
     checklist_lines = format_skill_checklist(audit).splitlines()[2:]
@@ -710,6 +851,7 @@ def _collect_inventory_entry_groups(
     return (
         lesson_entries,
         skill_entries,
+        promotion_entries,
         stale_text,
         len(lesson_entries),
         len(skill_entries),
@@ -746,7 +888,7 @@ def _collect_inventory(
     char-capped as a defensive floor; the real curator pass uses complete
     bounded batches from `_collect_inventory_batches`.
     """
-    lesson_entries, skill_entries, stale_text, n_lessons, n_skills = (
+    lesson_entries, skill_entries, promotion_entries, stale_text, n_lessons, n_skills = (
         _collect_inventory_entry_groups(conn, skill_audit=skill_audit)
     )
 
@@ -765,6 +907,14 @@ def _collect_inventory(
         parts.append("(none)")
         used += len(parts[-1]) + 1
         dropped_lessons = 0
+    parts.append(
+        "\n## LESSON CLUSTER PROMOTION CANDIDATES "
+        f"(n={len(promotion_entries)})\n"
+    )
+    if promotion_entries:
+        parts.extend(entry.text for entry in promotion_entries)
+    else:
+        parts.append("(none)")
     parts.append("\n" + stale_text)
     used += len(parts[-1]) + 1
     parts.append(
@@ -891,6 +1041,9 @@ def _render_batch_inventory(
     n_skills: int,
     n_concepts: int,
 ) -> _InventoryBatch:
+    promotion_entries = [
+        e for e in batch_entries if e.kind == "lesson_promotion"
+    ]
     lesson_entries = [e for e in batch_entries if e.kind == "lesson"]
     skill_entries = [e for e in batch_entries if e.kind == "skill"]
     concept_entries = [e for e in batch_entries if e.kind == "concept"]
@@ -900,6 +1053,7 @@ def _render_batch_inventory(
         (
             f"Coverage: entries {start_entry}-{end_entry} of "
             f"{total_entries}; batch_entries={len(batch_entries)} "
+            f"promotions={len(promotion_entries)} "
             f"lessons={len(lesson_entries)}/{n_lessons} "
             f"skills={len(skill_entries)}/{n_skills} "
             f"concepts={len(concept_entries)}/{n_concepts}."
@@ -910,11 +1064,20 @@ def _render_batch_inventory(
             "fingerprint, so do not infer that omitted entries are absent."
         ),
         (
-            "For CONSOLIDATE, only merge entries whose full lines appear in "
-            "this batch; otherwise recommend a future cross-batch review."
+            "For ordinary CONSOLIDATE, only merge entries whose full lines "
+            "appear in this batch; otherwise recommend a future cross-batch "
+            "review. A named PROMOTE_TO_SKILL candidate is the exception: "
+            "read its source lessons with lesson_get before acting."
         ),
-        f"\n## LESSONS (n={len(lesson_entries)})\n",
+        (
+            "\n## LESSON CLUSTER PROMOTION CANDIDATES "
+            f"(n={len(promotion_entries)})\n"
+        ),
     ]
+    parts.extend(entry.text for entry in promotion_entries)
+    if not promotion_entries:
+        parts.append("(none)")
+    parts.append(f"\n## LESSONS (n={len(lesson_entries)})\n")
     parts.extend(entry.text for entry in lesson_entries)
     if not lesson_entries:
         parts.append("(none)")
@@ -948,11 +1111,11 @@ def _collect_inventory_batches(
     conn: sqlite3.Connection,
     skill_audit: dict | None = None,
 ) -> tuple[list[_InventoryBatch], int, int, int]:
-    lesson_entries, skill_entries, stale_text, n_lessons, n_skills = (
+    lesson_entries, skill_entries, promotion_entries, stale_text, n_lessons, n_skills = (
         _collect_inventory_entry_groups(conn, skill_audit=skill_audit)
     )
     concept_entries, n_concepts = _collect_concept_entries(conn)
-    entries = lesson_entries + skill_entries + concept_entries
+    entries = promotion_entries + lesson_entries + skill_entries + concept_entries
     chunks = _chunk_inventory_entries(entries)
     total = len(chunks)
     batches: list[_InventoryBatch] = []


### PR DESCRIPTION
Adds deterministic curator promotion candidates for dense lesson subtopics, requires a validated checklist-style canonical skill before retiring unprotected source lessons, and sends protected clusters to human review. Includes focused threshold and promotion-path tests plus roadmap and architecture documentation. Closes #163