### PR TITLE
fix: prune unconsulted skills despite patches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ version bumps follow semver per the policy in
 [CONTRIBUTING.md → Releases](CONTRIBUTING.md#releases).
 
 ## [Unreleased]
+
 - **Fixed: one abandoned Evolve attempt can no longer deadlock the apply
   scheduler.** Managed-checkout refresh used to reject a dirty tree before the
   abandoned-WIP recovery gate ran, so a child that edited `main` and then hit a
@@ -97,6 +98,17 @@ version bumps follow semver per the policy in
   edit's mtime; filesystems without birth-time support fall back to mtime
   capped at discovery time. `last_patched_at` continues to record the edit
   signal used by the watcher.
+
+## v0.16.4 — 2026-09-11
+
+### Fixed
+
+- **Curator false-positive pruning now follows foreground consultation.**
+  Background-review skills with no foreground use remain eligible for prune
+  review after 14 days even when automatic maintenance has increased their
+  patch count. The curator audit displays foreground uses separately from
+  maintenance patches, and patch activity no longer keeps an unconsulted skill
+  alive.
 
 ## v0.16.3 — 2026-07-19
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ WORKDIR /app
 # Install the release this checkout declares. Skip the [semantic] extra (~700
 # MB fastembed ONNX model) — Glama only inspects the MCP tool schema, not
 # embedding quality.
-RUN pip install --no-cache-dir threadkeeper==0.16.3
+RUN pip install --no-cache-dir threadkeeper==0.16.4
 
 # Don't spawn shadow-review / curator / probe / dialectic daemons in
 # the Glama sandbox — they would try to invoke claude / codex / agy

--- a/README.md
+++ b/README.md
@@ -658,6 +658,12 @@ non-forced direct `curator_review()` calls return `not_due` inside the
 configured interval and record that status without spawning. A manual
 `curator_review(force=True)` bypasses the interval but still respects the lock.
 
+For automation-created skills, the audit keeps foreground consultation separate
+from maintenance: a background-review skill with `fg_uses=0` after 14 days is
+still a false-positive prune candidate even if automatic review or sync loops
+have increased its patch counter. Patches are maintenance activity, not proof
+that a foreground user or agent consulted the skill.
+
 Before spawning, the scheduler hashes lessons, concepts, skill bodies, support
 trees, validators, and mirror state. Repeated manual calls over identical bytes
 return `unchanged_inventory`; the scheduled three-day pass still runs because

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1173,7 +1173,11 @@ Optional subfolders: `references/`, `templates/`, `scripts/`, `assets/`.
   `foreground`, `pinned=1`, or **`tier='validated'`** (proven externally).
   Hypothesis-tier ages at half the configured window (unproven skills
   don't linger); observed-tier uses the default window. On apply,
-  physically archives into `.archive/<name>`.
+  physically archives into `.archive/<name>`. Its false-positive rubric uses
+  `foreground_use_count` and creation age: a background-review skill with
+  `fg_uses=0` after 14 days remains eligible for prune review even when
+  automation has incremented `patch_count`. Patch activity is maintenance, not
+  evidence of a foreground consultation.
 
 - **Skill tier** (`hypothesis`/`observed`/`validated`) — discrete trust
   signal driven by `foreground_use_count` and `wrong_count`. Mirrors

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -35,6 +35,9 @@ remains a live question.
 - `skill_watcher` daemon — tracks SKILL.md changes, bumps
   `last_patched_at`.
 - `skill_usage` telemetry + backfill from historical jsonl.
+- Curator false-positive skill pruning (#166): background-review skills with
+  zero foreground consultations remain eligible after 14 days even when
+  automated maintenance has increased their patch counts.
 - Dialectic user model: `dialectic_claim` / `evidence` / `synthesis` /
   `review` / `supersede`, smoothed-ratio confidence, grouping by domain
   in brief.
@@ -976,9 +979,6 @@ GitHub issues:
 - **Fail-loud event emission.** `_emit()` should not silently no-op when
   session setup is missing; forgetting the setup call should be a loud error or
   an auto-ensure path (#165).
-- **Skill prune heuristic fix.** The curator's false-positive skill prune logic
-  should key on real foreground use, not on auto-patch counts that make the
-  current gate unreachable (#166).
 - **Lesson contradiction reconciliation.** When a new lesson debunks an older
   permissive lesson or encodes an absolute user directive, flag the older
   guidance for patch/cross-link/supersession review (#167).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "threadkeeper"
-version = "0.16.3"
+version = "0.16.4"
 description = "Multi-agent shared brain across Claude Code/Desktop, Codex, Antigravity CLI, Copilot, and VS Code. Cross-session memory, self-improving skill loops, inter-agent signaling — one local MCP server."
 requires-python = ">=3.11"
 authors = [{ name = "thread-keeper contributors" }]

--- a/server.json
+++ b/server.json
@@ -7,12 +7,12 @@
     "url": "https://github.com/po4erk91/thread-keeper",
     "source": "github"
   },
-  "version": "0.16.3",
+  "version": "0.16.4",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "threadkeeper",
-      "version": "0.16.3",
+      "version": "0.16.4",
       "transport": {
         "type": "stdio"
       }

--- a/tests/test_curator.py
+++ b/tests/test_curator.py
@@ -748,6 +748,48 @@ def test_skill_validator_is_exhaustive_and_semantic(tmp_path, monkeypatch):
     assert "3. SKILL second-skill" in checklist
 
 
+def test_curator_prune_rubric_keeps_patched_unconsulted_skill_eligible(
+    tmp_path, monkeypatch,
+):
+    pkg = _bootstrap(tmp_path, monkeypatch, min_lessons="2")
+    pkg["lessons"].append_lesson(title="one", body="b1", source="shadow")
+    pkg["lessons"].append_lesson(title="two", body="b2", source="shadow")
+    _write_audit_skill(
+        pkg["skills_dir"], "patched-background-skill", "# Rule\nDo the test.",
+    )
+    now = int(time.time())
+    conn = pkg["db"].get_db()
+    conn.execute(
+        "INSERT INTO skill_usage "
+        "(name, created_at, created_by_origin, last_patched_at, patch_count, "
+        "foreground_use_count, state) VALUES (?, ?, ?, ?, ?, ?, ?)",
+        (
+            "patched-background-skill", now - 30 * 86400,
+            "background_review", now, 4, 0, "active",
+        ),
+    )
+    conn.commit()
+
+    import threadkeeper.tools.spawn as spawn_mod
+    captured: list[dict] = []
+
+    def fake_spawn(**kwargs):
+        captured.append(kwargs)
+        return "spawn task_id=patched-background-skill pid=0"
+
+    monkeypatch.setattr(spawn_mod, "spawn", fake_spawn)
+    pkg["curator"].run_curator_pass(force=True)
+
+    prompt = captured[0]["prompt"]
+    assert "origin=background_review AND fg_uses=0" in prompt
+    assert "they are not foreground consultation" in prompt
+    assert "SKILL patched-background-skill" in prompt
+    assert "fg_uses=0" in prompt
+    assert "maintenance_patches=4" in prompt
+    assert "created=30d_ago" in prompt
+    assert "patches=0" not in prompt
+
+
 def test_skill_validate_tool_returns_post_change_contract(tmp_path, monkeypatch):
     pkg = _bootstrap(tmp_path, monkeypatch)
     primary = pkg["skills_dir"]

--- a/threadkeeper/curator.py
+++ b/threadkeeper/curator.py
@@ -223,10 +223,11 @@ verdicts above):
   superseded by a newer entry, or a **FALSE POSITIVE** (auto-created
   by the background-review loop but never validated by actual use).
   Specifically flag as PRUNE:
-    • origin=background_review AND use_count=0 AND patches=0 AND
-      created >14 days ago → strong false-positive signal: nobody ever
-      consulted it, and the agent that created it never came back to
-      refine it.
+    • origin=background_review AND fg_uses=0 AND created >14 days ago
+      → strong false-positive signal: no foreground user or agent ever
+      consulted it. `maintenance_patches` count automated or other maintenance
+      writes; they are not foreground consultation and never reset this
+      eligibility signal.
     • SKILL_OUTCOME signals (in the events table) marking the skill
       as 'wrong' more often than 'helped' → user-judgment override.
   Format:

--- a/threadkeeper/skill_audit.py
+++ b/threadkeeper/skill_audit.py
@@ -18,6 +18,7 @@ import os
 from pathlib import Path
 import re
 import sqlite3
+import time
 from typing import Iterable
 
 import yaml
@@ -245,7 +246,8 @@ def _telemetry_rows(conn: sqlite3.Connection, include_archived: bool) -> dict[st
         rows = conn.execute(
             "SELECT name, created_at, created_by_origin, last_used_at, "
             "last_viewed_at, last_patched_at, use_count, view_count, "
-            "patch_count, pinned, state, tier FROM skill_usage" + where
+            "patch_count, foreground_use_count, pinned, state, tier "
+            "FROM skill_usage" + where
             + " ORDER BY name"
         ).fetchall()
     except sqlite3.OperationalError:
@@ -327,7 +329,7 @@ def _record_for(
             for key in (
                 "created_at", "last_used_at", "last_viewed_at",
                 "last_patched_at", "use_count", "view_count", "patch_count",
-                "pinned",
+                "foreground_use_count", "pinned",
             )
         },
         "source_path": str(source) if source else None,
@@ -533,9 +535,20 @@ def format_skill_checklist(manifest: dict) -> str:
     for index, record in enumerate(manifest["skills"], start=1):
         flags = ",".join(record["findings"]) or "clean"
         protected = " [PROTECTED]" if record["protected"] else ""
+        telemetry = record["telemetry"]
+        created_at = int(telemetry.get("created_at") or 0)
+        created_age = (
+            max(0, int(time.time()) - created_at) // 86400
+            if created_at else "?"
+        )
         lines.append(
             f"{index}. SKILL {record['name']}{protected} "
             f"state={record['state']} origin={record['origin']} "
+            f"fg_uses={telemetry.get('foreground_use_count') or 0} "
+            f"uses={telemetry.get('use_count') or 0} "
+            f"views={telemetry.get('view_count') or 0} "
+            f"maintenance_patches={telemetry.get('patch_count') or 0} "
+            f"created={created_age}d_ago "
             f"source_kind={record['source_kind']} "
             f"source={record['source_path'] or '-'} findings={flags}"
         )


### PR DESCRIPTION
Summary:
- Separate foreground consultation telemetry from maintenance patch activity in the Curator audit.
- Keep aged background-review skills eligible for false-positive prune review when foreground use is zero.
- Cover the patched-but-never-consulted case and update release and roadmap metadata.

Validation:
- env -u THREADKEEPER_NO_EMBEDDINGS .venv/bin/python -m pytest -q

Closes #166