### PR TITLE
fix: isolate evolve validation from abandoned untracked files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ Format loosely follows [Keep a Changelog](https://keepachangelog.com/);
 version bumps follow semver per the policy in
 [CONTRIBUTING.md → Releases](CONTRIBUTING.md#releases).
 
+## v0.17.2 — 2026-09-09
+
+- **Fixed: orphaned untracked tests no longer stall every Evolve PR repair.**
+  Managed refresh and the pre-spawn gate preserve a dead child’s non-ignored
+  files outside the checkout before validation. Live writers, explicit
+  checkouts, ignored runtime files, and backup failures retain their guards.
+
 ## v0.17.1 — 2026-09-09
 
 ### Fixed

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ WORKDIR /app
 # Install the release this checkout declares. Skip the [semantic] extra (~700
 # MB fastembed ONNX model) — Glama only inspects the MCP tool schema, not
 # embedding quality.
-RUN pip install --no-cache-dir threadkeeper==0.17.1
+RUN pip install --no-cache-dir threadkeeper==0.17.2
 
 # Don't spawn shadow-review / curator / probe / dialectic daemons in
 # the Glama sandbox — they would try to invoke claude / codex / agy

--- a/README.md
+++ b/README.md
@@ -859,7 +859,12 @@ throttling the roadmap loop.
 Before any PR-producing reviewer/audit or applier child is spawned, the parent
 checks the target checkout with `git status --porcelain --untracked-files=no`.
 Tracked-file WIP records `skipped_dirty_worktree` and no child is dispatched;
-untracked scratch files do not block. Each managed-checkout child fetches the
+the default managed checkout first preserves orphaned untracked files under
+`~/.threadkeeper/evolve-recovery/untracked-*/` and removes them from the next
+task’s tree. This prevents unrelated unfinished tests from blocking every PR
+repair. Ignored files (including `.venv`) and explicit operator checkouts stay
+in place; live writers prevent recovery, and backup failures block dispatch.
+Each managed-checkout child fetches the
 configured branch only to retrieve the configured immutable commit, then
 prepares or resumes its deterministic local/remote feature branch from
 `THREADKEEPER_EVOLVE_REPO_COMMIT`, never from the branch's moving tip. Retries

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -728,8 +728,13 @@ moving the high-water forward; `force=True` bypasses this due gate.
   --porcelain --untracked-files=no` must be empty (`skipped_dirty_worktree
   mode=git` is recorded on `events.kind='evolve_git_safety'` when tracked WIP is
   present), and no other PR-producing evolve reviewer/applier task may already
-  be running. The guard intentionally ignores untracked scratch files, matching
-  `auto_update`'s dirty-check semantics. Applier prompts fetch the base and
+  be running. In the default managed checkout, both refresh and the spawn gate
+  inventory non-ignored untracked files with NUL-delimited `git ls-files`, copy
+  them into an owner-only `evolve-recovery/untracked-*` directory, then remove
+  the originals. All copies must succeed before any source is removed; errors
+  block refresh/dispatch. This keeps orphaned tests out of the next PR suite
+  while preserving unfinished work. Ignored runtime files and explicit operator
+  checkouts are untouched. Applier prompts fetch the base and
   prepare or resume their deterministic local/remote feature branch before any
   reading or editing, then rebase it on the immutable
   `EVOLVE_REPO_COMMIT`. This makes retries validate previous branch work

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "threadkeeper"
-version = "0.17.1"
+version = "0.17.2"
 description = "Multi-agent shared brain across Claude Code/Desktop, Codex, Antigravity CLI, Copilot, and VS Code. Cross-session memory, self-improving skill loops, inter-agent signaling — one local MCP server."
 requires-python = ">=3.11"
 authors = [{ name = "thread-keeper contributors" }]

--- a/server.json
+++ b/server.json
@@ -7,12 +7,12 @@
     "url": "https://github.com/po4erk91/thread-keeper",
     "source": "github"
   },
-  "version": "0.17.1",
+  "version": "0.17.2",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "threadkeeper",
-      "version": "0.17.1",
+      "version": "0.17.2",
       "transport": {
         "type": "stdio"
       }

--- a/tests/test_evolve_applier.py
+++ b/tests/test_evolve_applier.py
@@ -2540,6 +2540,9 @@ def test_ensure_repo_ready_recovers_dirty_managed_base_before_refresh(
     (repo / "shared.txt").write_text(
         "issue implementation left on main\n", encoding="utf-8"
     )
+    (repo / "tests").mkdir()
+    orphan = repo / "tests" / "test_other_issue.py"
+    orphan.write_text("raise AssertionError('unrelated unfinished feature')\n")
     monkeypatch.setattr(
         pkg["ea"], "_prs_for_head_branch",
         lambda *args, **kwargs: (_ for _ in ()).throw(
@@ -2568,6 +2571,67 @@ def test_ensure_repo_ready_recovers_dirty_managed_base_before_refresh(
     ).fetchone()
     assert row["target"] == "managed_repo_refresh"
     assert "recovered_abandoned_wip branch=main" in row["summary"]
+    assert not orphan.exists()
+    saved = list((tmp_path / "evolve-recovery").glob("untracked-*/tests/*.py"))
+    assert len(saved) == 1
+    assert "unrelated unfinished feature" in saved[0].read_text()
+
+
+@pytest.mark.parametrize("mode", ["recover", "explicit", "live", "copy_error"])
+def test_untracked_recovery_preserves_work_and_isolates_next_validation(
+    tmp_path, monkeypatch, mode,
+):
+    pkg = _bootstrap(tmp_path, monkeypatch, pin_repo=False)
+    ea = pkg["ea"]
+    repo = ea._managed_repo_dir()
+    subprocess.run(["git", "init", str(repo)], check=True, capture_output=True)
+    # Use Git's actual ignore rules, including filenames with spaces/newlines.
+    (repo / ".git" / "info" / "exclude").write_text(".venv/\n")
+    (repo / ".venv").mkdir()
+    runtime = repo / ".venv" / "runtime"
+    runtime.write_text("keep runtime")
+    (repo / "tests").mkdir()
+    source = repo / "tests" / "test_orphan with\nnewline.py"
+    source.write_text("unfinished work\n")
+    outside = tmp_path / "outside.txt"
+    outside.write_text("external target")
+    link = repo / "orphan-link"
+    link.symlink_to(outside)
+    if mode == "explicit":
+        monkeypatch.setattr(ea, "EVOLVE_REPO_ROOT", str(repo))
+    if mode == "live":
+        monkeypatch.setattr(ea, "_running_git_writer_children", lambda conn: ["live"])
+    if mode == "copy_error":
+        def fail_copy(*args, **kwargs):
+            raise OSError("backup unavailable")
+        monkeypatch.setattr(ea.shutil, "copy2", fail_copy)
+
+    result = pkg["orig"]["_git_worktree_precondition"](
+        pkg["db"].get_db(), repo, "conflict_repair"
+    )
+
+    assert runtime.read_text() == "keep runtime"
+    assert outside.read_text() == "external target"
+    if mode == "recover":
+        assert result == ""
+        assert not source.exists() and not link.is_symlink()
+        backups = list((tmp_path / "evolve-recovery").glob("untracked-*"))
+        assert len(backups) == 1
+        assert backups[0].stat().st_mode & 0o777 == 0o700
+        assert (backups[0] / source.relative_to(repo)).read_text() == "unfinished work\n"
+        assert (backups[0] / "orphan-link").is_symlink()
+        assert pkg["orig"]["_git_worktree_precondition"](
+            pkg["db"].get_db(), repo, "conflict_repair"
+        ) == ""
+        assert len(list((tmp_path / "evolve-recovery").glob("untracked-*"))) == 1
+    else:
+        assert source.read_text() == "unfinished work\n" and link.is_symlink()
+        if mode == "live":
+            assert result.startswith("evolve_git_writer_running")
+        elif mode == "copy_error":
+            assert "untracked_quarantine_failed" in result
+        else:
+            assert result == ""
 
 
 def test_managed_refresh_checks_live_writer_before_dirty_recovery(

--- a/threadkeeper/evolve_applier.py
+++ b/threadkeeper/evolve_applier.py
@@ -56,6 +56,7 @@ import re
 import shutil
 import sqlite3
 import subprocess
+import tempfile
 import threading
 import time
 from pathlib import Path
@@ -1001,6 +1002,49 @@ def _archive_tracked_diff(
     return path, ""
 
 
+def _quarantine_managed_untracked(repo_root: Path) -> tuple[str, str]:
+    """Preserve a dead child's untracked files outside the next task's tree.
+
+    Call only after excluding live git writers. Ignored runtime files (including
+    the virtualenv) stay in place; explicit operator checkouts are untouched.
+    Copy the complete inventory before removing any source, so a backup failure
+    cannot discard unfinished work or allow a contaminated validation run.
+    """
+    if not _managed_repo_auto_recovery_allowed(repo_root):
+        return "", ""
+    backup = None
+    try:
+        proc = subprocess.run(
+            ["git", "-C", str(repo_root), "ls-files", "--others",
+             "--exclude-standard", "-z"],
+            capture_output=True, timeout=30, check=False,
+        )
+        if proc.returncode:
+            return "", "untracked_inventory_failed"
+        paths = [Path(os.fsdecode(p)) for p in proc.stdout.split(b"\0") if p]
+        if not paths:
+            return "", ""
+        for relative in paths:
+            source = repo_root / relative
+            if (relative.is_absolute() or ".." in relative.parts
+                    or any((repo_root / p).is_symlink() for p in relative.parents)
+                    or not (source.is_file() or source.is_symlink())):
+                return "", "untracked_inventory_unsafe_path"
+        recovery_dir = DB_PATH.parent / "evolve-recovery"
+        recovery_dir.mkdir(parents=True, exist_ok=True)
+        recovery_dir.chmod(0o700)
+        backup = Path(tempfile.mkdtemp(prefix="untracked-", dir=recovery_dir))
+        for relative in paths:
+            target = backup / relative
+            target.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(repo_root / relative, target, follow_symlinks=False)
+        for relative in paths:
+            (repo_root / relative).unlink()
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return "", f"untracked_quarantine_failed backup={backup} err={_short(str(exc))}"
+    return f"quarantined_untracked n={len(paths)} backup={backup.name}", ""
+
+
 def _archive_stale_merge_diff(
     repo_root: Path,
     pr_number: int,
@@ -1284,8 +1328,8 @@ def _git_worktree_precondition(
 ) -> str:
     """Parent-side gate before spawning any child that may commit/push.
 
-    Untracked scratch files intentionally do not block, matching auto_update's
-    `git status --porcelain --untracked-files=no` safety contract.
+    The managed checkout quarantines orphaned untracked files as well: pytest
+    collects them even though the tracked-only Git safety check ignores them.
     """
     # Check durable/live writer state before inspecting dirty files: a current
     # child owns its WIP and must never be mistaken for an orphan eligible for
@@ -1295,6 +1339,13 @@ def _git_worktree_precondition(
         outcome = f"evolve_git_writer_running n={len(running)}"
         _record_git_safety_event(conn, actor, outcome)
         return outcome
+    recovery, quarantine_err = _quarantine_managed_untracked(repo_root)
+    if quarantine_err:
+        outcome = f"ERR {quarantine_err}"
+        _record_git_safety_event(conn, actor, outcome)
+        return outcome
+    if recovery:
+        _record_git_safety_event(conn, actor, recovery)
     dirty, err = _tracked_worktree_status(repo_root)
     if err:
         outcome = f"ERR git_status_failed mode=git err={err}"
@@ -1424,6 +1475,11 @@ def _refresh_managed_repo(dest: Path) -> str:
             return f"ERR evolve_repo_refresh_running_check_failed={_short(str(e))}"
         if running:
             return f"ERR evolve_repo_refresh_in_use n={len(running)}"
+        recovery, quarantine_err = _quarantine_managed_untracked(dest)
+        if quarantine_err:
+            return f"ERR evolve_repo_refresh_{quarantine_err}"
+        if recovery:
+            _record_git_safety_event(conn, "managed_repo_refresh", recovery)
         dirty, status_err = _tracked_worktree_status(dest)
         if status_err:
             return f"ERR evolve_repo_refresh_status_failed={_short(status_err)}"


### PR DESCRIPTION
A failed Evolve child could leave an untracked test in the managed checkout. The tracked-only Git guard ignored it, while every later PR repair ran it in pytest and failed again. PR #297 hit the same unrelated test failures in six consecutive repair attempts.

Preserve all non-ignored untracked files outside the managed checkout before refresh and before spawning a Git writer. Copy the complete inventory before removing sources, block dispatch on backup failure, and retain the existing live-writer and explicit-checkout guards. Ignored runtime files remain in place.

Validation covers real Git inventories, repeated recovery, preserved contents and symlinks, ignored virtualenv files, explicit checkouts, active writers, backup failures, and refresh after abandoned tracked work. The focused applier suite passed. The full suite completed with 1440 passed and 3 skipped (`pytest --forked` under an isolated database with background daemons disabled). After rebasing onto the merged event-session change, the integrated applier, identity, and watchdog suites also passed (122 tests).
